### PR TITLE
docs: add hierarchical AGENTS.md knowledge base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,378 +1,217 @@
-# AGENTS.md
+# AGENTS.md — Overture Codebase Guide
 
-This file provides guidance for AI agents (GitHub Copilot, Cursor, Windsurf, etc.) working with the Overture codebase.
+AI agent guidance for GitHub Copilot, Cursor, OpenCode, and other tools working in this codebase.
 
-## Project Overview
+## What Overture Does
 
-**Overture** is a multi-platform MCP configuration orchestrator that manages Model Context Protocol (MCP) server configurations across all AI development tools from a single source of truth.
+Overture is a multi-platform MCP configuration orchestrator. It manages Model Context Protocol (MCP) server configurations and AI agents across **3 AI clients** (Claude Code, GitHub Copilot CLI, OpenCode) from a single `config.yaml` source of truth.
 
-**Current Version:** v0.3.0
-**Status:** Production-ready with 384 passing tests, 83%+ code coverage
-**Repository:** https://github.com/overture-stack/overture
+Key responsibilities: config loading/merging, client detection, config generation (`.mcp.json`, `opencode.json`, `.github/mcp.json`), agent sync, plugin management, skill sync, and diagnostics.
 
-### What It Does
-
-1. **Multi-Platform Sync** - Generates MCP configs for 3 AI clients (Claude Code, GitHub Copilot CLI, OpenCode)
-2. **Binary Detection** - Automatically detects installed AI clients, versions, and validates configs
-3. **User/Project Config** - Supports global (`~/.config/overture/config.yaml`) and project-specific (`.overture/config.yaml`) configurations
-4. **Documentation Generation** - Creates CLAUDE.md with plugin→MCP usage guidance
-5. **System Diagnostics** - `overture doctor` command for health checks and troubleshooting
-
-## Module System
-
-**Overture is a Pure ESM Project** (as of the ESM migration PR)
-
-All packages use ECMAScript Modules (ESM):
-
-- ✅ All packages have `"type": "module"`
-- ✅ TypeScript configured with `"module": "nodenext"`
-- ✅ Build outputs ESM format
-- ✅ Relative imports require `.js` extensions
-
-### ESM Patterns Used
-
-**Import Syntax:**
-
-```typescript
-// Relative imports need .js extension (even for .ts files)
-import { foo } from './utils.js';
-import { bar } from '../helpers.js';
-import { baz } from './directory/index.js'; // Explicit index required
-
-// Package imports don't need extension
-import { qux } from '@overture/utils';
-```
-
-**\_\_dirname Equivalent:**
-
-```typescript
-import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-```
-
-**Dynamic Imports:**
-
-```typescript
-const module = await import('./plugin.js'); // Note: .js extension required
-```
-
-### Requirements
-
-- **Node.js 18+** (required for full ESM support)
-- Modern package managers (npm 10+, pnpm 8+, yarn 4+)
-
-## Architecture
-
-### Tech Stack
-
-- **Language:** TypeScript 5.x (Pure ESM)
-- **Build System:** Nx 22.0.3 monorepo
-- **CLI Framework:** Commander.js
-- **Schema Validation:** Zod
-- **Config Parsing:** js-yaml
-- **Testing:** Vitest (918+ tests, 83%+ coverage)
-- **Bundler:** esbuild
-
-### Project Structure
+## Architecture: Hexagonal (Ports & Adapters)
 
 ```
-overture/
-├── apps/
-│   ├── cli/              # CLI application (@overture/cli)
-│   │   ├── src/
-│   │   │   ├── commands/     # CLI command implementations
-│   │   │   ├── core/         # Core business logic
-│   │   │   ├── domain/       # Domain models and constants
-│   │   │   ├── services/     # Services (detection, validation, etc.)
-│   │   │   └── main.ts       # CLI entry point
-│   │   └── project.json      # Nx project configuration
-│   └── cli-e2e/          # End-to-end tests
-├── docs/                 # Documentation
-│   ├── user-guide.md
-│   ├── QUICKSTART.md
-│   ├── examples.md
-│   ├── overture-schema.md
-│   └── archive/          # Historical docs
-└── dist/                 # Build output (git-ignored)
+libs/ports/        Pure TypeScript interfaces (no implementation)
+libs/domain/       Types + Zod schemas (zero Node.js deps, only zod)
+libs/core/         Business logic (depends on ports + domain only)
+libs/adapters/     Node.js implementations + AI client adapters
+libs/shared/       Cross-cutting utilities, formatters, test helpers
+apps/cli/          CLI commands + DI composition root
 ```
 
-### Core Modules
+**Critical invariant**: `libs/core/**` and `libs/domain/**` MUST NOT import `node:*` or `libs/adapters/infrastructure`. The ONLY place where infrastructure is instantiated is `apps/cli/src/composition-root.ts`.
 
-**Commands** (`apps/cli/src/commands/`)
+## Package Alias Map
 
-- `init.ts` - Initialize project configuration
-- `sync.ts` - Sync MCP configs to all clients
-- `doctor.ts` - System diagnostics
-- `mcp-commands.ts` - MCP management (list, enable)
-- `validate.ts` - Configuration validation
+Use these aliases (defined in `tsconfig.base.json`) — never use relative paths across package boundaries.
 
-**Services** (`apps/cli/src/services/`)
+| Alias | Package | Key Contents |
+| --- | --- | --- |
+| `@overture/config-types` | `libs/domain/config-types` | 15 type files: adapter, agent, base, client, config, discovery, import, mcp, plugin, skill, sync, utility, validation types |
+| `@overture/config-schema` | `libs/domain/config-schema` | Zod schemas (434L), marketplace registry (349L) |
+| `@overture/errors` | `libs/domain/errors` | OvertureError hierarchy + exit codes |
+| `@overture/config-core` | `libs/core/config` | ConfigLoader (548L), PathResolver (748L) |
+| `@overture/discovery-core` | `libs/core/discovery` | DiscoveryService (563L), WSL2Detector, BinaryDetector |
+| `@overture/sync-core` | `libs/core/sync` | SyncEngine (1299L), McpSyncService (554L), BackupService |
+| `@overture/plugin-core` | `libs/core/plugin` | PluginDetector (425L), Installer (387L), Exporter (424L) |
+| `@overture/diagnostics-core` | `libs/core/diagnostics` | 5 checkers: agents, clients, config-repo, mcp, skills |
+| `@overture/agent-core` | `libs/core/agent` | AgentSyncService |
+| `@overture/skill` | `libs/core/skill` | SkillDiscovery, SkillSyncService |
+| `@overture/client-adapters` | `libs/adapters/client-adapters` | 3 adapters + registry + factory + BaseClientAdapter |
+| `@overture/adapters-infrastructure` | `libs/adapters/infrastructure` | Node.js FilesystemAdapter, ProcessAdapter, OutputAdapter |
+| `@overture/ports-filesystem` | `libs/ports/filesystem` | FilesystemPort interface |
+| `@overture/ports-process` | `libs/ports/process` | ProcessPort interface |
+| `@overture/ports-output` | `libs/ports/output` | OutputPort interface |
+| `@overture/utils` | `libs/shared/utils` | error-handler (787L), validation-formatter (404L), 12 more |
+| `@overture/testing` | `libs/shared/testing` | builders, fixtures, mocks; config.builder.ts (441L) |
 
-- `binary-detector.ts` - Detect installed AI clients and versions
-- `config-loader.ts` - Load and merge user/project configs
-- `validator.ts` - Validate configuration schema
-- `backup-manager.ts` - Backup/restore configs
+## Where to Look
 
-**Core** (`apps/cli/src/core/`)
+| Task | Location |
+| --- | --- |
+| Add a CLI command | `apps/cli/src/cli/commands/` + register in `apps/cli/src/cli/index.ts` |
+| Change DI wiring | `apps/cli/src/composition-root.ts` (ONLY infra instantiation point) |
+| Modify sync behavior | `libs/core/sync/src/lib/sync-engine.ts` (1299L) |
+| Add a diagnostic check | `libs/core/diagnostics/src/lib/checkers/` |
+| Add/change config types | `libs/domain/config-types/src/lib/` |
+| Add/change Zod schemas | `libs/domain/config-schema/src/lib/config-schema.ts` |
+| Add a client adapter | `libs/adapters/client-adapters/src/lib/adapters/` |
+| Change path resolution | `libs/core/config/src/lib/path-resolver.ts` |
+| Add error type | `libs/domain/errors/src/lib/` |
+| Add test helper/mock | `libs/shared/testing/src/lib/` |
+| Add a utility | `libs/shared/utils/src/lib/` |
+| Format output | `libs/shared/formatters/src/lib/formatters/` |
 
-- `generator.ts` - Generate .mcp.json and CLAUDE.md files
-- `sync-engine.ts` - Multi-client sync orchestration
-- `client-adapters/` - Platform-specific adapters (7 clients)
+## Conventions
 
-**Domain** (`apps/cli/src/domain/`)
+### ESM (Pure ESM Project)
 
-- `config.types.ts` - TypeScript configuration types
-- `schemas.ts` - Zod validation schemas
-- `constants.ts` - Project constants
+- All imports use `.js` extension (even when importing `.ts` files)
+- `import { foo } from './utils.js'` — always `.js`
+- No `require()` anywhere
+- `__dirname` equivalent: `const __dirname = dirname(fileURLToPath(import.meta.url))`
 
-## Development Workflow
+### TypeScript Strict
 
-### Prerequisites
+- `noUnusedLocals`, `noImplicitReturns`, `noImplicitOverride` all enabled
+- **NEVER** use `as any`, `@ts-ignore`, or `@ts-expect-error`
+- Exception: `// eslint-disable-next-line security/detect-object-injection` when index is a validated `Platform` type
 
