### PR TITLE
feat: add WSL2-aware discovery service with Codex and Gemini CLI support

### DIFF
--- a/apps/cli/src/adapters/codex-adapter.ts
+++ b/apps/cli/src/adapters/codex-adapter.ts
@@ -1,0 +1,125 @@
+/**
+ * OpenAI Codex CLI Adapter
+ *
+ * Adapter for OpenAI Codex CLI with MCP support.
+ * Only supports user-level configuration (no project-level).
+ *
+ * Config locations:
+ * - Default: ~/.codex/mcp-config.json
+ * - Windows: %USERPROFILE%\.codex\mcp-config.json
+ *
+ * Context file: AGENTS.md (project root)
+ *
+ * @module adapters/codex-adapter
+ * @version 1.0
+ */
+
+import * as fs from 'fs';
+import {
+  BaseClientAdapter,
+  type ConfigPathResult,
+  type ClientMcpConfig,
+} from './client-adapter.interface';
+import type { Platform, OvertureConfig } from '../domain/config.types';
+import { getCodexPath } from '../core/path-resolver';
+
+/**
+ * OpenAI Codex CLI adapter implementation
+ */
+export class CodexAdapter extends BaseClientAdapter {
+  readonly name = 'codex' as const;
+  readonly schemaRootKey = 'mcpServers' as const;
+
+  detectConfigPath(platform: Platform, projectRoot?: string): ConfigPathResult {
+    return getCodexPath(platform);
+  }
+
+  readConfig(path: string): ClientMcpConfig {
+    if (!fs.existsSync(path)) {
+      return { mcpServers: {} };
+    }
+
+    try {
+      const content = fs.readFileSync(path, 'utf-8');
+      const parsed = JSON.parse(content);
+
+      // Ensure root key exists
+      if (!parsed.mcpServers) {
+        return { mcpServers: {} };
+      }
+
+      return parsed;
+    } catch (error) {
+      throw new Error(
+        `Failed to read Codex config at ${path}: ${(error as Error).message}`
+      );
+    }
+  }
+
+  writeConfig(path: string, config: ClientMcpConfig): void {
+    try {
+      // Ensure directory exists
+      const dir = path.substring(0, path.lastIndexOf('/'));
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+
+      const content = JSON.stringify(config, null, 2);
+      fs.writeFileSync(path, content, 'utf-8');
+    } catch (error) {
+      throw new Error(
+        `Failed to write Codex config to ${path}: ${(error as Error).message}`
+      );
+    }
+  }
+
+  convertFromOverture(
+    overtureConfig: OvertureConfig,
+    platform: Platform
+  ): ClientMcpConfig {
+    const mcpServers: Record<string, any> = {};
+
+    for (const [name, mcpConfig] of Object.entries(overtureConfig.mcp)) {
+      // Check if should sync
+      if (!this.shouldSyncMcp(mcpConfig, platform)) {
+        continue;
+      }
+
+      // Build config with all overrides applied
+      const serverConfig = this.buildServerConfig(mcpConfig, platform);
+
+      // Codex uses similar structure to Claude Code
+      mcpServers[name] = {
+        command: serverConfig.command,
+        args: serverConfig.args,
+        env: serverConfig.env,
+      };
+    }
+
+    return { mcpServers };
+  }
+
+  supportsTransport(transport: 'stdio' | 'http' | 'sse'): boolean {
+    // Codex CLI supports stdio (assumed based on MCP standard)
+    return transport === 'stdio';
+  }
+
+  needsEnvVarExpansion(): boolean {
+    // Codex CLI likely has native ${VAR} support
+    return false;
+  }
+
+  override getBinaryNames(): string[] {
+    return ['codex'];
+  }
+
+  override getAppBundlePaths(_platform: Platform): string[] {
+    // Codex CLI is a CLI-only tool
+    return [];
+  }
+
+  override requiresBinary(): boolean {
+    // Codex CLI requires the binary
+    return true;
+  }
+}

--- a/apps/cli/src/adapters/gemini-cli-adapter.ts
+++ b/apps/cli/src/adapters/gemini-cli-adapter.ts
@@ -1,0 +1,128 @@
+/**
+ * Google Gemini CLI Adapter
+ *
+ * Adapter for Google Gemini CLI with MCP support.
+ * Only supports user-level configuration (no project-level).
+ *
+ * Config locations:
+ * - Default: ~/.gemini/mcp-config.json
+ * - Windows: %USERPROFILE%\.gemini\mcp-config.json
+ *
+ * Context file: GEMINI.md (project root)
+ *
+ * Note: Gemini CLI has a 1M token context window, allowing for
+ * expanded context files and full API spec inclusion.
+ *
+ * @module adapters/gemini-cli-adapter
+ * @version 1.0
+ */
+
+import * as fs from 'fs';
+import {
+  BaseClientAdapter,
+  type ConfigPathResult,
+  type ClientMcpConfig,
+} from './client-adapter.interface';
+import type { Platform, OvertureConfig } from '../domain/config.types';
+import { getGeminiCliPath } from '../core/path-resolver';
+
+/**
+ * Google Gemini CLI adapter implementation
+ */
+export class GeminiCliAdapter extends BaseClientAdapter {
+  readonly name = 'gemini-cli' as const;
+  readonly schemaRootKey = 'mcpServers' as const;
+
+  detectConfigPath(platform: Platform, projectRoot?: string): ConfigPathResult {
+    return getGeminiCliPath(platform);
+  }
+
+  readConfig(path: string): ClientMcpConfig {
+    if (!fs.existsSync(path)) {
+      return { mcpServers: {} };
+    }
+
+    try {
+      const content = fs.readFileSync(path, 'utf-8');
+      const parsed = JSON.parse(content);
+
+      // Ensure root key exists
+      if (!parsed.mcpServers) {
+        return { mcpServers: {} };
+      }
+
+      return parsed;
+    } catch (error) {
+      throw new Error(
+        `Failed to read Gemini CLI config at ${path}: ${(error as Error).message}`
+      );
+    }
+  }
+
+  writeConfig(path: string, config: ClientMcpConfig): void {
+    try {
+      // Ensure directory exists
+      const dir = path.substring(0, path.lastIndexOf('/'));
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+
+      const content = JSON.stringify(config, null, 2);
+      fs.writeFileSync(path, content, 'utf-8');
+    } catch (error) {
+      throw new Error(
+        `Failed to write Gemini CLI config to ${path}: ${(error as Error).message}`
+      );
+    }
+  }
+
+  convertFromOverture(
+    overtureConfig: OvertureConfig,
+    platform: Platform
+  ): ClientMcpConfig {
+    const mcpServers: Record<string, any> = {};
+
+    for (const [name, mcpConfig] of Object.entries(overtureConfig.mcp)) {
+      // Check if should sync
+      if (!this.shouldSyncMcp(mcpConfig, platform)) {
+        continue;
+      }
+
+      // Build config with all overrides applied
+      const serverConfig = this.buildServerConfig(mcpConfig, platform);
+
+      // Gemini CLI uses similar structure to Claude Code
+      mcpServers[name] = {
+        command: serverConfig.command,
+        args: serverConfig.args,
+        env: serverConfig.env,
+      };
+    }
+
+    return { mcpServers };
+  }
+
+  supportsTransport(transport: 'stdio' | 'http' | 'sse'): boolean {
+    // Gemini CLI supports stdio (assumed based on MCP standard)
+    return transport === 'stdio';
+  }
+
+  needsEnvVarExpansion(): boolean {
+    // Gemini CLI likely has native ${VAR} support
+    return false;
+  }
+
+  override getBinaryNames(): string[] {
+    return ['gemini'];
+  }
+
+  override getAppBundlePaths(_platform: Platform): string[] {
+    // Gemini CLI is a CLI-only tool
+    return [];
+  }
+
+  override requiresBinary(): boolean {
+    // Gemini CLI requires the binary
+    return true;
+  }
+}

--- a/apps/cli/src/adapters/index.ts
+++ b/apps/cli/src/adapters/index.ts
@@ -15,6 +15,8 @@ import { CursorAdapter } from './cursor-adapter';
 import { WindsurfAdapter } from './windsurf-adapter';
 import { CopilotCliAdapter } from './copilot-cli-adapter';
 import { JetBrainsCopilotAdapter } from './jetbrains-copilot-adapter';
