### PR TITLE
fix: merge duplicate imports from @overture/config-types in validation-formatter

### DIFF
--- a/apps/cli/src/lib/formatters/validation-formatter.ts
+++ b/apps/cli/src/lib/formatters/validation-formatter.ts
@@ -5,10 +5,9 @@
  * Handles display and formatting of validation results.
  */
 
-import type { OvertureConfig } from '@overture/config-types';
+import type { OvertureConfig, ClientName } from '@overture/config-types';
 import type { OutputPort } from '@overture/ports-output';
 import type { AdapterRegistry } from '@overture/client-adapters';
-import type { ClientName } from '@overture/config-types';
 import {
   getTransportValidationSummary,
   type TransportWarning,


### PR DESCRIPTION
## Summary

Fixes an `import/no-duplicates` ESLint error in `validation-formatter.ts` where `OvertureConfig` and `ClientName` were imported in two separate statements from the same `@overture/config-types` package.

## Changes

- Merged two separate `import type` statements from `@overture/config-types` into a single statement

## Why

This was blocking CI — the linter exited with a non-zero status code due to these errors, causing the lint step to fail.