### PR TITLE
feat(cli): print agent and mcp-config locations in detect human output

### DIFF
--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -421,19 +421,24 @@ describe('formatJsonOutput', () => {
 });
 
 it('does not contain ANSI escape sequences', () => {
-  const output = {
-    platforms: [
-      {
-        id: 'claude-code',
-        displayName: 'Claude Code',
-        installed: true,
-        confidence: 'high',
-        matchedMarkers: ['/tmp/.claude.json'],
-        installMarkers: [],
-        mcpLocations: [],
-      },
-    ],
+  const platform: PlatformDetectionResult = {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    installed: true,
+    confidence: 'high',
+    matchedMarkers: ['/tmp/.claude.json'],
+    installMarkers: [],
+    mcpLocations: [],
+    detectionStrategy: 'marker-only',
+    mcpSupport: 'supported',
+    executableNames: [],
+    matchedExecutables: [],
+    mcpConfigured: false,
+    matchedMcpLocations: [],
+    orphanedMcpLocations: [],
+    reasonCode: 'marker-found',
   };
+  const output: DetectJsonOutput = { platforms: [platform] };
   const json = formatJsonOutput(output);
   expect(json).not.toContain('');
   expect(json).not.toMatch(/\x1b\[/);

--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -259,6 +259,157 @@ describe('formatHumanOutput', () => {
   });
 });
 
+it('detected platform with matchedExecutables shows agent path subline', () => {
+  const platform: PlatformDetectionResult = {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    installed: true,
+    confidence: 'high',
+    matchedMarkers: [],
+    installMarkers: [],
+    mcpLocations: [],
+    detectionStrategy: 'binary-first',
+    mcpSupport: 'supported',
+    executableNames: ['claude'],
+    matchedExecutables: [
+      {
+        name: 'claude',
+        resolvedPath: '/home/user/.local/share/claude/versions/2.1.138',
+        source: 'path',
+      },
+    ],
+    mcpConfigured: false,
+    matchedMcpLocations: [],
+    orphanedMcpLocations: [],
+    reasonCode: 'binary-found',
+  };
+  const output: DetectJsonOutput = { platforms: [platform] };
+  const result = formatHumanOutput(output);
+  expect(result).toContain(
+    '    agent: /home/user/.local/share/claude/versions/2.1.138',
+  );
+  expect(result).toContain('    mcp:   (not configured)');
+});
+
+it('detected platform falls back to matchedMarkers[0] when no executable', () => {
+  const platform: PlatformDetectionResult = {
+    id: 'cursor',
+    displayName: 'Cursor',
+    installed: true,
+    confidence: 'high',
+    matchedMarkers: ['/home/user/.cursor-server'],
+    installMarkers: [],
+    mcpLocations: [],
+    detectionStrategy: 'marker-only',
+    mcpSupport: 'supported',
+    executableNames: [],
+    matchedExecutables: [],
+    mcpConfigured: false,
+    matchedMcpLocations: [],
+    orphanedMcpLocations: [],
+    reasonCode: 'marker-found',
+  };
+  const output: DetectJsonOutput = { platforms: [platform] };
+  const result = formatHumanOutput(output);
+  expect(result).toContain('    agent: /home/user/.cursor-server');
+  expect(result).toContain('    mcp:   (not configured)');
+});
+
+it('detected platform with mcpConfigured shows resolved mcp path', () => {
+  const platform: PlatformDetectionResult = {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    installed: true,
+    confidence: 'high',
+    matchedMarkers: [],
+    installMarkers: [],
+    mcpLocations: [],
+    detectionStrategy: 'binary-first',
+    mcpSupport: 'supported',
+    executableNames: ['claude'],
+    matchedExecutables: [
+      {
+        name: 'claude',
+        resolvedPath: '/usr/bin/claude',
+        source: 'path',
+      },
+    ],
+    mcpConfigured: true,
+    matchedMcpLocations: [
+      {
+        id: 'claude-code-0',
+        resolvedPath: '/home/user/.claude.json',
+        format: 'json',
+        nonEmpty: true,
+      },
+    ],
+    orphanedMcpLocations: [],
+    reasonCode: 'mcp-configured',
+  };
+  const output: DetectJsonOutput = { platforms: [platform] };
+  const result = formatHumanOutput(output);
+  expect(result).toContain('    agent: /usr/bin/claude');
+  expect(result).toContain('    mcp:   /home/user/.claude.json');
+  expect(result).not.toContain('(not configured)');
+});
+
+it('unsupported inventory platform shows agent subline but no mcp subline', () => {
+  const platform: PlatformDetectionResult = {
+    id: 'aider',
+    displayName: 'Aider',
+    installed: true,
+    confidence: 'unsupported',
+    matchedMarkers: [],
+    installMarkers: [],
+    mcpLocations: [],
+    detectionStrategy: 'binary-first',
+    mcpSupport: 'unsupported',
+    executableNames: ['aider'],
+    matchedExecutables: [
+      {
+        name: 'aider',
+        resolvedPath: '/home/user/.local/bin/aider',
+        source: 'path',
+      },
+    ],
+    mcpConfigured: false,
+    matchedMcpLocations: [],
+    orphanedMcpLocations: [],
+    reasonCode: 'unsupported-no-mcp-client',
+  };
+  const output: DetectJsonOutput = { platforms: [platform] };
+  const result = formatHumanOutput(output);
+  expect(result).toContain('        agent: /home/user/.local/bin/aider');
+  expect(result).not.toContain('(not configured)');
+  const inventoryIdx = result.indexOf('Installed tools without MCP support');
+  const afterInventory = result.slice(inventoryIdx);
+  expect(afterInventory).not.toMatch(/\n\s+mcp:/);
+});
+
+it('detected platform with neither executable nor marker still emits (not configured) only', () => {
+  const platform: PlatformDetectionResult = {
+    id: 'github-copilot-cloud-agent',
+    displayName: 'GitHub Copilot Cloud Agent',
+    installed: true,
+    confidence: 'low',
+    matchedMarkers: [],
+    installMarkers: [],
+    mcpLocations: [],
+    detectionStrategy: 'marker-only',
+    mcpSupport: 'unsupported',
+    executableNames: [],
+    matchedExecutables: [],
+    mcpConfigured: false,
+    matchedMcpLocations: [],
+    orphanedMcpLocations: [],
+    reasonCode: 'unsupported-no-local-signal',
+  };
+  const output: DetectJsonOutput = { platforms: [platform] };
+  const result = formatHumanOutput(output);
+  expect(result).not.toMatch(/\n {4}agent:/);
+  expect(result).not.toMatch(/\n {4}mcp:/);
+});
+
 describe('formatJsonOutput', () => {
   it('returns parseable JSON with platforms key', () => {
     const output: DetectJsonOutput = { platforms: [] };

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -17,7 +17,6 @@ export function formatHumanOutput(output: DetectJsonOutput): string {
   if (installed.length === 0 && totalOrphans === 0) {
     return 'No supported MCP-capable platforms detected.\n';
   }
-
   const sections: string[] = [];
 
   // Section 1: installed platforms with MCP support (or unknown status)
@@ -34,6 +33,16 @@ export function formatHumanOutput(output: DetectJsonOutput): string {
         tag = '[mcp-not-configured]';
       }
       lines.push(`  - ${platform.displayName} (${platform.confidence}) ${tag}`);
+      const agentPath =
+        platform.matchedExecutables[0]?.resolvedPath ??
+        platform.matchedMarkers[0];
+      if (agentPath) {
+        lines.push(`    agent: ${agentPath}`);
+      }
+      const mcpPath = platform.mcpConfigured
+        ? platform.matchedMcpLocations[0]?.resolvedPath
+        : null;
+      lines.push(`    mcp:   ${mcpPath ?? '(not configured)'}`);
     }
     sections.push(lines.join('\n'));
   }
@@ -47,6 +56,12 @@ export function formatHumanOutput(output: DetectJsonOutput): string {
     for (const platform of unsupported) {
       const label = platform.executableNames[0] ?? platform.id;
       lines.push(`    - ${platform.displayName} (${label})`);
+      const agentPath =
+        platform.matchedExecutables[0]?.resolvedPath ??
+        platform.matchedMarkers[0];
+      if (agentPath) {
+        lines.push(`        agent: ${agentPath}`);
+      }
     }
     sections.push(lines.join('\n'));
   }


### PR DESCRIPTION
## Summary

When `overture detect` runs, the human-readable output now also prints the location of the agent and the location of the MCP configuration for that agent, as indented sublines beneath the existing one-liner.

## Before

```
- Claude Code (high) [mcp-configured]
- OpenCode (high) [mcp-not-configured]
```

## After

```
- Claude Code (high) [mcp-configured]
    agent: /home/jeff/.local/share/claude/versions/2.1.138
    mcp:   /home/jeff/.claude.json
- OpenCode (high) [mcp-not-configured]
    agent: /home/linuxbrew/.linuxbrew/Cellar/opencode/1.16.2/bin/opencode
    mcp:   (not configured)
```

Inventory section (unsupported tools like Aider) gets the `agent:` subline only — no MCP for those.

## Source data

- `agent:` comes from `matchedExecutables[0].resolvedPath` (binary-first) with fallback to `matchedMarkers[0]` (marker-only).
- `mcp:` comes from `matchedMcpLocations[0].resolvedPath` if `mcpConfigured` is true, else literal `(not configured)`.
- Orphan section is unchanged — it already prints the path.
- `--json` output is unchanged: all 16 fields preserved.

## Tests

- 5 new `formatHumanOutput` tests cover: matchedExecutables path, matchedMarkers fallback, mcpConfigured true, inventory agent subline, no-path no-mcp edge case.
- Full suite: 84/84 pass (was 79, +5).
- Build green, prettier clean.

## Host regression

Captured live output on this machine (5 installed + 1 inventory):

```
- Claude Code (high) [mcp-configured]
    agent: /home/jeff/.local/share/claude/versions/2.1.138
    mcp:   /home/jeff/.claude.json
- Claude Desktop (high) [mcp-configured]
    agent: /home/jeff/.config/Claude/claude_desktop_config.json
    mcp:   /home/jeff/.config/Claude/claude_desktop_config.json
- OpenCode (high) [mcp-not-configured]
    agent: /home/linuxbrew/.linuxbrew/Cellar/opencode/1.16.2/bin/opencode
    mcp:   (not configured)
- GitHub Copilot CLI (high) [mcp-not-configured]
    agent: /home/jeff/.nvm/versions/node/v25.2.1/lib/node_modules/@github/copilot/npm-loader.js
    mcp:   (not configured)
- OpenAI Codex (high) [mcp-not-configured]
    agent: /home/jeff/.nvm/versions/node/v25.2.1/lib/node_modules/@openai/codex/bin/codex.js
    mcp:   (not configured)

Installed tools without MCP support (inventory):
    - Aider (aider)
        agent: /home/jeff/.local/share/uv/tools/aider-chat/bin/aider
```