+import { CodexAdapter } from './codex-adapter';
+import { GeminiCliAdapter } from './gemini-cli-adapter';
 
 /**
  * Initialize all client adapters
@@ -39,6 +41,8 @@ export function initializeAdapters(): void {
   adapterRegistry.register(new WindsurfAdapter());
   adapterRegistry.register(new CopilotCliAdapter());
   adapterRegistry.register(new JetBrainsCopilotAdapter());
+  adapterRegistry.register(new CodexAdapter());
+  adapterRegistry.register(new GeminiCliAdapter());
 }
 
 // Export adapters for direct use if needed
@@ -50,6 +54,8 @@ export {
   WindsurfAdapter,
   CopilotCliAdapter,
   JetBrainsCopilotAdapter,
+  CodexAdapter,
+  GeminiCliAdapter,
 };
 
 // Export adapter registry utilities

--- a/apps/cli/src/core/discovery-service.spec.ts
+++ b/apps/cli/src/core/discovery-service.spec.ts
@@ -1,0 +1,529 @@
+/**
+ * Discovery Service Tests
+ *
+ * Tests for the DiscoveryService that orchestrates CLI detection
+ * with WSL2 support and YAML configuration overrides.
+ *
+ * @module core/discovery-service.spec
+ */
+
+import { DiscoveryService } from './discovery-service';
+import { BinaryDetector } from './binary-detector';
+import { wsl2Detector } from './wsl2-detector';
+import { adapterRegistry } from '../adapters/adapter-registry';
+import type { ClientAdapter } from '../adapters/client-adapter.interface';
+import type { DiscoveryConfig } from '../domain/config.types';
+import * as fs from 'fs';
+
+// Mock dependencies
+jest.mock('./binary-detector');
+jest.mock('./wsl2-detector', () => ({
+  WSL2Detector: jest.fn(),
+  wsl2Detector: {
+    detectEnvironment: jest.fn(),
+    getWindowsInstallPaths: jest.fn(),
+    getWindowsConfigPath: jest.fn(),
+    resetCache: jest.fn(),
+  },
+  WINDOWS_DEFAULT_PATHS: {
+    'claude-code': { binaryPaths: [], configPath: 'AppData/Roaming/Claude/mcp.json' },
+    'claude-desktop': { binaryPaths: [], configPath: 'AppData/Roaming/Claude/claude_desktop_config.json' },
+  },
+}));
+jest.mock('../adapters/adapter-registry');
+jest.mock('fs');
+
+const mockBinaryDetectorInstance = {
+  detectClient: jest.fn(),
+  detectBinary: jest.fn(),
+  detectAppBundle: jest.fn(),
+  validateConfigFile: jest.fn(),
+};
+
+(BinaryDetector as jest.Mock).mockImplementation(() => mockBinaryDetectorInstance);
+
+const mockAdapterRegistry = adapterRegistry as jest.Mocked<typeof adapterRegistry>;
+const mockWsl2Detector = wsl2Detector as jest.Mocked<typeof wsl2Detector>;
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+describe('DiscoveryService', () => {
+  let service: DiscoveryService;
+  let mockAdapter: jest.Mocked<ClientAdapter>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Reset mock implementations
+    mockWsl2Detector.detectEnvironment.mockResolvedValue({ isWSL2: false });
+    mockWsl2Detector.getWindowsInstallPaths.mockReturnValue([]);
+    mockWsl2Detector.getWindowsConfigPath.mockReturnValue(undefined);
+
+    // Create mock adapter
+    mockAdapter = {
+      name: 'claude-code' as any,
+      schemaRootKey: 'mcpServers',
+      getBinaryNames: jest.fn(() => ['claude']),
+      getAppBundlePaths: jest.fn(() => []),
+      requiresBinary: jest.fn(() => true),
+      detectConfigPath: jest.fn(() => '/home/user/.config/claude/mcp.json'),
+      readConfig: jest.fn(),
+      writeConfig: jest.fn(),
+      convertFromOverture: jest.fn(),
+      supportsTransport: jest.fn(),
+      needsEnvVarExpansion: jest.fn(),
+    } as unknown as jest.Mocked<ClientAdapter>;
+
+    // Mock adapter registry
+    mockAdapterRegistry.getAll.mockReturnValue([mockAdapter]);
+    mockAdapterRegistry.get.mockReturnValue(mockAdapter);
+
+    // Default: native detection succeeds
+    mockBinaryDetectorInstance.detectClient.mockResolvedValue({
+      status: 'found',
+      binaryPath: '/usr/local/bin/claude',
+      version: '2.1.0',
+      warnings: [],
+    });
+
+    mockFs.existsSync.mockReturnValue(false);
+
+    service = new DiscoveryService();
+  });
+
+  describe('constructor', () => {
+    it('should create service with default config', () => {
+      const svc = new DiscoveryService();
+      expect(svc.getConfig()).toEqual({ enabled: true });
+    });
+
+    it('should create service with custom config', () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        timeout: 10000,
+        wsl2_auto_detect: false,
+      };
+      const svc = new DiscoveryService(config);
+      expect(svc.getConfig()).toEqual(config);
+    });
+  });
+
+  describe('discoverAll', () => {
+    it('should discover all registered clients', async () => {
+      const report = await service.discoverAll();
+
+      expect(report.clients).toHaveLength(1);
+      expect(report.clients[0].client).toBe('claude-code');
+      expect(report.clients[0].detection.status).toBe('found');
+      expect(report.summary.detected).toBe(1);
+      expect(report.summary.notFound).toBe(0);
+    });
+
+    it('should include environment info in report', async () => {
+      const report = await service.discoverAll();
+
+      expect(report.environment.platform).toBeDefined();
+      expect(report.environment.isWSL2).toBe(false);
+    });
+
+    it('should include WSL2 info when in WSL2 environment', async () => {
+      mockWsl2Detector.detectEnvironment.mockResolvedValue({
+        isWSL2: true,
+        distroName: 'Ubuntu',
+        windowsUserProfile: '/mnt/c/Users/jeff',
+      });
+
+      const report = await service.discoverAll();
+
+      expect(report.environment.isWSL2).toBe(true);
+      expect(report.environment.wsl2Info?.distroName).toBe('Ubuntu');
+    });
+
+    it('should handle multiple clients', async () => {
+      const mockAdapter2: jest.Mocked<ClientAdapter> = {
+        name: 'vscode' as any,
+        schemaRootKey: 'servers',
+        getBinaryNames: jest.fn(() => ['code']),
+        getAppBundlePaths: jest.fn(() => []),
+        requiresBinary: jest.fn(() => true),
+        detectConfigPath: jest.fn(() => '/home/user/.config/Code/User/mcp.json'),
+        readConfig: jest.fn(),
+        writeConfig: jest.fn(),
+        convertFromOverture: jest.fn(),
+        supportsTransport: jest.fn(),
+        needsEnvVarExpansion: jest.fn(),
+      } as unknown as jest.Mocked<ClientAdapter>;
+
+      mockAdapterRegistry.getAll.mockReturnValue([mockAdapter, mockAdapter2]);
+
+      const report = await service.discoverAll();
+
+      expect(report.clients).toHaveLength(2);
+      expect(report.summary.totalClients).toBe(2);
+    });
+
+    it('should count not-found clients', async () => {
+      mockBinaryDetectorInstance.detectClient.mockResolvedValue({
+        status: 'not-found',
+        warnings: [],
+      });
+
+      const report = await service.discoverAll();
+
+      expect(report.summary.detected).toBe(0);
+      expect(report.summary.notFound).toBe(1);
+    });
+  });
+
+  describe('discoverByName', () => {
+    it('should discover specific client by name', async () => {
+      const result = await service.discoverByName('claude-code');
+
+      expect(result.client).toBe('claude-code');
+      expect(result.detection.status).toBe('found');
+    });
+
+    it('should throw error for unknown client', async () => {
+      mockAdapterRegistry.get.mockReturnValue(undefined);
+
+      await expect(service.discoverByName('unknown' as any)).rejects.toThrow(
+        'No adapter registered for client: unknown'
+      );
+    });
+  });
+
+  describe('discoverClient', () => {
+    it('should detect client via native detection', async () => {
+      const result = await service.discoverClient(mockAdapter, 'linux');
+
+      expect(result.client).toBe('claude-code');
+      expect(result.detection.status).toBe('found');
+      expect(result.source).toBe('native');
+      expect(result.environment).toBe('linux');
+    });
+
+    it('should use config override when specified', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        clients: {
+          'claude-code': {
+            binary_path: '/custom/claude',
+          },
+        },
+      };
+      service.updateConfig(config);
+      mockFs.existsSync.mockReturnValue(true);
+
+      const result = await service.discoverClient(mockAdapter, 'linux');
+
+      expect(result.detection.status).toBe('found');
+      expect(result.source).toBe('config-override');
+      expect(result.detection.binaryPath).toBe('/custom/claude');
+    });
+
+    it('should skip disabled client', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        clients: {
+          'claude-code': {
+            enabled: false,
+          },
+        },
+      };
+      service.updateConfig(config);
+
+      const result = await service.discoverClient(mockAdapter, 'linux');
+
+      expect(result.detection.status).toBe('skipped');
+      expect(result.source).toBe('config-override');
+    });
+
+    it('should fall back to native when config override path not found', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        clients: {
+          'claude-code': {
+            binary_path: '/nonexistent/claude',
+          },
+        },
+      };
+      service.updateConfig(config);
+      mockFs.existsSync.mockReturnValue(false);
+
+      const result = await service.discoverClient(mockAdapter, 'linux');
+
+      // Falls back to native detection which succeeds
+      expect(result.detection.status).toBe('found');
+      expect(result.source).toBe('native');
+    });
+
+    it('should detect app bundle via config override', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        clients: {
+          'claude-code': {
+            app_bundle_path: '/Applications/Claude.app',
+          },
+        },
+      };
+      service.updateConfig(config);
+      mockFs.existsSync.mockImplementation((path: any) => {
+        return path === '/Applications/Claude.app';
+      });
+
+      const result = await service.discoverClient(mockAdapter, 'darwin');
+
+      expect(result.detection.status).toBe('found');
+      expect(result.source).toBe('config-override');
+      expect(result.detection.appBundlePath).toBe('/Applications/Claude.app');
+    });
+
+    it('should include config path from override', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        clients: {
+          'claude-code': {
+            binary_path: '/custom/claude',
+            config_path: '/custom/config.json',
+          },
+        },
+      };
+      service.updateConfig(config);
+      mockFs.existsSync.mockReturnValue(true);
+
+      const result = await service.discoverClient(mockAdapter, 'linux');
+
+      expect(result.detection.configPath).toBe('/custom/config.json');
+    });
+  });
+
+  describe('WSL2 fallback detection', () => {
+    const wsl2Info = {
+      isWSL2: true,
+      distroName: 'Ubuntu',
+      windowsUserProfile: '/mnt/c/Users/jeff',
+    };
+
+    beforeEach(() => {
+      // Native detection fails
+      mockBinaryDetectorInstance.detectClient.mockResolvedValue({
+        status: 'not-found',
+        warnings: [],
+      });
+    });
+
+    it('should detect via WSL2 fallback when native fails', async () => {
+      mockWsl2Detector.getWindowsInstallPaths.mockReturnValue([
+        '/mnt/c/Users/jeff/AppData/Local/Programs/claude-code/claude.exe',
+      ]);
+      mockWsl2Detector.getWindowsConfigPath.mockReturnValue(
+        '/mnt/c/Users/jeff/AppData/Roaming/Claude/mcp.json'
+      );
+      mockFs.existsSync.mockReturnValue(true);
+
+      const result = await service.discoverClient(mockAdapter, 'linux', wsl2Info);
+
+      expect(result.detection.status).toBe('found');
+      expect(result.source).toBe('wsl2-fallback');
+      expect(result.environment).toBe('wsl2');
+      expect(result.windowsPath).toBeDefined();
+    });
+
+    it('should return not-found when WSL2 fallback also fails', async () => {
+      mockWsl2Detector.getWindowsInstallPaths.mockReturnValue([
+        '/mnt/c/nonexistent/path',
+      ]);
+      mockFs.existsSync.mockReturnValue(false);
+
+      const result = await service.discoverClient(mockAdapter, 'linux', wsl2Info);
+
+      expect(result.detection.status).toBe('not-found');
+      expect(result.source).toBe('native');
+    });
+
+    it('should not attempt WSL2 fallback without windowsUserProfile', async () => {
+      const partialWsl2Info = {
+        isWSL2: true,
+        distroName: 'Ubuntu',
+      };
+
+      const result = await service.discoverClient(mockAdapter, 'linux', partialWsl2Info);
+
+      expect(result.detection.status).toBe('not-found');
+      expect(mockWsl2Detector.getWindowsInstallPaths).not.toHaveBeenCalled();
+    });
+
+    it('should use WSL2 config path override when specified', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        wsl2: {
+          windows_config_paths: {
+            'claude-code': '/mnt/c/Custom/config.json',
+          },
+        },
+      };
+      service.updateConfig(config);
+
+      mockWsl2Detector.getWindowsInstallPaths.mockReturnValue([
+        '/mnt/c/Users/jeff/AppData/Local/Programs/claude-code/claude.exe',
+      ]);
+      mockFs.existsSync.mockReturnValue(true);
+
+      const result = await service.discoverClient(mockAdapter, 'linux', wsl2Info);
+
+      expect(result.detection.status).toBe('found');
+      expect(result.detection.configPath).toBe('/mnt/c/Custom/config.json');
+    });
+
+    it('should track WSL2 detections in discoverAll summary', async () => {
+      mockWsl2Detector.detectEnvironment.mockResolvedValue(wsl2Info);
+      mockWsl2Detector.getWindowsInstallPaths.mockReturnValue([
+        '/mnt/c/Users/jeff/AppData/Local/Programs/claude-code/claude.exe',
+      ]);
+      mockFs.existsSync.mockReturnValue(true);
+
+      const report = await service.discoverAll();
+
+      expect(report.summary.wsl2Detections).toBe(1);
+    });
+  });
+
+  describe('detectEnvironment', () => {
+    it('should auto-detect when no environment forced', async () => {
+      await service.discoverAll();
+
+      expect(mockWsl2Detector.detectEnvironment).toHaveBeenCalled();
+    });
+
+    it('should force WSL2 mode when environment is wsl2', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        environment: 'wsl2',
+      };
+      service.updateConfig(config);
+
+      mockWsl2Detector.detectEnvironment.mockResolvedValue({
+        isWSL2: false, // Real detection says no, but we force it
+        distroName: 'Ubuntu',
+        windowsUserProfile: '/mnt/c/Users/jeff',
+      });
+
+      const report = await service.discoverAll();
+
+      expect(report.environment.isWSL2).toBe(true);
+    });
+
+    it('should force native mode when environment is non-WSL2', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        environment: 'linux',
+      };
+      service.updateConfig(config);
+
+      mockWsl2Detector.detectEnvironment.mockResolvedValue({
+        isWSL2: true, // Real detection says yes, but we force native
+        distroName: 'Ubuntu',
+        windowsUserProfile: '/mnt/c/Users/jeff',
+      });
+
+      const report = await service.discoverAll();
+
+      expect(report.environment.isWSL2).toBe(false);
+    });
+
+    it('should respect wsl2_auto_detect: false', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        wsl2_auto_detect: false,
+      };
+      service.updateConfig(config);
+
+      mockWsl2Detector.detectEnvironment.mockResolvedValue({
+        isWSL2: true,
+        distroName: 'Ubuntu',
+        windowsUserProfile: '/mnt/c/Users/jeff',
+      });
+
+      const report = await service.discoverAll();
+
+      expect(report.environment.isWSL2).toBe(false);
+    });
+  });
+
+  describe('updateConfig and getConfig', () => {
+    it('should update configuration', () => {
+      const newConfig: DiscoveryConfig = {
+        enabled: false,
+        timeout: 10000,
+      };
+
+      service.updateConfig(newConfig);
+
+      expect(service.getConfig()).toEqual(newConfig);
+    });
+  });
+
+  describe('GUI app detection via WSL2', () => {
+    const wsl2Info = {
+      isWSL2: true,
+      distroName: 'Ubuntu',
+      windowsUserProfile: '/mnt/c/Users/jeff',
+    };
+
+    beforeEach(() => {
+      mockBinaryDetectorInstance.detectClient.mockResolvedValue({
+        status: 'not-found',
+        warnings: [],
+      });
+      mockWsl2Detector.getWindowsInstallPaths.mockReturnValue([]);
+    });
+
+    it('should detect GUI apps via app bundle path', async () => {
+      mockFs.existsSync.mockImplementation((path: any) => {
+        // GUI app found at Windows path
+        if (path === '/mnt/c/Users/jeff/AppData/Local/Programs/Claude/Claude.exe') {
+          return true;
+        }
+        return false;
+      });
+
+      // Simulate claude-desktop adapter
+      const guiAdapter = {
+        ...mockAdapter,
+        name: 'claude-desktop' as any,
+      } as jest.Mocked<ClientAdapter>;
+
+      const result = await service.discoverClient(guiAdapter, 'linux', wsl2Info);
+
+      expect(result.detection.status).toBe('found');
+      expect(result.source).toBe('wsl2-fallback');
+      expect(result.detection.appBundlePath).toBeDefined();
+    });
+  });
+
+  describe('tilde expansion', () => {
+    it('should expand tilde in binary_path', async () => {
+      const config: DiscoveryConfig = {
+        enabled: true,
+        clients: {
+          'claude-code': {
+            binary_path: '~/.local/bin/claude',
+          },
+        },
+      };
+      service.updateConfig(config);
+
+      // Mock that the expanded path exists
+      mockFs.existsSync.mockImplementation((path: any) => {
+        // The path should be expanded from ~ to actual home dir
+        return path.includes('.local/bin/claude') && !path.startsWith('~');
+      });
+
+      const result = await service.discoverClient(mockAdapter, 'linux');
+
+      expect(result.detection.status).toBe('found');
+      expect(result.source).toBe('config-override');
+      // The binary path should not start with ~
+      expect(result.detection.binaryPath).not.toMatch(/^~/);
+    });
+  });
+});

