### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/mcp.json
+++ b/.github/mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "nx-mcp": {
       "command": "npx",
-      "args": [
-        "nx",
-        "mcp"
-      ]
+      "args": ["nx", "mcp"]
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  ci:
-    name: Lint, Format, Test
+  quality:
+    name: Quality Gates
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +32,23 @@ jobs:
 
       - name: Format check
         run: npx prettier --check .
+
+  test:
+    name: Test
+    needs: [quality]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Test
         run: npx nx test @overture/cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  ci:
+    name: Lint, Format, Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npx nx run-many -t lint --all
+
+      - name: Format check
+        run: npx prettier --check .
+
+      - name: Test
+        run: npx nx test @overture/cli

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -5,7 +5,9 @@ This directory contains documentation for Overture contributors and developers.
 ## Contents
 
 ### [architecture.md](./architecture.md)
+
 Comprehensive architecture documentation covering:
+
 - Claude Code ecosystem research
 - Multi-platform MCP synchronization architecture
 - Component design and patterns
@@ -14,6 +16,7 @@ Comprehensive architecture documentation covering:
 **Audience:** Developers who want to understand Overture's internal architecture
 
 ### [add-new-cli-client.md](./add-new-cli-client.md)
+
 Step-by-step guide for adding support for a new AI coding CLI client to Overture.
 
 **Audience:** Contributors adding support for new AI development tools

--- a/libs/core/agent/src/lib/agent-sync-service.spec.ts
+++ b/libs/core/agent/src/lib/agent-sync-service.spec.ts
@@ -40,7 +40,8 @@ describe('AgentSyncService', () => {
     });
 
     filesystem.readFile.mockImplementation(async (path) => {
-      if (path === `${xdgConfigHome}/overture/models.yaml`) return 'smart: { "claude-code": "sonnet" }';
+      if (path === `${xdgConfigHome}/overture/models.yaml`)
+        return 'smart: { "claude-code": "sonnet" }';
       if (path === `${xdgConfigHome}/overture/agents/test.yaml`) {
         return 'name: test\ndescription: test agent';
       }
@@ -58,7 +59,7 @@ describe('AgentSyncService', () => {
     expect(summary.synced).toBe(1);
     expect(filesystem.writeFile).toHaveBeenCalledWith(
       `${homeDir}/.claude/agents/test.md`,
-      expect.stringContaining('test body')
+      expect.stringContaining('test body'),
     );
   });
 

--- a/libs/core/agent/src/lib/agent-transformer.spec.ts
+++ b/libs/core/agent/src/lib/agent-transformer.spec.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { AgentTransformer } from './agent-transformer.js';
-import {
-  AgentDefinition,
-  ModelMapping,
-} from '@overture/config-types';
+import { AgentDefinition, ModelMapping } from '@overture/config-types';
 
 describe('AgentTransformer', () => {
   const transformer = new AgentTransformer();

--- a/libs/core/agent/vite.config.ts
+++ b/libs/core/agent/vite.config.ts
@@ -19,6 +19,6 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: './test-output/vitest/coverage',
       provider: 'v8' as const,
-    }
+    },
   },
 }));

--- a/libs/core/agent/vitest.config.mts
+++ b/libs/core/agent/vitest.config.mts
@@ -13,6 +13,6 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: './test-output/vitest/coverage',
       provider: 'v8' as const,
-    }
+    },
   },
 }));

--- a/libs/shared/formatters/src/lib/formatters/summary-formatter.spec.ts
+++ b/libs/shared/formatters/src/lib/formatters/summary-formatter.spec.ts
@@ -106,7 +106,9 @@ describe('SummaryFormatter', () => {
 
       formatter.formatSummary(result, 3);
 
-      expect(output.info).toHaveBeenCalledWith(expect.stringContaining('Summary:'));
+      expect(output.info).toHaveBeenCalledWith(
+        expect.stringContaining('Summary:'),
+      );
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('Config repo:'),
       );

--- a/nx.json
+++ b/nx.json
@@ -1,10 +1,7 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*",
-      "sharedGlobals"
-    ],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [
       "default",
       "!{projectRoot}/.eslintrc.json",
@@ -61,25 +58,15 @@
   "targetDefaults": {
     "@nx/esbuild:esbuild": {
       "cache": true,
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
     },
     "test": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "@nx/vitest:test": {
       "cache": true,
-      "inputs": [
-        "default",
-        "^production"
-      ]
+      "inputs": ["default", "^production"]
     }
   },
   "release": {

--- a/opencode.json
+++ b/opencode.json
@@ -3,11 +3,7 @@
     "nx-mcp": {
       "type": "local",
       "enabled": true,
-      "command": [
-        "npx",
-        "nx",
-        "mcp"
-      ]
+      "command": ["npx", "nx", "mcp"]
     }
   },
   "$schema": "https://opencode.ai/config.json"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow that runs on push to `main` and on all pull requests targeting `main`.

## What It Does

One job (`ci`) with three sequential steps:

1. **Lint** – `nx run-many -t lint --all`
2. **Format check** – `prettier --check .`
3. **Test** – `nx test @overture/cli`

## Configuration

- Node.js 20 with npm cache enabled
- 15-minute job timeout
- Concurrency group cancels in-progress PR runs when a new commit is pushed (preserves push-to-main runs)