### PR TITLE
fix(cli): skip nx cache on link, suppress duplicate mcp subline for Claude Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The `link` script in `apps/cli/package.json` wraps both steps:
 ```json
 {
   "scripts": {
-    "link": "yarn nx build cli && npm link",
+    "link": "yarn nx build cli --skip-nx-cache && npm link",
     "unlink": "npm unlink -g overture"
   }
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -6,7 +6,7 @@
     "overture": "./dist/main.js"
   },
   "scripts": {
-    "link": "yarn nx build cli && npm link",
+    "link": "yarn nx build cli --skip-nx-cache && npm link",
     "unlink": "npm unlink -g overture"
   },
   "nx": {


### PR DESCRIPTION
## Summary

After merging PR #63, running `yarn nx run cli:link` produced a global `overture` that still ran the pre-PR bundle. Root cause: `yarn nx build cli` hit the Nx cache, did not rebuild, and `npm link` re-pointed the global symlink at the same stale dist.

Fix: add `--skip-nx-cache` to the build step so every `link` invocation does a fresh build.

## Diff

```diff
diff --git a/README.md b/README.md
@@
The `link` script in `apps/cli/package.json` wraps both steps:
 
 ```json
 {
   "scripts": {
-    "link": "yarn nx build cli && npm link",
+    "link": "yarn nx build cli --skip-nx-cache && npm link",
     "unlink": "npm unlink -g overture"
   }
 }
 ```

diff --git a/apps/cli/package.json b/apps/cli/package.json
@@
   "scripts": {
-    "link": "yarn nx build cli && npm link",
+    "link": "yarn nx build cli --skip-nx-cache && npm link",
     "unlink": "npm unlink -g overture"
   },
```

(`apps/cli/src/cli.spec.ts` also carries a 5-line type-annotation fix from the original PR #64 amend, hardening a pre-existing partial-fixture test against strict typecheck. Not part of this change but preserved across the rebase.)

## Verification

- `yarn vitest run`: 84/84 pass
- `yarn nx build cli`: green
- `yarn prettier --check .`: clean
- `node apps/cli/dist/main.js detect --json`: 14 platforms, all 16 fields

## Out of scope: Claude Desktop dedup

An earlier draft of this PR also tried to suppress a duplicate `mcp:` subline for Claude Desktop (where the install marker IS the config file). That was reverted before merge because the dedup was masking a real detection bug, not a Claude Desktop quirk — the host is WSL2, and the `~/.config/Claude/claude_desktop_config.json` is a Linux-side shadow of a Windows-side Claude Desktop install. A proper fix needs WSL2-aware detection; see the follow-up issue below.

## Follow-up

- #65 — feat: WSL2-aware cross-OS platform detection