--- a/apps/cli/src/core/discovery-service.ts
+++ b/apps/cli/src/core/discovery-service.ts
@@ -1,0 +1,457 @@
+/**
+ * Discovery Service
+ *
+ * Orchestrates CLI detection with WSL2 support and YAML configuration overrides.
+ * Provides unified discovery across native detection, config overrides, and WSL2 fallback.
+ *
+ * @module core/discovery-service
+ * @version 1.0
+ */
+
+import * as fs from 'fs';
+import type { ClientAdapter } from '../adapters/client-adapter.interface';
+import type {
+  Platform,
+  DiscoveryConfig,
+  ClientName,
+} from '../domain/config.types';
+import type {
+  DiscoveryReport,
+  ClientDiscoveryResult,
+  WSL2EnvironmentInfo,
+} from '../domain/discovery.types';
+import { BinaryDetector } from './binary-detector';
+import { WSL2Detector, wsl2Detector, WINDOWS_DEFAULT_PATHS } from './wsl2-detector';
+import { adapterRegistry } from '../adapters/adapter-registry';
+import { getPlatform, expandTilde } from './path-resolver';
+
+/**
+ * Discovery Service
+ *
+ * Orchestrates detection across all registered clients with support for:
+ * - Native binary detection (which/where)
+ * - YAML configuration overrides
+ * - WSL2 fallback detection via Windows paths
+ */
+export class DiscoveryService {
+  private binaryDetector: BinaryDetector;
+  private wsl2Detector: WSL2Detector;
+  private config: DiscoveryConfig;
+
+  /**
+   * Create a new discovery service
+   *
+   * @param config - Discovery configuration (optional, defaults to enabled with auto-WSL2 detection)
+   */
+  constructor(config?: DiscoveryConfig) {
+    this.binaryDetector = new BinaryDetector();
+    this.wsl2Detector = wsl2Detector;
+    this.config = config || { enabled: true };
+  }
+
+  /**
+   * Run full discovery across all registered clients
+   *
+   * @returns Discovery report with environment info and all client results
+   *
+   * @example
+   * ```typescript
+   * const service = new DiscoveryService();
+   * const report = await service.discoverAll();
+   *
+   * console.log(`Detected ${report.summary.detected} of ${report.summary.totalClients} clients`);
+   * if (report.environment.isWSL2) {
+   *   console.log(`Running in WSL2 (${report.environment.wsl2Info?.distroName})`);
+   * }
+   * ```
+   */
+  async discoverAll(): Promise<DiscoveryReport> {
+    const platform = getPlatform();
+    const wsl2Info = await this.detectEnvironment();
+    const isWSL2 =
+      wsl2Info.isWSL2 && (this.config.wsl2_auto_detect !== false);
+
+    const clients: ClientDiscoveryResult[] = [];
+    let wsl2Detections = 0;
+
+    for (const adapter of adapterRegistry.getAll()) {
+      const result = await this.discoverClient(
+        adapter,
+        platform,
+        isWSL2 ? wsl2Info : undefined
+      );
+      clients.push(result);
+
+      if (result.source === 'wsl2-fallback') {
+        wsl2Detections++;
+      }
+    }
+
+    return {
+      environment: {
+        platform,
+        isWSL2,
+        wsl2Info: isWSL2 ? wsl2Info : undefined,
+      },
+      clients,
+      summary: {
+        totalClients: clients.length,
+        detected: clients.filter((c) => c.detection.status === 'found').length,
+        notFound: clients.filter((c) => c.detection.status === 'not-found')
+          .length,
+        wsl2Detections,
+      },
+    };
+  }
+
+  /**
+   * Discover a specific client by name
+   *
+   * @param clientName - Name of the client to discover
+   * @returns Discovery result for the client
+   * @throws Error if client not found in registry
+   */
+  async discoverByName(clientName: ClientName): Promise<ClientDiscoveryResult> {
+    const adapter = adapterRegistry.get(clientName);
+    if (!adapter) {
+      throw new Error(`No adapter registered for client: ${clientName}`);
+    }
+
+    const platform = getPlatform();
+    const wsl2Info = await this.detectEnvironment();
+    const isWSL2 =
+      wsl2Info.isWSL2 && (this.config.wsl2_auto_detect !== false);
+
+    return this.discoverClient(adapter, platform, isWSL2 ? wsl2Info : undefined);
+  }
+
+  /**
+   * Discover a single client with fallback strategies
+   *
+   * Detection order:
+   * 1. Config override (if binary_path specified in YAML)
+   * 2. Native detection via BinaryDetector
+   * 3. WSL2 fallback (if in WSL2 and native detection failed)
+   *
+   * @param adapter - Client adapter
+   * @param platform - Target platform
+   * @param wsl2Info - WSL2 environment info (if in WSL2)
+   * @returns Discovery result with detection info and source
+   */
+  async discoverClient(
+    adapter: ClientAdapter,
+    platform: Platform,
+    wsl2Info?: WSL2EnvironmentInfo
+  ): Promise<ClientDiscoveryResult> {
+    // Check if discovery is disabled for this client
+    const clientOverride = this.config.clients?.[adapter.name];
+    if (clientOverride?.enabled === false) {
+      return {
+        client: adapter.name,
+        detection: {
+          status: 'skipped',
+          warnings: ['Discovery disabled for this client in config'],
+        },
+        source: 'config-override',
+        environment: platform,
+      };
+    }
+
+    // Check for config override first (binary_path or app_bundle_path)
+    if (clientOverride?.binary_path || clientOverride?.app_bundle_path) {
+      const overrideResult = await this.detectFromOverride(
+        adapter,
+        clientOverride,
+        platform
+      );
+      if (overrideResult.detection.status === 'found') {
+        return overrideResult;
+      }
+      // If override path not found, continue with other detection methods
+    }
+
+    // Standard native detection
+    const nativeResult = await this.binaryDetector.detectClient(
+      adapter,
+      platform
+    );
+
+    if (nativeResult.status === 'found') {
+      return {
+        client: adapter.name,
+        detection: nativeResult,
+        source: 'native',
+        environment: platform,
+      };
+    }
+
+    // WSL2 fallback if native detection failed
+    if (wsl2Info?.isWSL2 && wsl2Info.windowsUserProfile) {
+      const wsl2Result = await this.detectViaWSL2(adapter, wsl2Info);
+      if (wsl2Result) {
+        return wsl2Result;
+      }
+    }
+
+    // Not found by any method
+    return {
+      client: adapter.name,
+      detection: nativeResult,
+      source: 'native',
+      environment: platform,
+    };
+  }
+
+  /**
+   * Detect environment (WSL2 or native)
+   *
+   * Respects config.environment override if specified.
+   *
+   * @returns WSL2 environment information
+   */
+  private async detectEnvironment(): Promise<WSL2EnvironmentInfo> {
+    // Check for forced environment in config
+    if (this.config.environment === 'wsl2') {
+      // Force WSL2 mode
+      const actualInfo = await this.wsl2Detector.detectEnvironment();
+      return {
+        isWSL2: true,
+        distroName: actualInfo.distroName,
+        windowsUserProfile: actualInfo.windowsUserProfile,
+      };
+    }
+
+    // If environment is set to a non-WSL2 value (darwin, linux, win32), force native mode
+    // Note: We've already handled 'wsl2' above and returned, so if environment is set here,
+    // it must be one of the native platform values
+    if (this.config.environment) {
+      return { isWSL2: false };
+    }
+
+    // Auto-detect
+    return this.wsl2Detector.detectEnvironment();
+  }
+
+  /**
+   * Detect from YAML override configuration
+   *
+   * @param adapter - Client adapter
+   * @param override - Override configuration from YAML
+   * @param platform - Target platform
+   * @returns Discovery result from override
+   */
+  private async detectFromOverride(
+    adapter: ClientAdapter,
+    override: { binary_path?: string; config_path?: string; app_bundle_path?: string },
+    platform: Platform
+  ): Promise<ClientDiscoveryResult> {
+    const binaryPath = override.binary_path
+      ? expandTilde(override.binary_path)
+      : undefined;
+    const configPath = override.config_path
+      ? expandTilde(override.config_path)
+      : undefined;
+    const appBundlePath = override.app_bundle_path
+      ? expandTilde(override.app_bundle_path)
+      : undefined;
+
+    // Check binary path
+    if (binaryPath && fs.existsSync(binaryPath)) {
+      return {
+        client: adapter.name,
+        detection: {
+          status: 'found',
+          binaryPath,
+          configPath,
+          warnings: ['Detected via config override'],
+        },
+        source: 'config-override',
+        environment: platform,
+      };
+    }
+
+    // Check app bundle path
+    if (appBundlePath && fs.existsSync(appBundlePath)) {
+      return {
+        client: adapter.name,
+        detection: {
+          status: 'found',
+          appBundlePath,
+          configPath,
+          warnings: ['Detected via config override (app bundle)'],
+        },
+        source: 'config-override',
+        environment: platform,
+      };
+    }
+
+    // Override path not found
+    return {
+      client: adapter.name,
+      detection: {
+        status: 'not-found',
+        warnings: [
+          `Override path not found: ${binaryPath || appBundlePath || 'no path specified'}`,
+        ],
+      },
+      source: 'config-override',
+      environment: platform,
+    };
+  }
+
+  /**
+   * Attempt detection via WSL2 Windows paths
+   *
+   * Checks known Windows installation locations for the client.
+   *
+   * @param adapter - Client adapter
+   * @param wsl2Info - WSL2 environment info
+   * @returns Discovery result if found, null otherwise
+   */
+  private async detectViaWSL2(
+    adapter: ClientAdapter,
+    wsl2Info: WSL2EnvironmentInfo
+  ): Promise<ClientDiscoveryResult | null> {
+    const windowsProfile = wsl2Info.windowsUserProfile;
+    if (!windowsProfile) {
+      return null;
+    }
+
+    // Check for WSL2 config override
+    const wsl2ConfigPath = this.config.wsl2?.windows_config_paths?.[adapter.name];
+
+    // Get Windows installation paths to check
+    const windowsPaths = this.wsl2Detector.getWindowsInstallPaths(
+      adapter.name,
+      windowsProfile
+    );
+
+    // Add custom WSL2 binary paths from config
+    if (this.config.wsl2?.windows_binary_paths) {
+      for (const basePath of this.config.wsl2.windows_binary_paths) {
+        const defaults = WINDOWS_DEFAULT_PATHS[adapter.name];
+        if (defaults) {
+          for (const relativePath of defaults.binaryPaths) {
+            windowsPaths.push(`${basePath}/${relativePath.split('/').pop()}`);
+          }
+        }
+      }
+    }
+
+    // Check each path
+    for (const searchPath of windowsPaths) {
+      if (fs.existsSync(searchPath)) {
+        // Get config path
+        const configPath =
+          wsl2ConfigPath ||
+          this.wsl2Detector.getWindowsConfigPath(adapter.name, windowsProfile);
+
+        return {
+          client: adapter.name,
+          detection: {
+            status: 'found',
+            binaryPath: searchPath,
+            configPath,
+            warnings: [
+              'Detected via WSL2 Windows path - may not be directly executable from WSL2',
+            ],
+          },
+          source: 'wsl2-fallback',
+          environment: 'wsl2',
+          windowsPath: searchPath,
+          configSource: 'windows',
+        };
+      }
+    }
+
+    // Check for app bundles (GUI apps)
+    const appBundlePaths = this.getWindowsAppBundlePaths(adapter.name, windowsProfile);
+    for (const appPath of appBundlePaths) {
+      if (fs.existsSync(appPath)) {
+        const configPath =
+          wsl2ConfigPath ||
+          this.wsl2Detector.getWindowsConfigPath(adapter.name, windowsProfile);
+
+        return {
+          client: adapter.name,
+          detection: {
+            status: 'found',
+            appBundlePath: appPath,
+            configPath,
+            warnings: [
+              'Detected Windows GUI application via WSL2 - config can be managed but app runs on Windows',
+            ],
+          },
+          source: 'wsl2-fallback',
+          environment: 'wsl2',
+          windowsPath: appPath,
+          configSource: 'windows',
+        };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Get Windows app bundle paths for GUI applications
+   *
+   * @param client - Client name
+   * @param windowsProfile - Windows user profile path
+   * @returns Array of app bundle paths to check
+   */
+  private getWindowsAppBundlePaths(
+    client: ClientName,
+    windowsProfile: string
+  ): string[] {
+    const paths: string[] = [];
+
+    // GUI application paths
+    const guiAppPaths: Partial<Record<ClientName, string[]>> = {
+      'claude-desktop': [
+        `${windowsProfile}/AppData/Local/Programs/Claude/Claude.exe`,
+        '/mnt/c/Program Files/Claude/Claude.exe',
+      ],
+      vscode: [
+        `${windowsProfile}/AppData/Local/Programs/Microsoft VS Code/Code.exe`,
+        '/mnt/c/Program Files/Microsoft VS Code/Code.exe',
+      ],
+      cursor: [
+        `${windowsProfile}/AppData/Local/Programs/cursor/Cursor.exe`,
+        `${windowsProfile}/AppData/Local/cursor/Cursor.exe`,
+      ],
+      windsurf: [
+        `${windowsProfile}/AppData/Local/Programs/windsurf/Windsurf.exe`,
+      ],
+    };
+
+    if (guiAppPaths[client]) {
+      paths.push(...guiAppPaths[client]!);
+    }
+
+    return paths;
+  }
+
+  /**
+   * Update discovery configuration
+   *
+   * @param config - New discovery configuration
+   */
+  updateConfig(config: DiscoveryConfig): void {
+    this.config = config;
+  }
+
+  /**
+   * Get current discovery configuration
+   *
+   * @returns Current discovery configuration
+   */
+  getConfig(): DiscoveryConfig {
+    return this.config;
+  }
+}
+
+/**
+ * Global discovery service instance
+ */
+export const discoveryService = new DiscoveryService();

--- a/apps/cli/src/core/path-resolver.ts
+++ b/apps/cli/src/core/path-resolver.ts
@@ -281,6 +281,48 @@ export function getCopilotCliPath(platform?: Platform): string {
 }
 
 /**
+ * Get OpenAI Codex CLI MCP configuration path
+ *
+ * @param platform - Target platform (defaults to current platform)
+ * @returns Codex CLI config path
+ */
+export function getCodexPath(platform?: Platform): string {
+  const targetPlatform = platform || getPlatform();
+  const homeDir = os.homedir();
+
+  // Codex CLI uses ~/.codex/mcp-config.json on all platforms
+  switch (targetPlatform) {
+    case 'darwin':
+    case 'linux':
+    case 'win32':
+      return path.join(homeDir, '.codex', 'mcp-config.json');
+    default:
+      throw new Error(`Unsupported platform: ${targetPlatform}`);
+  }
+}
+
+/**
+ * Get Google Gemini CLI MCP configuration path
+ *
+ * @param platform - Target platform (defaults to current platform)
+ * @returns Gemini CLI config path
+ */
+export function getGeminiCliPath(platform?: Platform): string {
+  const targetPlatform = platform || getPlatform();
+  const homeDir = os.homedir();
+
+  // Gemini CLI uses ~/.gemini/mcp-config.json on all platforms
+  switch (targetPlatform) {
+    case 'darwin':
+    case 'linux':
+    case 'win32':
+      return path.join(homeDir, '.gemini', 'mcp-config.json');
+    default:
+      throw new Error(`Unsupported platform: ${targetPlatform}`);
+  }
+}
+
+/**
  * Get JetBrains GitHub Copilot plugin MCP configuration path
  *
  * @param platform - Target platform (defaults to current platform)
@@ -477,6 +519,10 @@ export function getClientConfigPath(
         user: getJetBrainsCopilotPath(platform),
         project: getJetBrainsCopilotWorkspacePath(projectRoot),
       };
+    case 'codex':
+      return getCodexPath(platform);
+    case 'gemini-cli':
+      return getGeminiCliPath(platform);
     default:
       throw new Error(`Unknown client: ${clientName}`);
   }

--- a/apps/cli/src/core/wsl2-detector.spec.ts
+++ b/apps/cli/src/core/wsl2-detector.spec.ts
@@ -1,0 +1,392 @@
+/**
+ * WSL2 Detector Tests
+ *
+ * Tests for WSL2 environment detection and Windows path resolution.
+ *
+ * @module core/wsl2-detector.spec
+ */
+
+import { WSL2Detector, WINDOWS_DEFAULT_PATHS } from './wsl2-detector';
+import { ProcessExecutor } from '../infrastructure/process-executor';
+import * as fs from 'fs';
+
+// Mock dependencies
+jest.mock('../infrastructure/process-executor');
+jest.mock('fs');
+
+const mockProcessExecutor = ProcessExecutor as jest.Mocked<typeof ProcessExecutor>;
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+describe('WSL2Detector', () => {
+  let detector: WSL2Detector;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    detector = new WSL2Detector();
+    detector.resetCache();
+    // Reset environment
+    process.env = { ...originalEnv };
+    delete process.env.WSL_DISTRO_NAME;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('isWSL2', () => {
+    it('should detect WSL2 via WSL_DISTRO_NAME environment variable', async () => {
+      process.env.WSL_DISTRO_NAME = 'Ubuntu';
+
+      const result = await detector.isWSL2();
+
+      expect(result).toBe(true);
+    });
+
+    it('should detect WSL2 via /proc/version containing "microsoft"', async () => {
+      mockFs.readFileSync.mockReturnValue(
+        'Linux version 5.15.90.1-microsoft-standard-WSL2 (oe-user@oe-host) (gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37)'
+      );
+
+      const result = await detector.isWSL2();
+
+      expect(result).toBe(true);
+      expect(mockFs.readFileSync).toHaveBeenCalledWith('/proc/version', 'utf-8');
+    });
+
+    it('should return false on native Linux without WSL', async () => {
+      mockFs.readFileSync.mockReturnValue(
+        'Linux version 6.1.0-generic (build@host) (gcc (Ubuntu 12.2.0) 12.2.0)'
+      );
+
+      const result = await detector.isWSL2();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when /proc/version cannot be read', async () => {
+      mockFs.readFileSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      const result = await detector.isWSL2();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getDistroName', () => {
+    it('should return WSL_DISTRO_NAME environment variable', () => {
+      process.env.WSL_DISTRO_NAME = 'Ubuntu-22.04';
+
+      const result = detector.getDistroName();
+
+      expect(result).toBe('Ubuntu-22.04');
+    });
+
+    it('should return undefined when not in WSL', () => {
+      const result = detector.getDistroName();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('detectEnvironment', () => {
+    it('should return cached info on subsequent calls', async () => {
+      process.env.WSL_DISTRO_NAME = 'Ubuntu';
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue(['jeff'] as any);
+      mockFs.statSync.mockReturnValue({ isDirectory: () => true } as any);
+
+      const result1 = await detector.detectEnvironment();
+      const result2 = await detector.detectEnvironment();
+
+      expect(result1).toBe(result2);
+    });
+
+    it('should return isWSL2: false when not in WSL2', async () => {
+      mockFs.readFileSync.mockReturnValue('Linux version 6.1.0');
+
+      const result = await detector.detectEnvironment();
+
+      expect(result.isWSL2).toBe(false);
+      expect(result.distroName).toBeUndefined();
+      expect(result.windowsUserProfile).toBeUndefined();
+    });
+
+    it('should detect full WSL2 environment info', async () => {
+      process.env.WSL_DISTRO_NAME = 'Ubuntu';
+      mockProcessExecutor.exec.mockResolvedValue({
+        stdout: 'C:\\Users\\jeff\r\n',
+        exitCode: 0,
+      });
+
+      const result = await detector.detectEnvironment();
+
+      expect(result.isWSL2).toBe(true);
+      expect(result.distroName).toBe('Ubuntu');
+      expect(result.windowsUserProfile).toBe('/mnt/c/Users/jeff');
+    });
+  });
+
+  describe('getWindowsUserProfile', () => {
+    it('should get profile via cmd.exe', async () => {
+      mockProcessExecutor.exec.mockResolvedValue({
+        stdout: 'C:\\Users\\testuser\r\n',
+        exitCode: 0,
+      });
+
+      const result = await detector.getWindowsUserProfile();
+
+      expect(result).toBe('/mnt/c/Users/testuser');
+      expect(mockProcessExecutor.exec).toHaveBeenCalledWith(
+        '/mnt/c/Windows/System32/cmd.exe',
+        ['/c', 'echo', '%USERPROFILE%']
+      );
+    });
+
+    it('should handle cmd.exe failure and infer from /mnt/c/Users/', async () => {
+      mockProcessExecutor.exec.mockRejectedValue(new Error('cmd.exe failed'));
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue(['jeff', 'Public', 'Default'] as any);
+      mockFs.statSync.mockReturnValue({ isDirectory: () => true } as any);
+
+      const result = await detector.getWindowsUserProfile();
+
+      expect(result).toBe('/mnt/c/Users/jeff');
+    });
+
+    it('should handle timeout and fallback to inference', async () => {
+      mockProcessExecutor.exec.mockImplementation(() =>
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('timeout')), 100)
+        )
+      );
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue(['alice'] as any);
+      mockFs.statSync.mockReturnValue({ isDirectory: () => true } as any);
+
+      const result = await detector.getWindowsUserProfile();
+
+      expect(result).toBe('/mnt/c/Users/alice');
+    });
+
+    it('should prefer user with Desktop folder when multiple users exist', async () => {
+      mockProcessExecutor.exec.mockRejectedValue(new Error('failed'));
+      mockFs.existsSync.mockImplementation((path: any) => {
+        if (path === '/mnt/c/Users') return true;
+        if (path === '/mnt/c/Users/bob/Desktop') return true;
+        return false;
+      });
+      mockFs.readdirSync.mockReturnValue(['alice', 'bob', 'Public'] as any);
+      mockFs.statSync.mockReturnValue({ isDirectory: () => true } as any);
+
+      const result = await detector.getWindowsUserProfile();
+
+      expect(result).toBe('/mnt/c/Users/bob');
+    });
+
+    it('should skip system users when inferring profile', async () => {
+      mockProcessExecutor.exec.mockRejectedValue(new Error('failed'));
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue([
+        'Public',
+        'Default',
+        'Default User',
+        'All Users',
+        'LOCALSERVICE',
+        'jeff',
+      ] as any);
+      mockFs.statSync.mockReturnValue({ isDirectory: () => true } as any);
+
+      const result = await detector.getWindowsUserProfile();
+
+      expect(result).toBe('/mnt/c/Users/jeff');
+    });
+
+    it('should return undefined when /mnt/c/Users does not exist', async () => {
+      mockProcessExecutor.exec.mockRejectedValue(new Error('failed'));
+      mockFs.existsSync.mockReturnValue(false);
+
+      const result = await detector.getWindowsUserProfile();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('translateWindowsPath', () => {
+    it('should translate C:\\ path to /mnt/c/', () => {
+      const result = detector.translateWindowsPath('C:\\Users\\jeff');
+
+      expect(result).toBe('/mnt/c/Users/jeff');
+    });
+
+    it('should translate D:\\ path to /mnt/d/', () => {
+      const result = detector.translateWindowsPath('D:\\Projects\\code');
+
+      expect(result).toBe('/mnt/d/Projects/code');
+    });
+
+    it('should handle lowercase drive letters', () => {
+      const result = detector.translateWindowsPath('c:\\Users\\jeff');
+
+      expect(result).toBe('/mnt/c/Users/jeff');
+    });
+
+    it('should return path unchanged if not a Windows path', () => {
+      const result = detector.translateWindowsPath('/mnt/c/Users/jeff');
+
+      expect(result).toBe('/mnt/c/Users/jeff');
+    });
+
+    it('should handle paths with multiple backslashes', () => {
+      const result = detector.translateWindowsPath('C:\\Users\\jeff\\AppData\\Local\\Programs');
+
+      expect(result).toBe('/mnt/c/Users/jeff/AppData/Local/Programs');
+    });
+  });
+
+  describe('pathExists', () => {
+    it('should check path existence directly for WSL paths', () => {
+      mockFs.existsSync.mockReturnValue(true);
+
+      const result = detector.pathExists('/mnt/c/Users/jeff');
+
+      expect(result).toBe(true);
+      expect(mockFs.existsSync).toHaveBeenCalledWith('/mnt/c/Users/jeff');
+    });
+
+    it('should translate and check Windows paths', () => {
+      mockFs.existsSync.mockReturnValue(true);
+
+      const result = detector.pathExists('C:\\Users\\jeff');
+
+      expect(result).toBe(true);
+      expect(mockFs.existsSync).toHaveBeenCalledWith('/mnt/c/Users/jeff');
+    });
+
+    it('should return false for non-existent paths', () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      const result = detector.pathExists('/mnt/c/nonexistent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getWindowsInstallPaths', () => {
+    const windowsProfile = '/mnt/c/Users/jeff';
+
+    it('should return Claude Code installation paths', () => {
+      const result = detector.getWindowsInstallPaths('claude-code', windowsProfile);
+
+      expect(result).toContain('/mnt/c/Users/jeff/AppData/Local/Programs/claude-code/claude.exe');
+      expect(result).toContain('/mnt/c/Users/jeff/AppData/Roaming/npm/claude.cmd');
+    });
+
+    it('should return Claude Desktop installation paths', () => {
+      const result = detector.getWindowsInstallPaths('claude-desktop', windowsProfile);
+
+      expect(result).toContain('/mnt/c/Users/jeff/AppData/Local/Programs/Claude/Claude.exe');
+    });
+
+    it('should return VS Code installation paths', () => {
+      const result = detector.getWindowsInstallPaths('vscode', windowsProfile);
+
+      expect(result.some(p => p.includes('Microsoft VS Code'))).toBe(true);
+    });
+
+    it('should return Cursor installation paths', () => {
+      const result = detector.getWindowsInstallPaths('cursor', windowsProfile);
+
+      expect(result.some(p => p.includes('cursor'))).toBe(true);
+    });
+
+    it('should return empty array for unknown client', () => {
+      const result = detector.getWindowsInstallPaths('unknown' as any, windowsProfile);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getWindowsConfigPath', () => {
+    const windowsProfile = '/mnt/c/Users/jeff';
+
+    it('should return Claude Code config path', () => {
+      const result = detector.getWindowsConfigPath('claude-code', windowsProfile);
+
+      expect(result).toBe('/mnt/c/Users/jeff/AppData/Roaming/Claude/mcp.json');
+    });
+
+    it('should return Claude Desktop config path', () => {
+      const result = detector.getWindowsConfigPath('claude-desktop', windowsProfile);
+
+      expect(result).toBe('/mnt/c/Users/jeff/AppData/Roaming/Claude/claude_desktop_config.json');
+    });
+
+    it('should return Cursor config path', () => {
+      const result = detector.getWindowsConfigPath('cursor', windowsProfile);
+
+      expect(result).toBe('/mnt/c/Users/jeff/.cursor/mcp.json');
+    });
+
+    it('should return undefined for client without config path', () => {
+      // Temporarily override to test undefined case
+      const originalPaths = WINDOWS_DEFAULT_PATHS['claude-code'];
+      (WINDOWS_DEFAULT_PATHS as any)['test-client'] = { binaryPaths: [] };
+
+      const result = detector.getWindowsConfigPath('test-client' as any, windowsProfile);
+
+      expect(result).toBeUndefined();
+      delete (WINDOWS_DEFAULT_PATHS as any)['test-client'];
+    });
+  });
+
+  describe('WINDOWS_DEFAULT_PATHS', () => {
+    it('should have paths defined for all supported clients', () => {
+      const expectedClients = [
+        'claude-code',
+        'claude-desktop',
+        'vscode',
+        'cursor',
+        'windsurf',
+        'copilot-cli',
+        'jetbrains-copilot',
+        'codex',
+        'gemini-cli',
+      ];
+
+      for (const client of expectedClients) {
+        expect(WINDOWS_DEFAULT_PATHS[client as keyof typeof WINDOWS_DEFAULT_PATHS]).toBeDefined();
+      }
+    });
+
+    it('should have binary paths and config paths for most clients', () => {
+      expect(WINDOWS_DEFAULT_PATHS['claude-code'].binaryPaths.length).toBeGreaterThan(0);
+      expect(WINDOWS_DEFAULT_PATHS['claude-code'].configPath).toBeDefined();
+
+      expect(WINDOWS_DEFAULT_PATHS['vscode'].binaryPaths.length).toBeGreaterThan(0);
+      expect(WINDOWS_DEFAULT_PATHS['vscode'].configPath).toBeDefined();
+    });
+  });
+
+  describe('resetCache', () => {
+    it('should clear cached environment info', async () => {
+      process.env.WSL_DISTRO_NAME = 'Ubuntu';
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue(['jeff'] as any);
+      mockFs.statSync.mockReturnValue({ isDirectory: () => true } as any);
+
+      await detector.detectEnvironment();
+      detector.resetCache();
+
+      // Change environment
+      delete process.env.WSL_DISTRO_NAME;
+      mockFs.readFileSync.mockReturnValue('Linux version 6.1.0');
+
+      const result = await detector.detectEnvironment();
+
+      expect(result.isWSL2).toBe(false);
+    });
+  });
+});

--- a/apps/cli/src/core/wsl2-detector.ts
+++ b/apps/cli/src/core/wsl2-detector.ts
@@ -1,0 +1,403 @@
+/**
+ * WSL2 Environment Detector
+ *
+ * Detects WSL2 environment and provides Windows path resolution capabilities.
+ * Handles translation between WSL2 Linux paths and Windows paths.
+ *
+ * @module core/wsl2-detector
+ * @version 1.0
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ProcessExecutor } from '../infrastructure/process-executor';
+import type { WSL2EnvironmentInfo } from '../domain/discovery.types';
+import type { ClientName } from '../domain/config.types';
+
+/**
+ * Timeout for WSL2 detection operations (ms)
+ */
+const WSL2_DETECTION_TIMEOUT = 3000;
+
+/**
+ * System users to exclude when inferring Windows profile
+ */
+const WINDOWS_SYSTEM_USERS = [
+  'Public',
+  'Default',
+  'Default User',
+  'All Users',
+  'defaultuser0',
+  'LOCALSERVICE',
+  'NETWORKSERVICE',
+];
+
+/**
+ * Default Windows installation paths for AI coding tools
+ * Relative to Windows user profile (/mnt/c/Users/{user})
+ */
+export const WINDOWS_DEFAULT_PATHS: Record<
+  ClientName,
+  { binaryPaths: string[]; configPath?: string }
+> = {
+  'claude-code': {
+    binaryPaths: [
+      'AppData/Local/Programs/claude-code/claude.exe',
+      'AppData/Roaming/npm/claude.cmd',
+    ],
+    configPath: 'AppData/Roaming/Claude/mcp.json',
+  },
+  'claude-desktop': {
+    binaryPaths: [
+      'AppData/Local/Programs/Claude/Claude.exe',
+      'AppData/Local/Claude/Claude.exe',
+    ],
+    configPath: 'AppData/Roaming/Claude/claude_desktop_config.json',
+  },
+  vscode: {
+    binaryPaths: [
+      'AppData/Local/Programs/Microsoft VS Code/Code.exe',
+      'AppData/Local/Programs/Microsoft VS Code/bin/code.cmd',
+    ],
+    configPath: 'AppData/Roaming/Code/User/mcp.json',
+  },
+  cursor: {
+    binaryPaths: [
+      'AppData/Local/Programs/cursor/Cursor.exe',
+      'AppData/Local/cursor/Cursor.exe',
+    ],
+    configPath: '.cursor/mcp.json',
+  },
+  windsurf: {
+    binaryPaths: [
+      'AppData/Local/Programs/windsurf/Windsurf.exe',
+      '.codeium/windsurf/Windsurf.exe',
+    ],
+    configPath: '.codeium/windsurf/mcp_config.json',
+  },
+  'copilot-cli': {
+    binaryPaths: [
+      'AppData/Roaming/npm/copilot.cmd',
+      'AppData/Roaming/npm/github-copilot-cli.cmd',
+    ],
+    configPath: '.copilot/mcp-config.json',
+  },
+  'jetbrains-copilot': {
+    binaryPaths: [],
+    configPath: 'AppData/Local/github-copilot/intellij/mcp.json',
+  },
+  codex: {
+    binaryPaths: [
+      'AppData/Roaming/npm/codex.cmd',
+      '.local/bin/codex.exe',
+    ],
+    configPath: '.codex/mcp-config.json',
+  },
+  'gemini-cli': {
+    binaryPaths: [
+      'AppData/Roaming/npm/gemini.cmd',
+      '.local/bin/gemini.exe',
+    ],
+    configPath: '.gemini/mcp-config.json',
+  },
+};
+
+/**
+ * WSL2 Environment Detector
+ *
+ * Provides methods to detect WSL2 environment and resolve Windows paths.
+ */
+export class WSL2Detector {
+  private cachedInfo: WSL2EnvironmentInfo | null = null;
+
+  /**
+   * Detect if running in WSL2 environment and gather environment info
+   *
+   * @returns WSL2 environment information
+   *
+   * @example
+   * ```typescript
+   * const detector = new WSL2Detector();
+   * const info = await detector.detectEnvironment();
+   * if (info.isWSL2) {
+   *   console.log(`Running in WSL2 (${info.distroName})`);
+   *   console.log(`Windows profile: ${info.windowsUserProfile}`);
+   * }
+   * ```
+   */
+  async detectEnvironment(): Promise<WSL2EnvironmentInfo> {
+    if (this.cachedInfo) return this.cachedInfo;
+
+    const isWSL2 = await this.isWSL2();
+
+    if (!isWSL2) {
+      this.cachedInfo = { isWSL2: false };
+      return this.cachedInfo;
+    }
+
+    const [distroName, windowsUserProfile] = await Promise.all([
+      this.getDistroName(),
+      this.getWindowsUserProfile(),
+    ]);
+
+    this.cachedInfo = {
+      isWSL2: true,
+      distroName,
+      windowsUserProfile,
+    };
+
+    return this.cachedInfo;
+  }
+
+  /**
+   * Check if running in WSL2 environment
+   *
+   * Uses multiple detection methods:
+   * 1. WSL_DISTRO_NAME environment variable (fast)
+   * 2. /proc/version containing "microsoft" (fallback)
+   *
+   * @returns True if running in WSL2
+   */
+  async isWSL2(): Promise<boolean> {
+    // Check environment variable first (fast path)
+    if (process.env.WSL_DISTRO_NAME) {
+      return true;
+    }
+
+    // Check /proc/version for "microsoft" string
+    try {
+      const procVersion = fs.readFileSync('/proc/version', 'utf-8');
+      return procVersion.toLowerCase().includes('microsoft');
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get WSL2 distribution name
+   *
+   * @returns Distribution name or undefined
+   */
+  getDistroName(): string | undefined {
+    return process.env.WSL_DISTRO_NAME;
+  }
+
+  /**
+   * Get Windows user profile path as WSL2 mount path
+   *
+   * Tries multiple detection methods:
+   * 1. Execute cmd.exe to get USERPROFILE
+   * 2. Infer from /mnt/c/Users/ directory
+   *
+   * @returns Windows user profile path in WSL2 format (e.g., /mnt/c/Users/jeff)
+   */
+  async getWindowsUserProfile(): Promise<string | undefined> {
+    // Try cmd.exe first
+    const cmdProfile = await this.getProfileViaCmdExe();
+    if (cmdProfile) {
+      return cmdProfile;
+    }
+
+    // Fallback: infer from /mnt/c/Users/
+    return this.inferWindowsUserProfile();
+  }
+
+  /**
+   * Get Windows user profile via cmd.exe
+   *
+   * @returns Translated Windows profile path or undefined
+   */
+  private async getProfileViaCmdExe(): Promise<string | undefined> {
+    try {
+      // Use Promise.race for timeout
+      const result = await Promise.race<{ stdout: string; exitCode: number }>([
+        ProcessExecutor.exec('/mnt/c/Windows/System32/cmd.exe', [
+          '/c',
+          'echo',
+          '%USERPROFILE%',
+        ]),
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error('timeout')),
+            WSL2_DETECTION_TIMEOUT
+          )
+        ),
+      ]);
+
+      if (result.exitCode === 0 && result.stdout.trim()) {
+        const windowsPath = result.stdout.trim();
+        // Only translate if it looks like a Windows path
+        if (windowsPath.match(/^[A-Za-z]:\\/)) {
+          return this.translateWindowsPath(windowsPath);
+        }
+      }
+    } catch {
+      // cmd.exe failed or timed out
+    }
+    return undefined;
+  }
+
+  /**
+   * Infer Windows user profile by checking /mnt/c/Users/
+   *
+   * Finds non-system user directories and picks the most likely one.
+   *
+   * @returns Inferred user profile path or undefined
+   */
+  private inferWindowsUserProfile(): string | undefined {
+    const usersDir = '/mnt/c/Users';
+
+    try {
+      if (!fs.existsSync(usersDir)) {
+        return undefined;
+      }
+
+      const entries = fs.readdirSync(usersDir);
+      const userDirs = entries.filter((entry) => {
+        // Skip system users
+        if (WINDOWS_SYSTEM_USERS.includes(entry)) {
+          return false;
+        }
+
+        // Verify it's a directory
+        try {
+          const stat = fs.statSync(path.join(usersDir, entry));
+          return stat.isDirectory();
+        } catch {
+          return false;
+        }
+      });
+
+      // If exactly one user found, use it
+      if (userDirs.length === 1) {
+        return path.join(usersDir, userDirs[0]);
+      }
+
+      // If multiple users, prefer the one with common Windows user artifacts
+      for (const dir of userDirs) {
+        const desktopPath = path.join(usersDir, dir, 'Desktop');
+        if (fs.existsSync(desktopPath)) {
+          return path.join(usersDir, dir);
+        }
+      }
+
+      // Return first user if any exist
+      if (userDirs.length > 0) {
+        return path.join(usersDir, userDirs[0]);
+      }
+    } catch {
+      // Directory enumeration failed
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Translate Windows path to WSL2 mount path
+   *
+   * @param windowsPath - Windows path (e.g., C:\Users\jeff)
+   * @returns WSL2 path (e.g., /mnt/c/Users/jeff)
+   *
+   * @example
+   * ```typescript
+   * detector.translateWindowsPath('C:\\Users\\jeff')
+   * // Returns: '/mnt/c/Users/jeff'
+   *
+   * detector.translateWindowsPath('D:\\Projects')
+   * // Returns: '/mnt/d/Projects'
+   * ```
+   */
+  translateWindowsPath(windowsPath: string): string {
+    // Handle C:\path format
+    const match = windowsPath.match(/^([A-Za-z]):\\(.*)$/);
+    if (match) {
+      const drive = match[1].toLowerCase();
+      const rest = match[2].replace(/\\/g, '/');
+      return `/mnt/${drive}/${rest}`;
+    }
+    return windowsPath;
+  }
+
+  /**
+   * Check if a path exists, handling Windows path translation
+   *
+   * @param targetPath - Path to check (Windows or WSL2 format)
+   * @returns True if path exists
+   */
+  pathExists(targetPath: string): boolean {
+    const translatedPath = targetPath.includes(':\\')
+      ? this.translateWindowsPath(targetPath)
+      : targetPath;
+    return fs.existsSync(translatedPath);
+  }
+
+  /**
+   * Get Windows installation paths for a specific client
+   *
+   * @param client - Client name
+   * @param windowsUserProfile - Windows user profile path in WSL2 format
+   * @returns Array of potential installation paths
+   */
+  getWindowsInstallPaths(
+    client: ClientName,
+    windowsUserProfile: string
+  ): string[] {
+    const paths: string[] = [];
+    const defaults = WINDOWS_DEFAULT_PATHS[client];
+
+    if (!defaults) {
+      return paths;
+    }
+
+    // Add binary paths relative to user profile
+    for (const relativePath of defaults.binaryPaths) {
+      paths.push(path.join(windowsUserProfile, relativePath));
+    }
+
+    // Add Program Files paths
+    paths.push(
+      ...defaults.binaryPaths
+        .map((p) => {
+          if (p.includes('AppData')) return null;
+          return path.join('/mnt/c/Program Files', p);
+        })
+        .filter(Boolean) as string[]
+    );
+
+    return paths;
+  }
+
+  /**
+   * Get Windows config path for a specific client
+   *
+   * @param client - Client name
+   * @param windowsUserProfile - Windows user profile path in WSL2 format
+   * @returns Config file path or undefined
+   */
+  getWindowsConfigPath(
+    client: ClientName,
+    windowsUserProfile: string
+  ): string | undefined {
+    const defaults = WINDOWS_DEFAULT_PATHS[client];
+
+    if (!defaults?.configPath) {
+      return undefined;
+    }
+
+    return path.join(windowsUserProfile, defaults.configPath);
+  }
+
+  /**
+   * Reset cached environment info
+   *
+   * Primarily for testing purposes.
+   */
+  resetCache(): void {
+    this.cachedInfo = null;
+  }
+}
+
+/**
+ * Global WSL2 detector instance
+ */
+export const wsl2Detector = new WSL2Detector();

--- a/apps/cli/src/domain/config.schema.ts
+++ b/apps/cli/src/domain/config.schema.ts
@@ -37,7 +37,14 @@ export const ClientNameSchema = z.enum([
   'windsurf',
   'copilot-cli',
   'jetbrains-copilot',
+  'codex',
+  'gemini-cli',
 ]);
+
+/**
+ * Detection environment schema (Platform + WSL2)
+ */
+export const DetectionEnvironmentSchema = z.enum(['darwin', 'linux', 'win32', 'wsl2']);
 
 /**
  * Merge strategy schema
@@ -163,6 +170,43 @@ export const PluginConfigSchema = z.object({
 }).strict();
 
 /**
+ * Client Discovery Override Schema
+ *
+ * Per-client override configuration for discovery.
+ */
+export const ClientDiscoveryOverrideSchema = z.object({
+  binary_path: z.string().optional(),
+  config_path: z.string().optional(),
+  app_bundle_path: z.string().optional(),
+  enabled: z.boolean().optional(),
+}).strict();
+
+/**
+ * WSL2 Configuration Schema
+ *
+ * Configuration for WSL2 environment detection.
+ */
+export const WSL2ConfigSchema = z.object({
+  windows_user_profile: z.string().optional(),
+  windows_binary_paths: z.array(z.string()).optional(),
+  windows_config_paths: z.record(ClientNameSchema, z.string()).optional(),
+}).strict();
+
+/**
+ * Discovery Configuration Schema
+ *
+ * Settings for CLI/tool discovery and detection.
+ */
+export const DiscoveryConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  timeout: z.number().int().positive().default(5000),
+  wsl2_auto_detect: z.boolean().default(true),
+  environment: DetectionEnvironmentSchema.optional(),
+  clients: z.record(ClientNameSchema, ClientDiscoveryOverrideSchema).optional(),
+  wsl2: WSL2ConfigSchema.optional(),
+}).strict();
+
+/**
  * Main Overture v2.0 Configuration Schema
  *
  * Validates the complete user or project configuration file.
@@ -174,6 +218,7 @@ export const OvertureConfigSchema = z.object({
   clients: z.record(z.string(), ClientConfigSchema).optional(),
   mcp: z.record(z.string(), McpServerConfigSchema),
   sync: SyncOptionsSchema.optional(),
+  discovery: DiscoveryConfigSchema.optional(),
 }).strict(); // Reject unknown fields at top level
 
 /**
@@ -296,3 +341,7 @@ export type ValidationError = z.infer<typeof ValidationErrorSchema>;
 export type ValidationWarning = z.infer<typeof ValidationWarningSchema>;
 export type ValidationResult = z.infer<typeof ValidationResultSchema>;
 export type ProcessLock = z.infer<typeof ProcessLockSchema>;
+export type DetectionEnvironment = z.infer<typeof DetectionEnvironmentSchema>;
+export type ClientDiscoveryOverride = z.infer<typeof ClientDiscoveryOverrideSchema>;
+export type WSL2Config = z.infer<typeof WSL2ConfigSchema>;
+export type DiscoveryConfig = z.infer<typeof DiscoveryConfigSchema>;

--- a/apps/cli/src/domain/config.types.ts
+++ b/apps/cli/src/domain/config.types.ts
@@ -40,7 +40,15 @@ export type ClientName =
   | 'cursor'
   | 'windsurf'
   | 'copilot-cli'
-  | 'jetbrains-copilot';
+  | 'jetbrains-copilot'
+  | 'codex'
+  | 'gemini-cli';
+
+/**
+ * Detection environment types
+ * Extends Platform with WSL2 as a special case
+ */
+export type DetectionEnvironment = 'darwin' | 'linux' | 'win32' | 'wsl2';
 
 /**
  * Merge strategy for config synchronization
@@ -337,6 +345,133 @@ export interface SyncOptions {
 }
 
 /**
+ * Per-client discovery override configuration
+ *
+ * Allows overriding default binary and config paths for specific clients.
+ *
+ * @example
+ * ```yaml
+ * discovery:
+ *   clients:
+ *     claude-code:
+ *       binary_path: "/custom/path/to/claude"
+ *       config_path: "~/.custom-claude/mcp.json"
+ * ```
+ */
+export interface ClientDiscoveryOverride {
+  /**
+   * Override binary path for this client
+   * @example "/usr/local/bin/claude"
+   */
+  binary_path?: string;
+
+  /**
+   * Override config file path for this client
+   * @example "~/.custom-claude/mcp.json"
+   */
+  config_path?: string;
+
+  /**
+   * Override app bundle path for this client (GUI apps)
+   * @example "/Applications/Claude.app"
+   */
+  app_bundle_path?: string;
+
+  /**
+   * Disable discovery for this client
+   * @default true (enabled)
+   */
+  enabled?: boolean;
+}
+
+/**
+ * WSL2-specific discovery configuration
+ *
+ * Configuration for detecting Windows applications from WSL2 environment.
+ *
+ * @example
+ * ```yaml
+ * discovery:
+ *   wsl2:
+ *     windows_user_profile: "/mnt/c/Users/jeff"
+ *     windows_binary_paths:
+ *       - "/mnt/c/Program Files/Custom Apps"
+ * ```
+ */
+export interface WSL2Config {
+  /**
+   * Windows user profile path (auto-detected if not specified)
+   * @example "/mnt/c/Users/jeff"
+   */
+  windows_user_profile?: string;
+
+  /**
+   * Additional Windows paths to search for binaries
+   * @example ["/mnt/c/Program Files/Custom Apps"]
+   */
+  windows_binary_paths?: string[];
+
+  /**
+   * Per-client Windows config file paths
+   * @example { "claude-desktop": "/mnt/c/Users/jeff/AppData/Roaming/Claude/config.json" }
+   */
+  windows_config_paths?: Partial<Record<ClientName, string>>;
+}
+
+/**
+ * Discovery configuration
+ *
+ * Settings for CLI/tool discovery and detection.
+ *
+ * @example
+ * ```yaml
+ * discovery:
+ *   enabled: true
+ *   timeout: 5000
+ *   wsl2_auto_detect: true
+ *   clients:
+ *     codex:
+ *       binary_path: "~/.local/bin/codex"
+ *   wsl2:
+ *     windows_user_profile: "/mnt/c/Users/jeff"
+ * ```
+ */
+export interface DiscoveryConfig {
+  /**
+   * Enable/disable discovery
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Timeout per binary detection in milliseconds
+   * @default 5000
+   */
+  timeout?: number;
+
+  /**
+   * Auto-detect WSL2 environment and enable Windows path fallback
+   * @default true
+   */
+  wsl2_auto_detect?: boolean;
+
+  /**
+   * Force specific detection environment (overrides auto-detection)
+   */
+  environment?: DetectionEnvironment;
+
+  /**
+   * Per-client discovery overrides
+   */
+  clients?: Partial<Record<ClientName, ClientDiscoveryOverride>>;
+
+  /**
+   * WSL2-specific configuration
+   */
+  wsl2?: WSL2Config;
+}
+
+/**
  * Overture v2.0 Configuration (User Global)
  *
  * This is the main configuration file for Overture v2.0.
@@ -400,6 +535,11 @@ export interface OvertureConfig {
    * Synchronization options
    */
   sync?: SyncOptions;
+
+  /**
+   * Discovery configuration for CLI/tool detection
+   */
+  discovery?: DiscoveryConfig;
 }
 
 /**

--- a/apps/cli/src/domain/discovery.types.ts
+++ b/apps/cli/src/domain/discovery.types.ts
@@ -1,0 +1,242 @@
+/**
+ * Discovery Types
+ *
+ * Types for CLI discovery, WSL2 detection, and discovery reports.
+ *
+ * @module domain/discovery.types
+ * @version 1.0
+ */
+
+import type {
+  ClientName,
+  Platform,
+  DetectionEnvironment,
+  BinaryDetectionResult,
+} from './config.types';
+
+/**
+ * WSL2 environment detection result
+ *
+ * Contains information about the WSL2 environment when detected.
+ *
+ * @example
+ * ```typescript
+ * {
+ *   isWSL2: true,
+ *   distroName: 'Ubuntu',
+ *   windowsUserProfile: '/mnt/c/Users/jeff',
+ *   windowsVersion: '10.0.22631'
+ * }
+ * ```
+ */
+export interface WSL2EnvironmentInfo {
+  /**
+   * Whether running in WSL2 environment
+   */
+  isWSL2: boolean;
+
+  /**
+   * WSL2 distribution name (from WSL_DISTRO_NAME env var)
+   * @example "Ubuntu", "Debian", "Ubuntu-22.04"
+   */
+  distroName?: string;
+
+  /**
+   * Windows user profile path (translated to WSL2 mount path)
+   * @example "/mnt/c/Users/jeff"
+   */
+  windowsUserProfile?: string;
+
+  /**
+   * Windows version string (if detectable)
+   * @example "10.0.22631"
+   */
+  windowsVersion?: string;
+}
+
+/**
+ * Detection source indicating how the client was discovered
+ */
+export type DetectionSource = 'native' | 'wsl2-fallback' | 'config-override';
+
+/**
+ * Config source indicating where the config file was found
+ */
+export type ConfigSource = 'linux' | 'windows';
+
+/**
+ * Discovery result for a single client with extended metadata
+ *
+ * Extends the base BinaryDetectionResult with discovery-specific information
+ * including how and where the client was detected.
+ *
+ * @example
+ * ```typescript
+ * {
+ *   client: 'claude-desktop',
+ *   detection: { status: 'found', appBundlePath: '/mnt/c/Users/jeff/AppData/...' },
+ *   source: 'wsl2-fallback',
+ *   environment: 'wsl2',
+ *   windowsPath: 'C:\\Users\\jeff\\AppData\\Local\\Programs\\Claude\\Claude.exe'
+ * }
+ * ```
+ */
+export interface ClientDiscoveryResult {
+  /**
+   * Client name that was discovered
+   */
+  client: ClientName;
+
+  /**
+   * Binary detection result with status, paths, and version
+   */
+  detection: BinaryDetectionResult;
+
+  /**
+   * How the client was detected
+   * - native: Found via standard PATH/binary detection
+   * - wsl2-fallback: Found via Windows paths from WSL2
+   * - config-override: Found via user-specified path in config
+   */
+  source: DetectionSource;
+
+  /**
+   * Environment where detection occurred
+   */
+  environment: DetectionEnvironment;
+
+  /**
+   * Original Windows path (for WSL2 detections)
+   * @example "C:\\Users\\jeff\\AppData\\Local\\Programs\\Claude\\Claude.exe"
+   */
+  windowsPath?: string;
+
+  /**
+   * Where the config file was found (for WSL2 environments)
+   */
+  configSource?: ConfigSource;
+}
+
+/**
+ * Full discovery report with environment info and all client results
+ *
+ * Returned by DiscoveryService.discoverAll() with comprehensive
+ * information about the detection environment and all clients.
+ *
+ * @example
+ * ```typescript
+ * {
+ *   environment: {
+ *     platform: 'linux',
+ *     isWSL2: true,
+ *     wsl2Info: { distroName: 'Ubuntu', windowsUserProfile: '/mnt/c/Users/jeff' }
+ *   },
+ *   clients: [...],
+ *   summary: { totalClients: 9, detected: 5, notFound: 4, wsl2Detections: 3 }
+ * }
+ * ```
+ */
+export interface DiscoveryReport {
+  /**
+   * Environment information
+   */
+  environment: {
+    /**
+     * Detected platform
+     */
+    platform: Platform;
+
+    /**
+     * Whether running in WSL2
+     */
+    isWSL2: boolean;
+
+    /**
+     * WSL2-specific information (only present if isWSL2 is true)
+     */
+    wsl2Info?: WSL2EnvironmentInfo;
+  };
+
+  /**
+   * Discovery results for each client
+   */
+  clients: ClientDiscoveryResult[];
+
+  /**
+   * Summary statistics
+   */
+  summary: {
+    /**
+     * Total number of clients checked
+     */
+    totalClients: number;
+
+    /**
+     * Number of clients detected (status === 'found')
+     */
+    detected: number;
+
+    /**
+     * Number of clients not found (status === 'not-found')
+     */
+    notFound: number;
+
+    /**
+     * Number of clients detected via WSL2 fallback
+     */
+    wsl2Detections: number;
+  };
+}
+
+/**
+ * Default installation paths per client per platform
+ *
+ * Used by discovery service to check known installation locations.
+ */
+export interface DefaultInstallationPaths {
+  [client: string]: {
+    /**
+     * Binary paths by platform
+     */
+    binary: Partial<Record<Platform | 'wsl2', string[]>>;
+
+    /**
+     * App bundle paths by platform
+     */
+    appBundle: Partial<Record<Platform | 'wsl2', string[]>>;
+
+    /**
+     * Config file path by platform
+     */
+    config: Partial<Record<Platform | 'wsl2', string>>;
+  };
+}
+
+/**
+ * Windows default paths for common clients
+ *
+ * Standard Windows installation locations that can be checked from WSL2.
+ */
+export interface WindowsDefaultPaths {
+  /**
+   * Client name
+   */
+  client: ClientName;
+
+  /**
+   * Paths relative to Windows user profile (e.g., AppData/Local/Programs/...)
+   * These will be joined with the detected windowsUserProfile
+   */
+  profileRelativePaths: string[];
+
+  /**
+   * Absolute Windows paths (e.g., /mnt/c/Program Files/...)
+   * Already translated to WSL2 mount format
+   */
+  absolutePaths: string[];
+
+  /**
+   * Config file path relative to Windows user profile
+   */
+  configPath?: string;
+}


### PR DESCRIPTION
## Summary

This PR implements a comprehensive CLI discovery feature with WSL2/Windows11 compatibility, enabling Overture to detect AI coding tools across different environments.

### Key Features

- **WSL2 Auto-Detection**: Automatically detects WSL2 environment via `/proc/version` or `WSL_DISTRO_NAME` env var
- **Windows Path Translation**: Converts Windows paths (C:\Users\jeff) to WSL2 mount paths (/mnt/c/Users/jeff)  
- **9 AI Clients Supported**: claude-code, claude-desktop, vscode, cursor, windsurf, copilot-cli, jetbrains-copilot, codex, gemini-cli
- **YAML Override Configuration**: Custom binary/config paths via `.overture/config.yaml`
- **Fallback Detection Strategy**: native → config override → WSL2 Windows paths

### New Components

| File | Purpose |
|------|---------|
| `discovery-service.ts` | Orchestrates detection with WSL2 support and YAML overrides |
| `wsl2-detector.ts` | WSL2 environment detection and Windows path resolution |
| `codex-adapter.ts` | OpenAI Codex CLI adapter |
| `gemini-cli-adapter.ts` | Google Gemini CLI adapter |
| `discovery.types.ts` | Type definitions for discovery feature |

### Doctor Command Enhancements

- `--wsl2` flag to force WSL2 detection mode
- `--no-wsl2` flag to disable WSL2 detection
- Shows WSL2 environment info (distro name, Windows user profile)
- `[WSL2: Windows]` tag for Windows-detected clients
- Install recommendations for all missing clients

### Example Output (WSL2)

```
Environment:
  Platform: WSL2 (Ubuntu)
  Windows User: /mnt/c/Users/Jeff

Checking client installations...

✓ claude-code (2.0.69) - /home/jeff/.local/bin/claude
  Config: /home/jeff/.config/claude/mcp.json (valid)

✓ vscode (1.106.3) - /mnt/c/Program Files/Microsoft VS Code/bin/code
  Config: /home/jeff/.config/Code/User/mcp.json (valid)

✗ codex - not installed
  → Install OpenAI Codex CLI: pip install openai-codex

Summary:
  Clients detected: 4 / 9
  Clients missing:  5
```

## Test plan

- [x] Unit tests for WSL2 detector (wsl2-detector.spec.ts)
- [x] Unit tests for discovery service (discovery-service.spec.ts)
- [x] Unit tests for Codex and Gemini CLI adapters
- [x] All 1299 tests passing
- [x] Build succeeds
- [x] Manual testing of `overture doctor` command in WSL2 environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)