-- Node.js 20+
-- npm 10+
-- Nx CLI (installed globally or via npx)
+### Testing (Vitest)
 
-### Common Commands
+- `globals: true` → no need to import `describe`, `it`, `expect`, `beforeEach`, `vi`
+- `environment: 'node'`, v8 coverage provider
+- Tests co-located with source: `foo.ts` → `foo.spec.ts`
+- Use `@overture/testing` builders/fixtures for config objects — never construct them inline
+- Mock all filesystem/process operations — no real I/O in unit tests
+
+### Diagnostic Pattern
+
+- Diagnostic checkers **never throw** — always return results with error messages
+- Return type: `DiagnosticResult[]` or similar typed result
+- Pattern: collect errors into array, return at end
+
+### Dependency Injection
+
+- All services use constructor injection
+- Dependencies flow: `composition-root.ts` → commands → services → ports
+- Never instantiate `Node*Adapter` classes outside `composition-root.ts`
+
+## Anti-Patterns (NEVER do these)
+
+- **Import `node:*` in `libs/core/` or `libs/domain/`** — use ports interfaces instead
+- **Import `@overture/adapters-infrastructure` in `libs/core/` or `libs/domain/`**
+- **Use relative paths across package boundaries** — use `@overture/*` aliases
+- **Suppress TypeScript errors** — fix the type, don't hide it
+- **Throw inside diagnostic checkers** — always return results
+- **Skip `.js` extension on relative imports** — ESM requires it
+- **Instantiate adapters outside composition-root.ts**
+
+## Directory Structure
+
+```
+apps/
+├── cli/src/
+│   ├── cli/commands/     # 10 commands: init, sync, validate, doctor, mcp, plugin, user, audit, backup, skill
+│   ├── cli/index.ts      # createProgram() — registers all commands
+│   ├── lib/              # option-parser.ts, config-loader.ts, formatters/, validators/
+│   ├── core/             # process-lock.ts (prevents concurrent runs)
+│   ├── test-utils/       # app-dependencies.mock.ts (373L), test-fixtures.ts (303L)
+│   ├── composition-root.ts  # DI wiring (307L) — ONLY infra instantiation point
+│   └── main.ts           # CLI entry point
+└── cli-e2e/              # End-to-end tests
+
+libs/
+├── domain/               # Types + schemas — no Node.js deps
+│   ├── config-types/     # 15 TypeScript interface files
+│   ├── config-schema/    # Zod schemas + marketplace registry
+│   ├── diagnostics-types/ # Diagnostic result types
+│   └── errors/           # OvertureError hierarchy + exit codes
+├── ports/                # Pure interfaces
+│   ├── filesystem/       # FilesystemPort
+│   ├── process/          # ProcessPort
+│   └── output/           # OutputPort
+├── adapters/             # Node.js implementations
+│   ├── client-adapters/  # 3 adapters (claude-code, copilot-cli, opencode) + registry + factory
+│   └── infrastructure/   # NodeFilesystemAdapter, NodeProcessAdapter, etc.
+├── core/                 # Business logic
+│   ├── sync/             # SyncEngine (1299L), McpSyncService, BackupService
+│   ├── config/           # ConfigLoader (548L), PathResolver (748L)
+│   ├── discovery/        # DiscoveryService, BinaryDetector, WSL2Detector
+│   ├── diagnostics/      # 5 checkers (agents, clients, config-repo, mcp, skills)
+│   ├── plugin/           # PluginDetector, Installer, Exporter
+│   ├── agent/            # AgentSyncService
+│   └── skill/            # SkillDiscovery, SkillSyncService
+└── shared/               # Cross-cutting
+    ├── utils/            # error-handler (787L), validation-formatter, 12 more
+    ├── formatters/       # sync-formatter (601L), config-repo-formatter, 11 more
+    ├── testing/          # builders, fixtures, mocks
+    └── cli-utils/        # verbose-mode.ts
+```
+
+## CLI Commands
+
+| Command | File | Description |
+| --- | --- | --- |
+| `overture init` | `init.ts` | Initialize `.overture/config.yaml` |
+| `overture sync` | `sync.ts` | Sync MCPs + agents + skills to all clients |
+| `overture validate` | `validate.ts` | Validate config files |
+| `overture doctor` | `doctor.ts` | System diagnostics |
+| `overture mcp` | `mcp-commands.ts` | MCP server management |
+| `overture plugin` | `plugin-commands.ts` | Plugin management |
+| `overture user` | `user-commands.ts` | User global config management |
+| `overture audit` | `audit-commands.ts` | Find unmanaged MCPs |
+| `overture backup` | `backup-commands.ts` | Backup/restore configs |
+| `overture skill` | `skill-commands.ts` | Skill management |
+
+## Development Commands
+
+**Always use `nx` commands, never run underlying tools directly.**
 
 ```bash
-# Install dependencies
+# Install
 npm install
 
-# Run all tests
+# Test
 nx test @overture/cli
-
-# Run tests in watch mode
 nx test @overture/cli --watch
-
-# Run tests with coverage
 nx test @overture/cli --coverage
 
-# Build the CLI
-nx build @overture/cli
+# Lint + format (must pass before commit)
+nx run-many -t lint --all
+npx prettier --check .
+npx prettier --write .
 
-# Run the CLI locally
+# Build
+nx build @overture/cli
 node dist/apps/cli/main.js --help
 
-# Lint code
-nx lint @overture/cli
-
-# Show workspace structure
-nx graph
+# Nx utilities
+nx graph                    # visualize dependency graph
+nx reset                    # clear cache
+npx tsc --noEmit            # type check without build
 ```
 
-### Testing Strategy
+## CI Pipeline
 
-**Test Framework:** Vitest with TypeScript support
+`.github/workflows/ci.yml` runs two jobs:
+1. **quality**: `nx run-many -t lint --all` + `prettier --check .`
+2. **test** (requires quality): `nx test @overture/cli` on Node.js 20
 
-- **Total Tests:** 384+ passing
-- **Coverage:** 83%+ (branches, functions, lines)
-- **Test Files:** Located alongside source files (\*.spec.ts)
+## Git Workflow
 
-**Test Categories:**
+- Default branch: `main`
+- Feature branches: `feat/*`, `fix/*`, `docs/*`, `refactor/*`, `test/*`
+- Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `build:`, `chore:`
+- **Pull `main` before starting work. Work on a branch. Create a PR.**
 
-1. **Unit Tests** - Individual functions and classes
-2. **Integration Tests** - Service interactions
-3. **Command Tests** - CLI command execution
-4. **Generator Tests** - Config and documentation generation
-5. **Validation Tests** - Schema and MCP validation
+## Notes
 
-**Key Test Patterns:**
-
-- Use `vi.mock()` for external dependencies (Vitest)
-- Test both success and error paths
-- Validate generated outputs (JSON, Markdown)
-- Mock file system operations
-- Test platform-specific behavior
-
-### Code Style
-
-**Conventions:**
-
-- Use descriptive variable names
-- Prefer `async/await` over promises
-- Use TypeScript strict mode
-- Validate inputs with Zod schemas
-- Handle errors gracefully with user-friendly messages
-
-**File Organization:**
-
-- One class/major function per file
-- Co-locate tests with source (`*.spec.ts`)
-- Group related functionality in directories
-- Use barrel exports (`index.ts`) sparingly
-
-### Git Workflow
-
-**Branch Strategy:**
-
-- `main` - Production-ready code
-- `feat/*` - New features
-- `fix/*` - Bug fixes
-- `docs/*` - Documentation updates
-
-**Commit Conventions:**
-
-```
-feat: add new feature
-fix: resolve bug
-docs: update documentation
-refactor: restructure code
-test: add/update tests
-build: build system changes
-chore: maintenance tasks
-```
-
-**Before Committing:**
-
-1. Run linter: `nx run-many -t lint --all`
-2. Run formatter: `npx prettier --write .`
-3. Run tests: `nx test @overture/cli`
-4. Run build: `nx build @overture/cli`
-5. Review changes: `git diff`
-6. Write descriptive commit message with body
-
-## Key Configuration Patterns
-
-### User Global Config (`~/.config/overture/config.yaml`)
-
-```yaml
-version: '1.0'
-
-mcp:
-  filesystem:
-    command: 'npx'
-    args: ['-y', '@modelcontextprotocol/server-filesystem', '${HOME}']
-
-  memory:
-    command: 'npx'
-    args: ['-y', 'mcp-server-memory']
-
-  github:
-    command: 'mcp-server-github'
-    env:
-      GITHUB_TOKEN: '${GITHUB_TOKEN}'
-```
-
-### Project Config (`.overture/config.yaml`)
-
-```yaml
-version: '1.0'
-
-project:
-  name: my-project
-  type: python-backend
-
-mcp:
-  python-repl:
-    command: 'uvx'
-    args: ['mcp-server-python-repl']
-
-  ruff:
-    command: 'uvx'
-    args: ['mcp-server-ruff']
-```
-
-### Generated Outputs
-
-**`.mcp.json`** - Claude Code project MCP configuration
-**`~/.claude.json`** - Claude Code user MCP configuration
-**`.github/mcp.json`** - GitHub Copilot CLI project MCP configuration
-**`~/.config/github-copilot/mcp.json`** - Copilot CLI user MCP configuration
-**`opencode.json`** - OpenCode project MCP configuration
-**`~/.config/opencode/opencode.json`** - OpenCode user MCP configuration
-**`CLAUDE.md`** - Project guidance with plugin→MCP mappings
-
-All configs generated from single `config.yaml` source of truth (3 clients).
-
-**Note:** Both `.yaml` and `.yml` extensions are supported, with `.yaml` as the preferred extension. Using `.yml` will show a deprecation warning.
-
-## Important Notes
-
-### Always Use Nx Commands
-
-```bash
-# ✅ Correct
-nx test @overture/cli
-nx build @overture/cli
-
-# ❌ Wrong
-npm test
-npm run build
-vitest
-```
-
-### Nx Dependency Updates
-
-Always use `nx migrate` for Nx package updates:
-
-```bash
-nx migrate latest
-npm install
-nx migrate --run-migrations
-rm migrations.json
-```
-
-### Environment Variables
-
-The CLI supports environment variable expansion in config files:
-
-```yaml
-env:
-  GITHUB_TOKEN: '${GITHUB_TOKEN}' # Required, fails if not set
-  DATABASE_URL: '${DATABASE_URL:-postgresql://localhost:5432/dev}' # With default
-```
-
-### Platform Detection
-
-The binary detector service automatically detects installed clients:
-
-- **CLI Detection:** Uses `which`/`where` commands
-- **GUI Detection:** Checks platform-specific application paths
-- **Version Extraction:** Runs `--version` flags with 5-second timeout
-- **Config Validation:** Verifies JSON syntax
-
-## Troubleshooting
-
-### Common Issues
-
-**Tests failing:**
-
-- Ensure all dependencies installed: `npm install`
-- Clear Nx cache: `nx reset`
-- Check for TypeScript errors: `npx tsc --noEmit`
-
-**Build failing:**
-
-- Clear dist directory: `rm -rf dist/`
-- Rebuild: `nx build @overture/cli`
-
-**Binary detection not working:**
-
-- Check PATH environment variable
-- Verify client is actually installed
-- Try with `skipBinaryDetection: true` in config
-
-## Documentation
-
-- **User Guide:** `docs/user-guide.md` - Comprehensive how-to
-- **Quick Start:** `docs/QUICKSTART.md` - 5-minute setup
-- **Examples:** `docs/examples.md` - Real-world scenarios
-- **Schema:** `docs/overture-schema.md` - Configuration reference
-- **Purpose:** `docs/PURPOSE.md` - Vision and roadmap
-
-## Related Projects
-
-- **Claude Code Workflows** (wshobson/agents) - Plugin marketplace
-- **Claude Code Flow** (ruvnet/claude-code-flow) - Multi-agent execution
-- **CCMem** (adestefa/ccmem) - Persistent memory MCP
-
-See `docs/related-projects.md` for detailed analysis.
-
----
+- `apps/cli/src/cli/commands/doctor.ts.backup` — leftover file, ignore
+- Version string lives in `apps/cli/src/cli/index.ts` as `CLI_VERSION`
+- Config supports both `.yaml` and `.yml` extensions; `.yaml` preferred; `.yml` shows deprecation warning
+- Environment variable expansion: `${VAR}` (required) and `${VAR:-default}` (with fallback)
+- WSL2 detection handles path translation between Windows/Linux file systems
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,42 +25,42 @@ apps/cli/          CLI commands + DI composition root
 
 Use these aliases (defined in `tsconfig.base.json`) — never use relative paths across package boundaries.
 
-| Alias | Package | Key Contents |
-| --- | --- | --- |
-| `@overture/config-types` | `libs/domain/config-types` | 15 type files: adapter, agent, base, client, config, discovery, import, mcp, plugin, skill, sync, utility, validation types |
-| `@overture/config-schema` | `libs/domain/config-schema` | Zod schemas (434L), marketplace registry (349L) |
-| `@overture/errors` | `libs/domain/errors` | OvertureError hierarchy + exit codes |
-| `@overture/config-core` | `libs/core/config` | ConfigLoader (548L), PathResolver (748L) |
-| `@overture/discovery-core` | `libs/core/discovery` | DiscoveryService (563L), WSL2Detector, BinaryDetector |
-| `@overture/sync-core` | `libs/core/sync` | SyncEngine (1299L), McpSyncService (554L), BackupService |
-| `@overture/plugin-core` | `libs/core/plugin` | PluginDetector (425L), Installer (387L), Exporter (424L) |
-| `@overture/diagnostics-core` | `libs/core/diagnostics` | 5 checkers: agents, clients, config-repo, mcp, skills |
-| `@overture/agent-core` | `libs/core/agent` | AgentSyncService |
-| `@overture/skill` | `libs/core/skill` | SkillDiscovery, SkillSyncService |
-| `@overture/client-adapters` | `libs/adapters/client-adapters` | 3 adapters + registry + factory + BaseClientAdapter |
-| `@overture/adapters-infrastructure` | `libs/adapters/infrastructure` | Node.js FilesystemAdapter, ProcessAdapter, OutputAdapter |
-| `@overture/ports-filesystem` | `libs/ports/filesystem` | FilesystemPort interface |
-| `@overture/ports-process` | `libs/ports/process` | ProcessPort interface |
-| `@overture/ports-output` | `libs/ports/output` | OutputPort interface |
-| `@overture/utils` | `libs/shared/utils` | error-handler (787L), validation-formatter (404L), 12 more |
-| `@overture/testing` | `libs/shared/testing` | builders, fixtures, mocks; config.builder.ts (441L) |
+| Alias                               | Package                         | Key Contents                                                                                                                |
+| ----------------------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `@overture/config-types`            | `libs/domain/config-types`      | 15 type files: adapter, agent, base, client, config, discovery, import, mcp, plugin, skill, sync, utility, validation types |
+| `@overture/config-schema`           | `libs/domain/config-schema`     | Zod schemas (434L), marketplace registry (349L)                                                                             |
+| `@overture/errors`                  | `libs/domain/errors`            | OvertureError hierarchy + exit codes                                                                                        |
+| `@overture/config-core`             | `libs/core/config`              | ConfigLoader (548L), PathResolver (748L)                                                                                    |
+| `@overture/discovery-core`          | `libs/core/discovery`           | DiscoveryService (563L), WSL2Detector, BinaryDetector                                                                       |
+| `@overture/sync-core`               | `libs/core/sync`                | SyncEngine (1299L), McpSyncService (554L), BackupService                                                                    |
+| `@overture/plugin-core`             | `libs/core/plugin`              | PluginDetector (425L), Installer (387L), Exporter (424L)                                                                    |
+| `@overture/diagnostics-core`        | `libs/core/diagnostics`         | 5 checkers: agents, clients, config-repo, mcp, skills                                                                       |
+| `@overture/agent-core`              | `libs/core/agent`               | AgentSyncService                                                                                                            |
+| `@overture/skill`                   | `libs/core/skill`               | SkillDiscovery, SkillSyncService                                                                                            |
+| `@overture/client-adapters`         | `libs/adapters/client-adapters` | 3 adapters + registry + factory + BaseClientAdapter                                                                         |
+| `@overture/adapters-infrastructure` | `libs/adapters/infrastructure`  | Node.js FilesystemAdapter, ProcessAdapter, OutputAdapter                                                                    |
+| `@overture/ports-filesystem`        | `libs/ports/filesystem`         | FilesystemPort interface                                                                                                    |
+| `@overture/ports-process`           | `libs/ports/process`            | ProcessPort interface                                                                                                       |
+| `@overture/ports-output`            | `libs/ports/output`             | OutputPort interface                                                                                                        |
+| `@overture/utils`                   | `libs/shared/utils`             | error-handler (787L), validation-formatter (404L), 12 more                                                                  |
+| `@overture/testing`                 | `libs/shared/testing`           | builders, fixtures, mocks; config.builder.ts (441L)                                                                         |
 
 ## Where to Look
 
-| Task | Location |
-| --- | --- |
-| Add a CLI command | `apps/cli/src/cli/commands/` + register in `apps/cli/src/cli/index.ts` |
-| Change DI wiring | `apps/cli/src/composition-root.ts` (ONLY infra instantiation point) |
-| Modify sync behavior | `libs/core/sync/src/lib/sync-engine.ts` (1299L) |
-| Add a diagnostic check | `libs/core/diagnostics/src/lib/checkers/` |
-| Add/change config types | `libs/domain/config-types/src/lib/` |
-| Add/change Zod schemas | `libs/domain/config-schema/src/lib/config-schema.ts` |
-| Add a client adapter | `libs/adapters/client-adapters/src/lib/adapters/` |
-| Change path resolution | `libs/core/config/src/lib/path-resolver.ts` |
-| Add error type | `libs/domain/errors/src/lib/` |
-| Add test helper/mock | `libs/shared/testing/src/lib/` |
-| Add a utility | `libs/shared/utils/src/lib/` |
-| Format output | `libs/shared/formatters/src/lib/formatters/` |
+| Task                    | Location                                                               |
+| ----------------------- | ---------------------------------------------------------------------- |
+| Add a CLI command       | `apps/cli/src/cli/commands/` + register in `apps/cli/src/cli/index.ts` |
+| Change DI wiring        | `apps/cli/src/composition-root.ts` (ONLY infra instantiation point)    |
+| Modify sync behavior    | `libs/core/sync/src/lib/sync-engine.ts` (1299L)                        |
+| Add a diagnostic check  | `libs/core/diagnostics/src/lib/checkers/`                              |
+| Add/change config types | `libs/domain/config-types/src/lib/`                                    |
+| Add/change Zod schemas  | `libs/domain/config-schema/src/lib/config-schema.ts`                   |
+| Add a client adapter    | `libs/adapters/client-adapters/src/lib/adapters/`                      |
+| Change path resolution  | `libs/core/config/src/lib/path-resolver.ts`                            |
+| Add error type          | `libs/domain/errors/src/lib/`                                          |
+| Add test helper/mock    | `libs/shared/testing/src/lib/`                                         |
+| Add a utility           | `libs/shared/utils/src/lib/`                                           |
+| Format output           | `libs/shared/formatters/src/lib/formatters/`                           |
 
 ## Conventions
 
@@ -151,18 +151,18 @@ libs/
 
 ## CLI Commands
 
-| Command | File | Description |
-| --- | --- | --- |
-| `overture init` | `init.ts` | Initialize `.overture/config.yaml` |
-| `overture sync` | `sync.ts` | Sync MCPs + agents + skills to all clients |
-| `overture validate` | `validate.ts` | Validate config files |
-| `overture doctor` | `doctor.ts` | System diagnostics |
-| `overture mcp` | `mcp-commands.ts` | MCP server management |
-| `overture plugin` | `plugin-commands.ts` | Plugin management |
-| `overture user` | `user-commands.ts` | User global config management |
-| `overture audit` | `audit-commands.ts` | Find unmanaged MCPs |
-| `overture backup` | `backup-commands.ts` | Backup/restore configs |
-| `overture skill` | `skill-commands.ts` | Skill management |
+| Command             | File                 | Description                                |
+| ------------------- | -------------------- | ------------------------------------------ |
+| `overture init`     | `init.ts`            | Initialize `.overture/config.yaml`         |
+| `overture sync`     | `sync.ts`            | Sync MCPs + agents + skills to all clients |
+| `overture validate` | `validate.ts`        | Validate config files                      |
+| `overture doctor`   | `doctor.ts`          | System diagnostics                         |
+| `overture mcp`      | `mcp-commands.ts`    | MCP server management                      |
+| `overture plugin`   | `plugin-commands.ts` | Plugin management                          |
+| `overture user`     | `user-commands.ts`   | User global config management              |
+| `overture audit`    | `audit-commands.ts`  | Find unmanaged MCPs                        |
+| `overture backup`   | `backup-commands.ts` | Backup/restore configs                     |
+| `overture skill`    | `skill-commands.ts`  | Skill management                           |
 
 ## Development Commands
 
@@ -195,6 +195,7 @@ npx tsc --noEmit            # type check without build
 ## CI Pipeline
 
 `.github/workflows/ci.yml` runs two jobs:
+
 1. **quality**: `nx run-many -t lint --all` + `prettier --check .`
 2. **test** (requires quality): `nx test @overture/cli` on Node.js 20
 
@@ -219,6 +220,7 @@ nx test @overture/cli
 ```
 
 All three must pass. Do not open a PR if any step fails.
+
 ## Notes
 
 - `apps/cli/src/cli/commands/doctor.ts.backup` — leftover file, ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,20 @@ npx tsc --noEmit            # type check without build
 - Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `build:`, `chore:`
 - **Pull `main` before starting work. Work on a branch. Create a PR.**
 
+### Pre-PR Checklist (REQUIRED — must pass before opening a PR)
+
+```bash
+# 1. Format
+npx prettier --write .
+
+# 2. Lint
+nx run-many -t lint --all
+
+# 3. Test
+nx test @overture/cli
+```
+
+All three must pass. Do not open a PR if any step fails.
 ## Notes
 
 - `apps/cli/src/cli/commands/doctor.ts.backup` — leftover file, ignore

--- a/apps/cli/src/AGENTS.md
+++ b/apps/cli/src/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md — apps/cli/src
+
+CLI application root: composition root (DI wiring), CLI bootstrap, entry point, and shared app utilities.
+
+## This Directory
+
+```
+apps/cli/src/
+├── composition-root.ts   # DI wiring (307L) — ONLY place where Node adapters are instantiated
+├── main.ts               # CLI entry point — calls createProgram(), handleError exported for tests
+├── cli/
+│   ├── index.ts          # createProgram() — registers all commands, CLI_VERSION constant
+│   └── commands/         # 10 command files (see commands/AGENTS.md)
+├── lib/
+│   ├── option-parser.ts  # Commander.js option parsing helpers
+│   ├── config-loader.ts  # CLI-layer config loading wrapper
+│   ├── formatters/       # Output formatters for CLI display
+│   └── validators/       # Input validators for CLI args
+├── core/
+│   └── process-lock.ts   # Prevents concurrent CLI runs via lock file
+└── test-utils/
+    ├── app-dependencies.mock.ts  # 373L — mock AppDependencies for unit tests
+    └── test-fixtures.ts          # 303L — shared test fixtures
+```
+
+## Composition Root (CRITICAL)
+
+`composition-root.ts` is the **only** file in the entire codebase allowed to import from `@overture/adapters-infrastructure`. It wires all concrete implementations to their port interfaces and returns an `AppDependencies` object consumed by commands.
+
+```typescript
+// Pattern in composition-root.ts:
+const filesystem = new NodeFilesystemAdapter();
+const process = new NodeProcessAdapter();
+const output = new NodeOutputAdapter();
+
+// Services are constructed with ports, never with concrete adapters
+const configLoader = new ConfigLoader(filesystem, process);
+const syncEngine = new SyncEngine(configLoader, filesystem, output, ...);
+```
+
+**Never add infrastructure imports anywhere else.** If a service needs filesystem access, it must accept `FilesystemPort` via constructor injection.
+
+## Adding a New Command
+
+1. Create `apps/cli/src/cli/commands/my-command.ts`
+2. Export a `registerMyCommand(program: Command, deps: AppDependencies)` function
+3. Import and call it in `apps/cli/src/cli/index.ts` inside `createProgram()`
+4. Wire any new services it needs in `composition-root.ts`
+
+## AppDependencies Interface
+
+The `AppDependencies` type (defined near `composition-root.ts`) carries all service instances. Commands receive it as a parameter — never construct services inside command handlers.
+
+## Test Patterns
+
+- Unit tests use `app-dependencies.mock.ts` to get a fully mocked `AppDependencies`
+- Mock all port calls with `vi.fn()` — no real I/O
+- Use `test-fixtures.ts` for pre-built config objects

--- a/apps/cli/src/cli/commands/AGENTS.md
+++ b/apps/cli/src/cli/commands/AGENTS.md
@@ -4,18 +4,18 @@ All 10 CLI command handlers. Each file registers subcommands onto Commander.js `
 
 ## Command Files
 
-| File | Command | Key Behavior |
-| --- | --- | --- |
-| `init.ts` | `overture init` | Scaffold `.overture/config.yaml` in cwd |
-| `sync.ts` | `overture sync` | Run full sync: MCPs + agents + skills to all clients |
-| `validate.ts` | `overture validate` | Validate config YAML against Zod schema |
-| `doctor.ts` | `overture doctor` | Run all 5 diagnostic checkers, display results |
-| `mcp-commands.ts` | `overture mcp` | MCP server add/remove/list |
-| `plugin-commands.ts` | `overture plugin` | Claude Code plugin install/list/export |
-| `user-commands.ts` | `overture user` | User global config management |
-| `audit-commands.ts` | `overture audit` | Scan client configs for unmanaged MCPs |
-| `backup-commands.ts` | `overture backup` | Backup/restore client configs |
-| `skill-commands.ts` | `overture skill` | Agent skill sync/list/validate |
+| File                 | Command             | Key Behavior                                         |
+| -------------------- | ------------------- | ---------------------------------------------------- |
+| `init.ts`            | `overture init`     | Scaffold `.overture/config.yaml` in cwd              |
+| `sync.ts`            | `overture sync`     | Run full sync: MCPs + agents + skills to all clients |
+| `validate.ts`        | `overture validate` | Validate config YAML against Zod schema              |
+| `doctor.ts`          | `overture doctor`   | Run all 5 diagnostic checkers, display results       |
+| `mcp-commands.ts`    | `overture mcp`      | MCP server add/remove/list                           |
+| `plugin-commands.ts` | `overture plugin`   | Claude Code plugin install/list/export               |
+| `user-commands.ts`   | `overture user`     | User global config management                        |
+| `audit-commands.ts`  | `overture audit`    | Scan client configs for unmanaged MCPs               |
+| `backup-commands.ts` | `overture backup`   | Backup/restore client configs                        |
+| `skill-commands.ts`  | `overture skill`    | Agent skill sync/list/validate                       |
 
 `doctor.ts.backup` — leftover file, ignore entirely.
 
@@ -23,7 +23,10 @@ All 10 CLI command handlers. Each file registers subcommands onto Commander.js `
 
 ```typescript
 // Every command follows this pattern:
-export function registerMyCommand(program: Command, deps: AppDependencies): void {
+export function registerMyCommand(
+  program: Command,
+  deps: AppDependencies,
+): void {
   program
     .command('my-command')
     .description('...')

--- a/apps/cli/src/cli/commands/AGENTS.md
+++ b/apps/cli/src/cli/commands/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md — apps/cli/src/cli/commands
+
+All 10 CLI command handlers. Each file registers subcommands onto Commander.js `program`.
+
+## Command Files
+
+| File | Command | Key Behavior |
+| --- | --- | --- |
+| `init.ts` | `overture init` | Scaffold `.overture/config.yaml` in cwd |
+| `sync.ts` | `overture sync` | Run full sync: MCPs + agents + skills to all clients |
+| `validate.ts` | `overture validate` | Validate config YAML against Zod schema |
+| `doctor.ts` | `overture doctor` | Run all 5 diagnostic checkers, display results |
+| `mcp-commands.ts` | `overture mcp` | MCP server add/remove/list |
+| `plugin-commands.ts` | `overture plugin` | Claude Code plugin install/list/export |
+| `user-commands.ts` | `overture user` | User global config management |
+| `audit-commands.ts` | `overture audit` | Scan client configs for unmanaged MCPs |
+| `backup-commands.ts` | `overture backup` | Backup/restore client configs |
+| `skill-commands.ts` | `overture skill` | Agent skill sync/list/validate |
+
+`doctor.ts.backup` — leftover file, ignore entirely.
+
+## Command Pattern
+
+```typescript
+// Every command follows this pattern:
+export function registerMyCommand(program: Command, deps: AppDependencies): void {
+  program
+    .command('my-command')
+    .description('...')
+    .option('--flag', 'description')
+    .action(async (options) => {
+      try {
+        const result = await deps.myService.doThing(options);
+        deps.output.info(formatResult(result));
+      } catch (error) {
+        handleError(error); // from main.ts — exits with appropriate code
+      }
+    });
+}
+```
+
+## Sync Command Options
+
+`sync.ts` handles: `--skip-agents`, `--skip-skills`, `--skip-plugins`, `--dry-run`, `--detail`. It delegates to `SyncEngine` via `deps.syncEngine.sync(options)`.
+
+## Doctor Command Pattern
+
+`doctor.ts` calls each of the 5 checkers in sequence, collects `DiagnosticResult[]`, and formats output via `@overture/utils` formatters. Checkers never throw — always return results with status.
+
+## Error Handling
+
+All commands wrap their action in `try/catch` and call `handleError(error)`. The `handleError` function (exported from `main.ts`) maps `OvertureError` instances to appropriate exit codes and user-friendly messages.
+
+## Testing Commands
+
+- Mock `AppDependencies` using `../../test-utils/app-dependencies.mock.ts`
+- Use Commander.js `.parseAsync(['node', 'overture', 'command', '--flag'])` pattern
+- Assert on `deps.output.info` / `deps.output.error` mock calls

--- a/libs/adapters/client-adapters/src/lib/AGENTS.md
+++ b/libs/adapters/client-adapters/src/lib/AGENTS.md
@@ -1,0 +1,71 @@
+# AGENTS.md — libs/adapters/client-adapters/src/lib
+
+Three AI client adapters + registry + factory. Translates Overture config to each client's native format.
+
+## Files
+
+```
+client-adapters/src/lib/
+├── adapters/
+│   ├── claude-code.adapter.ts   # Generates .mcp.json and ~/.claude.json
+│   ├── copilot-cli.adapter.ts   # Generates .github/mcp.json
+│   └── opencode.adapter.ts      # Generates opencode.json
+├── client-adapter.interface.ts  # 389L — ClientAdapter interface + BaseClientAdapter abstract class
+├── adapter-registry.ts          # AdapterRegistry — maps ClientName → adapter instance
+├── adapter-factory.ts           # AdapterFactory — constructs adapters with deps
+└── skill-paths.ts               # Skill path resolution per client
+```
+
+## ClientAdapter Interface
+
+```typescript
+interface ClientAdapter {
+  readonly clientName: ClientName;
+  
+  // Check if this adapter should handle MCP for the given server config
+  shouldSyncMcp(serverConfig: McpServerConfig): boolean;
+  
+  // Transform Overture MCP config → client-specific server config object
+  buildServerConfig(name: string, serverConfig: McpServerConfig): Record<string, unknown>;
+  
+  // Write the final config file(s) for this client
+  writeConfig(config: OvertureConfig, projectDir: string): Promise<void>;
+  
+  // Read existing client config (for merge strategy)
+  readExistingConfig(projectDir: string): Promise<Record<string, unknown> | null>;
+}
+```
+
+`BaseClientAdapter` (abstract class in `client-adapter.interface.ts`) provides default implementations of `shouldSyncMcp` (checks `clients.include`/`clients.exclude`) and common helpers.
+
+## Adding a New Client Adapter
+
+1. Create `adapters/new-client.adapter.ts` extending `BaseClientAdapter`
+2. Implement `writeConfig()` and `buildServerConfig()`
+3. Add `'new-client'` to `CLIENT_NAMES` in `@overture/config-types`
+4. Register in `AdapterRegistry` and `AdapterFactory`
+5. Wire in `composition-root.ts`
+
+## Per-Client Config Locations
+
+| Client | Project Config | User Config |
+| --- | --- | --- |
+| claude-code | `.mcp.json` | `~/.claude.json` |
+| copilot-cli | `.github/mcp.json` | — |
+| opencode | `opencode.json` | `~/.config/opencode/config.json` |
+
+## shouldSyncMcp Logic
+
+```typescript
+// BaseClientAdapter default:
+shouldSyncMcp(serverConfig: McpServerConfig): boolean {
+  const { include, exclude } = serverConfig.clients ?? {};
+  if (include) return include.includes(this.clientName);
+  if (exclude) return !exclude.includes(this.clientName);
+  return true; // sync to all by default
+}
+```
+
+## skill-paths.ts
+
+Maps each `ClientName` to the filesystem path where skills/agents are stored. Used by `SkillSyncService`.

--- a/libs/adapters/client-adapters/src/lib/AGENTS.md
+++ b/libs/adapters/client-adapters/src/lib/AGENTS.md
@@ -21,18 +21,23 @@ client-adapters/src/lib/
 ```typescript
 interface ClientAdapter {
   readonly clientName: ClientName;
-  
+
   // Check if this adapter should handle MCP for the given server config
   shouldSyncMcp(serverConfig: McpServerConfig): boolean;
-  
+
   // Transform Overture MCP config → client-specific server config object
-  buildServerConfig(name: string, serverConfig: McpServerConfig): Record<string, unknown>;
-  
+  buildServerConfig(
+    name: string,
+    serverConfig: McpServerConfig,
+  ): Record<string, unknown>;
+
   // Write the final config file(s) for this client
   writeConfig(config: OvertureConfig, projectDir: string): Promise<void>;
-  
+
   // Read existing client config (for merge strategy)
-  readExistingConfig(projectDir: string): Promise<Record<string, unknown> | null>;
+  readExistingConfig(
+    projectDir: string,
+  ): Promise<Record<string, unknown> | null>;
 }
 ```
 
@@ -48,11 +53,11 @@ interface ClientAdapter {
 
 ## Per-Client Config Locations
 
-| Client | Project Config | User Config |
-| --- | --- | --- |
-| claude-code | `.mcp.json` | `~/.claude.json` |
-| copilot-cli | `.github/mcp.json` | — |
-| opencode | `opencode.json` | `~/.config/opencode/config.json` |
+| Client      | Project Config     | User Config                      |
+| ----------- | ------------------ | -------------------------------- |
+| claude-code | `.mcp.json`        | `~/.claude.json`                 |
+| copilot-cli | `.github/mcp.json` | —                                |
+| opencode    | `opencode.json`    | `~/.config/opencode/config.json` |
 
 ## shouldSyncMcp Logic
 

--- a/libs/core/config/src/lib/AGENTS.md
+++ b/libs/core/config/src/lib/AGENTS.md
@@ -27,6 +27,7 @@ class ConfigLoader {
 ```
 
 Key behaviors:
+
 - Supports both `.yaml` and `.yml` (`.yml` logs deprecation warning)
 - Expands `${VAR}` and `${VAR:-default}` environment variables
 - Throws `OvertureError` with `CONFIG_NOT_FOUND` exit code when no config found
@@ -49,6 +50,7 @@ class PathResolver {
 ```
 
 Key behaviors:
+
 - All paths computed from `process.env.HOME`, `process.cwd()` via `ProcessPort`
 - WSL2 detection: if running in WSL2 and target is Windows path, translates via `/mnt/c/...`
 - No hardcoded paths — all derived from environment

--- a/libs/core/config/src/lib/AGENTS.md
+++ b/libs/core/config/src/lib/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md — libs/core/config/src/lib
+
+Config loading and path resolution. Two large services: ConfigLoader (548L) and PathResolver (748L).
+
+## Key Files
+
+```
+config/src/lib/
+├── config-loader.ts    # 548L — loads, merges, and validates config.yaml
+├── path-resolver.ts    # 748L — resolves all platform/client-specific paths
+└── config-merger.ts    # Merges project config with user global config
+```
+
+## ConfigLoader
+
+Loads `.overture/config.yaml` (project) and `~/.config/overture/config.yaml` (user global), merges them with project taking precedence, validates against Zod schema.
+
+```typescript
+class ConfigLoader {
+  constructor(
+    private readonly filesystem: FilesystemPort,
+    private readonly process: ProcessPort,
+  ) {}
+
+  async load(projectDir: string): Promise<OvertureConfig> { ... }
+}
+```
+
+Key behaviors:
+- Supports both `.yaml` and `.yml` (`.yml` logs deprecation warning)
+- Expands `${VAR}` and `${VAR:-default}` environment variables
+- Throws `OvertureError` with `CONFIG_NOT_FOUND` exit code when no config found
+- Merges user global MCP servers with project MCPs (project wins on conflicts)
+
+## PathResolver
+
+Resolves platform-specific paths for all 3 AI clients and Overture itself. Handles WSL2 path translation (Windows ↔ Linux).
+
+```typescript
+class PathResolver {
+  constructor(private readonly process: ProcessPort) {}
+
+  getClaudeCodeAgentsDir(): string { ... }
+  getOpenCodeAgentsDir(): string { ... }
+  getCopilotAgentsDir(projectDir: string): string { ... }
+  getOvertureConfigDir(): string { ... }
+  // ... 20+ more methods
+}
+```
+
+Key behaviors:
+- All paths computed from `process.env.HOME`, `process.cwd()` via `ProcessPort`
+- WSL2 detection: if running in WSL2 and target is Windows path, translates via `/mnt/c/...`
+- No hardcoded paths — all derived from environment
+
+## Config Merge Strategy
+
+```
+User global config (~/.config/overture/config.yaml)
+  +
+Project config (.overture/config.yaml)
+  ↓
+Merged: project MCPs + user MCPs (deduplicated, project wins)
+```
+
+`sync.mergeStrategy: 'append'` vs `'replace'` controls how existing client configs are handled.
+
+## Invariants
+
+- No `node:*` imports — all I/O via ports
+- ConfigLoader never writes files (read-only)
+- PathResolver is pure computation (no I/O)

--- a/libs/core/diagnostics/src/lib/AGENTS.md
+++ b/libs/core/diagnostics/src/lib/AGENTS.md
@@ -40,6 +40,7 @@ async check(): Promise<DiagnosticResult[]> {
 ## AgentsChecker
 
 Validates that every agent has both a `.yaml` and `.md` file (paired). Checks:
+
 - YAML schema validity
 - Markdown file presence
 - Agent sync status (in-sync vs needs-update) across all 3 clients
@@ -51,6 +52,7 @@ Detects Claude Code, Copilot CLI, OpenCode installation. Returns version info an
 ## McpChecker
 
 Reads each client's MCP config files and validates:
+
 - JSON/YAML parse success
 - Required fields present
 - No duplicate server names

--- a/libs/core/diagnostics/src/lib/AGENTS.md
+++ b/libs/core/diagnostics/src/lib/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md — libs/core/diagnostics/src/lib
+
+Five diagnostic checkers for `overture doctor`. Each checker validates a specific aspect of system health.
+
+## Checkers
+
+```
+diagnostics/src/lib/
+├── checkers/
+│   ├── agents-checker.ts      # Validates agent YAML+MD pairs in agents directories
+│   ├── clients-checker.ts     # Detects installed AI clients and their versions
+│   ├── config-repo-checker.ts # Validates config repository existence and structure
+│   ├── mcp-checker.ts         # Validates MCP server configs across clients
+│   └── skills-checker.ts      # Validates skill files and sync status
+└── diagnostics-service.ts     # Orchestrates all 5 checkers, aggregates results
+```
+
+## Critical Pattern: Never Throw
+
+```typescript
+// CORRECT: collect errors, return results
+async check(): Promise<DiagnosticResult[]> {
+  const results: DiagnosticResult[] = [];
+  try {
+    const agents = await this.filesystem.readDir(agentsPath);
+    // validate...
+    results.push({ status: 'ok', message: '...' });
+  } catch (error) {
+    results.push({ status: 'error', message: formatError(error) });
+  }
+  return results;
+}
+
+// WRONG: throwing from a checker
+async check(): Promise<DiagnosticResult[]> {
+  const agents = await this.filesystem.readDir(agentsPath); // throws → breaks doctor
+}
+```
+
+## AgentsChecker
+
+Validates that every agent has both a `.yaml` and `.md` file (paired). Checks:
+- YAML schema validity
+- Markdown file presence
+- Agent sync status (in-sync vs needs-update) across all 3 clients
+
+## ClientsChecker
+
+Detects Claude Code, Copilot CLI, OpenCode installation. Returns version info and config path for each.
+
+## McpChecker
+
+Reads each client's MCP config files and validates:
+- JSON/YAML parse success
+- Required fields present
+- No duplicate server names
+
+## Adding a New Checker
+
+1. Create `checkers/my-checker.ts` implementing `check(): Promise<DiagnosticResult[]>`
+2. Constructor-inject `FilesystemPort` and any needed services
+3. Register in `DiagnosticsService` constructor and call in its `runAll()` method
+4. Wire the new checker in `composition-root.ts`
+
+## DiagnosticResult Type
+
+Defined in `@overture/config-types` (diagnostics-types). Fields: `status: 'ok' | 'warning' | 'error'`, `message: string`, optional `detail: string`.

--- a/libs/core/plugin/src/lib/AGENTS.md
+++ b/libs/core/plugin/src/lib/AGENTS.md
@@ -19,6 +19,7 @@ Scans Claude Code's plugin directories to find installed plugins. Returns list o
 ## PluginInstaller
 
 Installs plugins defined in `config.yaml` under `plugins:` section. Handles:
+
 - npm package plugins (installs via process execution)
 - Local path plugins (copies or symlinks)
 - Version conflict detection
@@ -34,7 +35,7 @@ Reads currently installed plugins and generates config YAML snippet. Used by `ov
 plugins:
   - name: my-plugin
     source: npm:@scope/my-plugin
-    version: "^1.0.0"
+    version: '^1.0.0'
 ```
 
 ## Invariants

--- a/libs/core/plugin/src/lib/AGENTS.md
+++ b/libs/core/plugin/src/lib/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md — libs/core/plugin/src/lib
+
+Claude Code plugin management: detect, install, export plugins.
+
+## Key Files
+
+```
+plugin/src/lib/
+├── plugin-detector.ts    # 425L — finds installed Claude Code plugins
+├── plugin-installer.ts   # 387L — installs plugins from config
+├── plugin-exporter.ts    # 424L — exports current plugin state to config
+└── plugin-types.ts       # Internal plugin types (see also @overture/config-types)
+```
+
+## PluginDetector
+
+Scans Claude Code's plugin directories to find installed plugins. Returns list of `DetectedPlugin` objects with name, version, path.
+
+## PluginInstaller
+
+Installs plugins defined in `config.yaml` under `plugins:` section. Handles:
+- npm package plugins (installs via process execution)
+- Local path plugins (copies or symlinks)
+- Version conflict detection
+
+## PluginExporter
+
+Reads currently installed plugins and generates config YAML snippet. Used by `overture plugin export`.
+
+## Plugin Config Shape
+
+```yaml
+# In .overture/config.yaml:
+plugins:
+  - name: my-plugin
+    source: npm:@scope/my-plugin
+    version: "^1.0.0"
+```
+
+## Invariants
+
+- All filesystem ops via `FilesystemPort`, process exec via `ProcessPort`
+- No `node:*` imports
+- PluginInstaller never modifies files outside designated plugin directory

--- a/libs/core/sync/src/lib/AGENTS.md
+++ b/libs/core/sync/src/lib/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md — libs/core/sync/src/lib
+
+The sync engine: orchestrates multi-client MCP and agent synchronization. Largest core package (23 files).
+
+## Key Files
+
+```
+sync/src/lib/
+├── sync-engine.ts              # 1299L — main orchestrator, entry point for all sync operations
+├── backup-service.ts           # Backup/restore logic for client configs
+├── config-sync-service.ts      # Config file read/write coordination
+├── sync-types.ts               # Internal sync result types
+└── services/
+    ├── mcp-sync-service.ts     # 554L — MCP server config sync per client
+    ├── plugin-sync-coordinator.ts  # Plugin installation coordination
+    └── config-sync-*.ts        # Additional config sync helpers
+```
+
+## SyncEngine (sync-engine.ts)
+
+The main entry point for `overture sync`. Coordinates:
+1. Load config (via `ConfigLoader`)
+2. Detect clients (via `DiscoveryService`)
+3. Sync MCPs to each client adapter
+4. Sync agents
+5. Sync skills
+6. Sync plugins
+
+**Method signature pattern:**
+```typescript
+class SyncEngine {
+  constructor(
+    private readonly configLoader: ConfigLoader,
+    private readonly filesystem: FilesystemPort,
+    private readonly output: OutputPort,
+    private readonly adapters: ClientAdapterRegistry,
+    // ... other services via DI
+  ) {}
+
+  async sync(options: SyncOptions): Promise<SyncResult> { ... }
+}
+```
+
+## McpSyncService (services/mcp-sync-service.ts)
+
+Handles per-client MCP config generation. For each detected client:
+1. Load existing client config
+2. Merge/append MCP entries from Overture config
+3. Write back via `FilesystemPort`
+
+Uses `ClientAdapter.buildServerConfig()` to transform MCP definitions to client-specific format.
+
+## Adding Sync Behavior
+
+- **New sync step**: Add to `SyncEngine.sync()`, create a new service class, inject via constructor
+- **New MCP field**: Update `McpSyncService` + relevant `ClientAdapter.buildServerConfig()`
+- **New client**: Add adapter in `libs/adapters/client-adapters/` and register in `AdapterRegistry`
+
+## Invariants
+
+- No `node:*` imports — all I/O via `FilesystemPort` and `ProcessPort`
+- No imports from `@overture/adapters-infrastructure`
+- Services are stateless between sync runs (fresh load each time)
+- All errors propagate as `OvertureError` instances
+
+## BackupService
+
+Creates timestamped backups of client config files before overwriting. Uses `sync.backupRetention` from config to prune old backups.

--- a/libs/core/sync/src/lib/AGENTS.md
+++ b/libs/core/sync/src/lib/AGENTS.md
@@ -19,6 +19,7 @@ sync/src/lib/
 ## SyncEngine (sync-engine.ts)
 
 The main entry point for `overture sync`. Coordinates:
+
 1. Load config (via `ConfigLoader`)
 2. Detect clients (via `DiscoveryService`)
 3. Sync MCPs to each client adapter
@@ -27,6 +28,7 @@ The main entry point for `overture sync`. Coordinates:
 6. Sync plugins
 
 **Method signature pattern:**
+
 ```typescript
 class SyncEngine {
   constructor(
@@ -44,6 +46,7 @@ class SyncEngine {
 ## McpSyncService (services/mcp-sync-service.ts)
 
 Handles per-client MCP config generation. For each detected client:
+
 1. Load existing client config
 2. Merge/append MCP entries from Overture config
 3. Write back via `FilesystemPort`

--- a/libs/domain/config-types/src/lib/AGENTS.md
+++ b/libs/domain/config-types/src/lib/AGENTS.md
@@ -4,22 +4,22 @@ All TypeScript interface definitions. 15 files, zero runtime deps — pure type 
 
 ## Files by Domain
 
-| File | Key Types |
-| --- | --- |
-| `adapter.types.ts` | `ClientAdapter`, `AdapterConfig`, `ServerConfig` |
-| `agent-types.ts` | `AgentConfig`, `AgentDefinition`, `ModelMapping` |
-| `base-types.ts` | `Platform`, `ClientName` (`'claude-code' \| 'copilot-cli' \| 'opencode'`) |
-| `client-names.ts` | `SUPPORTED_CLIENTS`, `ALL_KNOWN_CLIENTS` consts + `SupportedClientName`, `KnownClientName` types |
-| `client-types.ts` | `ClientConfig`, `ClientDetectionResult` |
-| `config.types.ts` | `OvertureConfig` (root config shape), `SyncConfig`, `ProjectConfig` |
-| `discovery.types.ts` | `DiscoveryResult`, `DetectedClient` |
-| `import.types.ts` | `ImportConfig` for config repository imports |
-| `mcp-types.ts` | `McpServerConfig`, `McpTransport`, `McpClientFilter` |
-| `plugin.types.ts` | `PluginConfig`, `DetectedPlugin` |
-| `skill.types.ts` | `SkillConfig`, `SkillDefinition` |
-| `sync-types.ts` | `SyncOptions`, `SyncResult`, `SyncStatus` |
-| `utility-types.ts` | `DeepPartial`, `Result<T>`, shared utility types |
-| `validation-types.ts` | `ValidationResult`, `ValidationError` |
+| File                  | Key Types                                                                                        |
+| --------------------- | ------------------------------------------------------------------------------------------------ |
+| `adapter.types.ts`    | `ClientAdapter`, `AdapterConfig`, `ServerConfig`                                                 |
+| `agent-types.ts`      | `AgentConfig`, `AgentDefinition`, `ModelMapping`                                                 |
+| `base-types.ts`       | `Platform`, `ClientName` (`'claude-code' \| 'copilot-cli' \| 'opencode'`)                        |
+| `client-names.ts`     | `SUPPORTED_CLIENTS`, `ALL_KNOWN_CLIENTS` consts + `SupportedClientName`, `KnownClientName` types |
+| `client-types.ts`     | `ClientConfig`, `ClientDetectionResult`                                                          |
+| `config.types.ts`     | `OvertureConfig` (root config shape), `SyncConfig`, `ProjectConfig`                              |
+| `discovery.types.ts`  | `DiscoveryResult`, `DetectedClient`                                                              |
+| `import.types.ts`     | `ImportConfig` for config repository imports                                                     |
+| `mcp-types.ts`        | `McpServerConfig`, `McpTransport`, `McpClientFilter`                                             |
+| `plugin.types.ts`     | `PluginConfig`, `DetectedPlugin`                                                                 |
+| `skill.types.ts`      | `SkillConfig`, `SkillDefinition`                                                                 |
+| `sync-types.ts`       | `SyncOptions`, `SyncResult`, `SyncStatus`                                                        |
+| `utility-types.ts`    | `DeepPartial`, `Result<T>`, shared utility types                                                 |
+| `validation-types.ts` | `ValidationResult`, `ValidationError`                                                            |
 
 ## Rules for This Package
 

--- a/libs/domain/config-types/src/lib/AGENTS.md
+++ b/libs/domain/config-types/src/lib/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — libs/domain/config-types/src/lib
+
+All TypeScript interface definitions. 15 files, zero runtime deps — pure type declarations.
+
+## Files by Domain
+
+| File | Key Types |
+| --- | --- |
+| `adapter.types.ts` | `ClientAdapter`, `AdapterConfig`, `ServerConfig` |
+| `agent-types.ts` | `AgentConfig`, `AgentDefinition`, `ModelMapping` |
+| `base-types.ts` | `Platform`, `ClientName` (`'claude-code' \| 'copilot-cli' \| 'opencode'`) |
+| `client-names.ts` | `SUPPORTED_CLIENTS`, `ALL_KNOWN_CLIENTS` consts + `SupportedClientName`, `KnownClientName` types |
+| `client-types.ts` | `ClientConfig`, `ClientDetectionResult` |
+| `config.types.ts` | `OvertureConfig` (root config shape), `SyncConfig`, `ProjectConfig` |
+| `discovery.types.ts` | `DiscoveryResult`, `DetectedClient` |
+| `import.types.ts` | `ImportConfig` for config repository imports |
+| `mcp-types.ts` | `McpServerConfig`, `McpTransport`, `McpClientFilter` |
+| `plugin.types.ts` | `PluginConfig`, `DetectedPlugin` |
+| `skill.types.ts` | `SkillConfig`, `SkillDefinition` |
+| `sync-types.ts` | `SyncOptions`, `SyncResult`, `SyncStatus` |
+| `utility-types.ts` | `DeepPartial`, `Result<T>`, shared utility types |
+| `validation-types.ts` | `ValidationResult`, `ValidationError` |
+
+## Rules for This Package
+
+- **No runtime code** — only `interface`, `type`, `enum`, and `const` declarations
+- **No imports from `node:*`** — zero Node.js dependencies
+- **No imports from other `@overture/*` packages** except `@overture/errors` for error types
+- Export everything through `index.ts`
+
+## ClientName vs SupportedClientName
+
+Two overlapping systems:
+
+```typescript
+// base-types.ts — the 3 active clients (preferred for MCP/sync logic)
+export type ClientName = 'claude-code' | 'copilot-cli' | 'opencode';
+
+// client-names.ts — const arrays (use for iteration or validation)
+export const SUPPORTED_CLIENTS = ['claude-code', 'copilot-cli', 'opencode'] as const;
+export type SupportedClientName = (typeof SUPPORTED_CLIENTS)[number];
+
+// Also includes legacy/known clients for migration warnings:
+export const ALL_KNOWN_CLIENTS = [...SUPPORTED_CLIENTS, 'claude-desktop', 'vscode', ...] as const;
+export type KnownClientName = (typeof ALL_KNOWN_CLIENTS)[number];
+```
+
+Use `ClientName` for type annotations. Use `SUPPORTED_CLIENTS` when you need to iterate over clients at runtime. Never hardcode client name strings.
+
+## McpServerConfig
+
+```typescript
+interface McpServerConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  transport?: 'stdio' | 'sse';
+  clients?: {
+    include?: ClientName[];
+    exclude?: ClientName[];
+  };
+  platforms?: {
+    include?: Platform[];
+    exclude?: Platform[];
+  };
+}
+```
+
+## Adding a New Type
+
+1. Add to the appropriate existing file (prefer extending existing types)
+2. Or create `new-thing.types.ts` if the domain is distinct
+3. Export from `index.ts`
+4. Never add implementation logic — types only

--- a/libs/shared/testing/src/lib/AGENTS.md
+++ b/libs/shared/testing/src/lib/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md — libs/shared/testing/src/lib
+
+Test infrastructure: builders, fixtures, and mocks for the entire codebase.
+
+## Structure
+
+```
+testing/src/lib/
+├── builders/
+│   └── config.builder.ts   # 441L — fluent builder for OvertureConfig test objects
+├── fixtures/
+│   └── *.fixture.ts        # Pre-built config/result objects for common test scenarios
+└── mocks/
+    ├── filesystem.mock.ts  # Mock FilesystemPort with in-memory FS
+    ├── process.mock.ts     # Mock ProcessPort (env vars, cwd)
+    └── output.mock.ts      # Mock OutputPort (captures info/error calls)
+```
+
+## Config Builder (config.builder.ts)
+
+Primary factory for test config objects. Always use this — never construct `OvertureConfig` inline.
+
+```typescript
+import { buildConfig } from '@overture/testing';
+
+// Minimal config:
+const config = buildConfig();
+
+// With customizations:
+const config = buildConfig({
+  mcp: {
+    'my-server': buildMcpServer({ command: 'my-cmd', args: ['--port', '3000'] }),
+  },
+  sync: { backup: false },
+});
+
+// With agent:
+const config = buildConfig({
+  agents: [buildAgent({ name: 'assistant', model: 'claude-3-5-sonnet' })],
+});
+```
+
+## Port Mocks
+
+```typescript
+import { createFilesystemMock, createProcessMock, createOutputMock } from '@overture/testing';
+
+const fs = createFilesystemMock({
+  '/path/to/config.yaml': 'version: "2.0"\n...',
+});
+const proc = createProcessMock({ HOME: '/home/user', cwd: '/project' });
+const output = createOutputMock();
+
+// After test:
+expect(output.info).toHaveBeenCalledWith(expect.stringContaining('Sync complete'));
+```
+
+## Fixtures
+
+Pre-built objects for common scenarios:
+
+```typescript
+import { 
+  MINIMAL_CONFIG,        // bare minimum valid OvertureConfig
+  FULL_CONFIG,           // config with all features enabled
+  CLAUDE_CODE_CLIENT,    // DetectedClient for claude-code
+  SYNC_SUCCESS_RESULT,   // SyncResult with all success statuses
+} from '@overture/testing';
+```
+
+## Rules
+
+- Always import from `@overture/testing` — never use relative paths to test helpers
+- Extend builders rather than duplicating — add new builder methods to `config.builder.ts`
+- Mocks must cover the full `FilesystemPort`/`ProcessPort`/`OutputPort` interface
+- No real I/O in `testing/` package — everything is in-memory or mocked

--- a/libs/shared/testing/src/lib/AGENTS.md
+++ b/libs/shared/testing/src/lib/AGENTS.md
@@ -29,7 +29,10 @@ const config = buildConfig();
 // With customizations:
 const config = buildConfig({
   mcp: {
-    'my-server': buildMcpServer({ command: 'my-cmd', args: ['--port', '3000'] }),
+    'my-server': buildMcpServer({
+      command: 'my-cmd',
+      args: ['--port', '3000'],
+    }),
   },
   sync: { backup: false },
 });
@@ -43,7 +46,11 @@ const config = buildConfig({
 ## Port Mocks
 
 ```typescript
-import { createFilesystemMock, createProcessMock, createOutputMock } from '@overture/testing';
+import {
+  createFilesystemMock,
+  createProcessMock,
+  createOutputMock,
+} from '@overture/testing';
 
 const fs = createFilesystemMock({
   '/path/to/config.yaml': 'version: "2.0"\n...',
@@ -52,7 +59,9 @@ const proc = createProcessMock({ HOME: '/home/user', cwd: '/project' });
 const output = createOutputMock();
 
 // After test:
-expect(output.info).toHaveBeenCalledWith(expect.stringContaining('Sync complete'));
+expect(output.info).toHaveBeenCalledWith(
+  expect.stringContaining('Sync complete'),
+);
 ```
 
 ## Fixtures
@@ -60,11 +69,11 @@ expect(output.info).toHaveBeenCalledWith(expect.stringContaining('Sync complete'
 Pre-built objects for common scenarios:
 
 ```typescript
-import { 
-  MINIMAL_CONFIG,        // bare minimum valid OvertureConfig
-  FULL_CONFIG,           // config with all features enabled
-  CLAUDE_CODE_CLIENT,    // DetectedClient for claude-code
-  SYNC_SUCCESS_RESULT,   // SyncResult with all success statuses
+import {
+  MINIMAL_CONFIG, // bare minimum valid OvertureConfig
+  FULL_CONFIG, // config with all features enabled
+  CLAUDE_CODE_CLIENT, // DetectedClient for claude-code
+  SYNC_SUCCESS_RESULT, // SyncResult with all success statuses
 } from '@overture/testing';
 ```
 

--- a/libs/shared/utils/src/lib/AGENTS.md
+++ b/libs/shared/utils/src/lib/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md — libs/shared/utils/src/lib
+
+14 cross-cutting utility modules. Used by core, adapters, and CLI layers.
+
+## Utility Files
+
+| File | Purpose |
+| --- | --- |
+| `error-handler.ts` (787L) | `handleError()`, `OvertureError` factory helpers, exit code mapping |
+| `validation-formatter.ts` (404L) | Format Zod validation errors into human-readable messages |
+| `config-resolver.ts` | Resolve config file paths with `.yaml`/`.yml` fallback |
+| `env-expander.ts` | Expand `${VAR}` and `${VAR:-default}` in config strings |
+| `file-utils.ts` | Common file operation helpers (read JSON, write YAML, etc.) |
+| `merge-utils.ts` | Deep merge helpers for config objects |
+| `platform-utils.ts` | OS detection, WSL2 detection helpers |
+| `string-utils.ts` | String normalization, slugify, case conversion |
+| `array-utils.ts` | Deduplication, diff, partition utilities |
+| `path-utils.ts` | Path normalization across platforms |
+| `logger.ts` | Lightweight logger wrapping `OutputPort` |
+| `result-utils.ts` | `Result<T, E>` pattern helpers |
+| `version-utils.ts` | Semver comparison helpers |
+| `yaml-utils.ts` | YAML parse/stringify with error handling |
+
+## error-handler.ts (Key File)
+
+Contains `handleError(error: unknown): never` — the global error handler called by all CLI commands. Maps:
+- `OvertureError` → appropriate exit code (1-99) + formatted message
+- `ZodError` → validation error display via `validation-formatter`
+- Unknown errors → exit code 1 + stack trace (in DEBUG mode)
+
+Also exports `createOvertureError(code, message, cause?)` factory.
+
+## validation-formatter.ts (Key File)
+
+Transforms Zod `ZodError` into user-friendly output:
+```
+Config validation failed:
+  • mcp.my-server.command: Required
+  • sync.mergeStrategy: Expected 'append' | 'replace', got 'merge'
+```
+
+## env-expander.ts
+
+Handles `${VAR}` expansion throughout config loading:
+- `${VAR}` — required; throws `OvertureError` if `VAR` not set
+- `${VAR:-default}` — optional with fallback; returns `default` if not set
+
+## Rules
+
+- All utils are **pure functions** or depend only on `OutputPort` (never `FilesystemPort`)
+- No state — stateless utility functions only
+- Import these from `@overture/utils`, never via relative path from other packages

--- a/libs/shared/utils/src/lib/AGENTS.md
+++ b/libs/shared/utils/src/lib/AGENTS.md
@@ -4,26 +4,27 @@
 
 ## Utility Files
 
-| File | Purpose |
-| --- | --- |
-| `error-handler.ts` (787L) | `handleError()`, `OvertureError` factory helpers, exit code mapping |
-| `validation-formatter.ts` (404L) | Format Zod validation errors into human-readable messages |
-| `config-resolver.ts` | Resolve config file paths with `.yaml`/`.yml` fallback |
-| `env-expander.ts` | Expand `${VAR}` and `${VAR:-default}` in config strings |
-| `file-utils.ts` | Common file operation helpers (read JSON, write YAML, etc.) |
-| `merge-utils.ts` | Deep merge helpers for config objects |
-| `platform-utils.ts` | OS detection, WSL2 detection helpers |
-| `string-utils.ts` | String normalization, slugify, case conversion |
-| `array-utils.ts` | Deduplication, diff, partition utilities |
-| `path-utils.ts` | Path normalization across platforms |
-| `logger.ts` | Lightweight logger wrapping `OutputPort` |
-| `result-utils.ts` | `Result<T, E>` pattern helpers |
-| `version-utils.ts` | Semver comparison helpers |
-| `yaml-utils.ts` | YAML parse/stringify with error handling |
+| File                             | Purpose                                                             |
+| -------------------------------- | ------------------------------------------------------------------- |
+| `error-handler.ts` (787L)        | `handleError()`, `OvertureError` factory helpers, exit code mapping |
+| `validation-formatter.ts` (404L) | Format Zod validation errors into human-readable messages           |
+| `config-resolver.ts`             | Resolve config file paths with `.yaml`/`.yml` fallback              |
+| `env-expander.ts`                | Expand `${VAR}` and `${VAR:-default}` in config strings             |
+| `file-utils.ts`                  | Common file operation helpers (read JSON, write YAML, etc.)         |
+| `merge-utils.ts`                 | Deep merge helpers for config objects                               |
+| `platform-utils.ts`              | OS detection, WSL2 detection helpers                                |
+| `string-utils.ts`                | String normalization, slugify, case conversion                      |
+| `array-utils.ts`                 | Deduplication, diff, partition utilities                            |
+| `path-utils.ts`                  | Path normalization across platforms                                 |
+| `logger.ts`                      | Lightweight logger wrapping `OutputPort`                            |
+| `result-utils.ts`                | `Result<T, E>` pattern helpers                                      |
+| `version-utils.ts`               | Semver comparison helpers                                           |
+| `yaml-utils.ts`                  | YAML parse/stringify with error handling                            |
 
 ## error-handler.ts (Key File)
 
 Contains `handleError(error: unknown): never` — the global error handler called by all CLI commands. Maps:
+
 - `OvertureError` → appropriate exit code (1-99) + formatted message
 - `ZodError` → validation error display via `validation-formatter`
 - Unknown errors → exit code 1 + stack trace (in DEBUG mode)
@@ -33,6 +34,7 @@ Also exports `createOvertureError(code, message, cause?)` factory.
 ## validation-formatter.ts (Key File)
 
 Transforms Zod `ZodError` into user-friendly output:
+
 ```
 Config validation failed:
   • mcp.my-server.command: Required
@@ -42,6 +44,7 @@ Config validation failed:
 ## env-expander.ts
 
 Handles `${VAR}` expansion throughout config loading:
+
 - `${VAR}` — required; throws `OvertureError` if `VAR` not set
 - `${VAR:-default}` — optional with fallback; returns `default` if not set
 


### PR DESCRIPTION
## Summary

Adds a hierarchical `AGENTS.md` knowledge base across key subdirectories and corrects the root `AGENTS.md` with accurate, up-to-date guidance.

## Root AGENTS.md — Corrections

The existing root file had several inaccuracies:
- **3 AI clients** supported (not 7 as previously stated): `claude-code`, `copilot-cli`, `opencode`
- Added full `libs/` hexagonal architecture structure with invariants (`libs/core/**` and `libs/domain/**` must not import `node:*` or `libs/adapters/infrastructure`)
- Corrected package alias map to match actual `tsconfig.base.json` paths
- Fixed directory structure to reflect actual codebase layout

## New Subdirectory AGENTS.md Files (10 new files)

Each file provides targeted guidance for AI agents working in that directory:

| File | Focus |
|---|---|
| `apps/cli/src/AGENTS.md` | DI composition root, command registration pattern |
| `apps/cli/src/cli/commands/AGENTS.md` | All 10 CLI commands, error handling conventions |
| `libs/core/sync/src/lib/AGENTS.md` | SyncEngine (1299L), McpSyncService, extension points |
| `libs/core/diagnostics/src/lib/AGENTS.md` | 5 checkers, never-throw diagnostic pattern |
| `libs/core/config/src/lib/AGENTS.md` | ConfigLoader, PathResolver, merge strategy |
| `libs/core/plugin/src/lib/AGENTS.md` | PluginDetector, Installer, Exporter |
| `libs/domain/config-types/src/lib/AGENTS.md` | 15 type interface files, `SUPPORTED_CLIENTS` usage |
| `libs/adapters/client-adapters/src/lib/AGENTS.md` | 3 adapters + factory + how to add a new client |
| `libs/shared/utils/src/lib/AGENTS.md` | 14 utility modules, error-handler, env-expander |
| `libs/shared/testing/src/lib/AGENTS.md` | builders, port mocks, fixture patterns |

## Motivation

Hierarchical `AGENTS.md` files give AI coding assistants (Copilot, Cursor, OpenCode, etc.) precise, locally-scoped context when they open files in a subdirectory — without having to parse the entire root guide. This significantly improves code generation accuracy for directory-specific conventions (e.g., the never-throw diagnostic pattern, ESM `.js` extension requirement, constructor-only DI).
