### PR TITLE
feat(platforms): add typed MCP config designs for supported agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,21 @@ the aggregate renames it on import (`continueDef as continueAgent`).
 Use the same workaround if you add an agent whose id collides with a
 reserved word.
 
+**Typed MCP config designs.** Every supported local MCP-capable agent exports a
+colocated `<AgentName>McpConfig` type from its `apps/cli/src/platforms/agents/<id>.ts`
+file. Shared MCP config primitives (e.g. `McpServerMap`, `StdioServerBase`,
+`PermissiveConfigObject`) live in `apps/cli/src/platforms/agents/types.ts`; compose
+new per-agent types from those primitives rather than redefining shape locally.
+These types are compile-time only: no runtime validators, no readers, no writers
+land in the same PR as the type addition. Unsupported and no-local-read agents
+(`aider`, `github-copilot-cloud-agent`) deliberately do not export a config type.
+When the agent file's `mcpLocations` registry metadata conflicts with the
+canonical future-read schema in `docs/coding-platform-mcp-configurations.md`,
+types follow the docs as the source of truth; the registry detection metadata
+itself is updated in a separate, detection-focused PR. The type-contract spec
+in `apps/cli/src/platforms/agents/mcp-config-types.spec.ts` is the canonical home
+for fixture-based type tests.
+
 ## Things not to change without asking
 
 - `.yarnrc.yml` (`nodeLinker: node-modules`) — switching to PnP will break

--- a/apps/cli/src/platforms/agents/claude-code.ts
+++ b/apps/cli/src/platforms/agents/claude-code.ts
@@ -1,6 +1,13 @@
 // Claude Code agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type {
+  AgentDefinition,
+  McpServerMap,
+  PermissiveConfigObject,
+  RemoteServerBase,
+  StdioServerBase,
+  StringMap,
+} from './types.js';
 
 export const claudeCode: AgentDefinition = {
   id: 'claude-code',
@@ -47,3 +54,35 @@ export const claudeCode: AgentDefinition = {
   executableNames: ['claude'],
   mcp: notImplementedMcpHandlers('claude-code'),
 };
+
+/** Native Claude Code MCP config: `mcpServers` map; each server is either a stdio transport or a remote transport (HTTP / streamable-http / SSE / WebSocket). The top level may also carry a local `imports` map (Claude Code's local-imports feature). */
+
+export interface ClaudeCodeMcpConfig {
+  readonly mcpServers?: McpServerMap<ClaudeCodeMcpServer>;
+
+  /** Local-imports map: imports named JSON files (e.g. Claude Desktop) into the active config. */
+
+  readonly imports?: StringMap;
+}
+
+/** Discriminated by `type`; defaults to `stdio` when omitted. Carries a permissive index signature for forward-compatible extension fields. */
+
+export type ClaudeCodeMcpServer = (
+  | ClaudeCodeStdioServer
+  | ClaudeCodeRemoteServer
+) &
+  PermissiveConfigObject;
+
+/** Stdio transport: local process invocation. */
+
+export interface ClaudeCodeStdioServer extends StdioServerBase {
+  /** Transport discriminator. Omitted for stdio in practice; kept open to permit future variants. */
+  readonly type?: string;
+}
+
+/** Remote transport: HTTP / streamable-http / SSE / WebSocket. */
+
+export interface ClaudeCodeRemoteServer extends RemoteServerBase {
+  /** Transport discriminator. Literal values include 'http', 'streamable-http', 'sse', 'ws'; unknown strings are tolerated for forward compatibility. */
+  readonly type?: string;
+}

--- a/apps/cli/src/platforms/agents/claude-desktop.ts
+++ b/apps/cli/src/platforms/agents/claude-desktop.ts
@@ -1,6 +1,10 @@
 // Claude Desktop agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type {
+  AgentDefinition,
+  McpServerMap,
+  StdioServerBase,
+} from './types.js';
 
 export const claudeDesktop: AgentDefinition = {
   id: 'claude-desktop',
@@ -71,3 +75,13 @@ export const claudeDesktop: AgentDefinition = {
   executableNames: [],
   mcp: notImplementedMcpHandlers('claude-desktop'),
 };
+
+/** Native Claude Desktop MCP config: `mcpServers` map; each server is stdio-only (no remote transport supported). */
+
+export interface ClaudeDesktopMcpConfig {
+  readonly mcpServers?: McpServerMap<ClaudeDesktopMcpServer>;
+}
+
+/** Claude Desktop server: local process invocation via stdio. */
+
+export type ClaudeDesktopMcpServer = StdioServerBase;

--- a/apps/cli/src/platforms/agents/cline.ts
+++ b/apps/cli/src/platforms/agents/cline.ts
@@ -1,6 +1,32 @@
 // Cline agent definition.
 import { notImplementedMcpHandlers } from './types.js';
 import type { AgentDefinition } from './types.js';
+import type { McpServerMap, StringList, StringMap } from './types.js';
+
+/**
+ * Native Cline MCP server entry. Cline accepts either stdio-style servers
+ * (with `command`/`args`/`env`) or remote servers (with `url`/`headers`)
+ * and lets users pick the transport via the optional `transportType`
+ * discriminator.
+ */
+export interface ClineMcpServer {
+  command?: string;
+  args?: StringList;
+  env?: StringMap;
+  url?: string;
+  headers?: StringMap;
+  disabled?: boolean;
+  autoApprove?: StringList;
+  transportType?: string;
+}
+
+/**
+ * Native Cline MCP config shape. The top-level `mcpServers` key holds a
+ * read-only map of server name to {@link ClineMcpServer} entries.
+ */
+export interface ClineMcpConfig {
+  readonly mcpServers?: McpServerMap<ClineMcpServer>;
+}
 
 export const cline: AgentDefinition = {
   id: 'cline',

--- a/apps/cli/src/platforms/agents/continue.ts
+++ b/apps/cli/src/platforms/agents/continue.ts
@@ -1,6 +1,68 @@
 // Continue agent definition.
 import { notImplementedMcpHandlers } from './types.js';
 import type { AgentDefinition } from './types.js';
+import type { RequestInitConfig, StringList, StringMap } from './types.js';
+import type { ClaudeCodeMcpConfig } from './claude-code.js';
+import type { CursorMcpConfig } from './cursor.js';
+import type { ClineMcpConfig } from './cline.js';
+
+/**
+ * Native Continue MCP server entry inside a standalone YAML config.
+ * The `name` field is required because Continue identifies servers by
+ * name within the YAML `mcpServers` list, not by map key.
+ */
+export interface ContinueMcpServer {
+  name: string;
+  type?: string;
+
+  command?: string;
+  args?: StringList;
+  env?: StringMap;
+  cwd?: string;
+  url?: string;
+  requestOptions?: RequestInitConfig;
+  connectionTimeout?: number;
+}
+
+/**
+ * Standalone YAML MCP config written under
+ * `<workspace>/.continue/mcpServers/*.yaml`. Per the Continue docs the
+ * top-level `mcpServers` key holds an ordered list of server entries
+ * (not a map), and the file is identified by `name`/`version`/`schema`
+ * metadata. This is the canonical Continue native shape.
+ */
+export interface ContinueYamlMcpConfig {
+  name: string;
+  version: string;
+  schema: string;
+
+  mcpServers: readonly ContinueMcpServer[];
+}
+
+/**
+ * Imported JSON MCP config Continue can read from
+ * `<workspace>/.continue/mcpServers/*.json`. Continue accepts files
+ * copied verbatim from supported clients (Claude Code, Cursor, Cline,
+ * and friends), so the imported shape is a union of those native types.
+ */
+export type ContinueImportedJsonMcpConfig =
+  | ClaudeCodeMcpConfig
+  | CursorMcpConfig
+  | ClineMcpConfig;
+
+/**
+ * Native Continue MCP config shape. Continue supports two layouts:
+ * - standalone YAML files (see {@link ContinueYamlMcpConfig})
+ * - imported JSON files copied from other clients
+ *   (see {@link ContinueImportedJsonMcpConfig})
+ * Detection metadata in {@link continueDef} still points at
+ * `.continue/config.json`; the YAML/imported-JSON layout is the
+ * forward-looking read target documented in
+ * `docs/coding-platform-mcp-configurations.md`.
+ */
+export type ContinueMcpConfig =
+  | ContinueYamlMcpConfig
+  | ContinueImportedJsonMcpConfig;
 
 export const continueDef: AgentDefinition = {
   id: 'continue',

--- a/apps/cli/src/platforms/agents/cursor.ts
+++ b/apps/cli/src/platforms/agents/cursor.ts
@@ -1,6 +1,12 @@
 // Cursor agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type {
+  AgentDefinition,
+  McpServerMap,
+  PermissiveConfigObject,
+  RemoteServerBase,
+  StdioServerBase,
+} from './types.js';
 
 export const cursor: AgentDefinition = {
   id: 'cursor',
@@ -46,4 +52,45 @@ export const cursor: AgentDefinition = {
   mcpSupport: 'supported',
   executableNames: ['cursor'],
   mcp: notImplementedMcpHandlers('cursor'),
+};
+
+/** Native Cursor MCP config: `mcpServers` map; servers may be stdio (with `command`/`args`/`env`) or remote (with `url`/`headers`). Per-server `envFile` overrides; static OAuth-like credentials live under `auth`. */
+
+export interface CursorMcpConfig {
+  readonly mcpServers?: McpServerMap<CursorMcpServer>;
+}
+
+/** Cursor server: union of stdio and remote transports with permissive extension fields. */
+
+export type CursorMcpServer = (CursorStdioServer | CursorRemoteServer) &
+  PermissiveConfigObject;
+
+/** Stdio transport: local process invocation. */
+
+export interface CursorStdioServer extends StdioServerBase {
+  /** Path to a dotenv-style env file whose entries are merged into `env`. */
+
+  readonly envFile?: string;
+
+  /** Static OAuth-like credentials: `CLIENT_ID`, `CLIENT_SECRET`, optional `scopes`, plus an open index signature for forward-compatible fields. */
+
+  readonly auth?: CursorAuth;
+}
+
+/** Remote transport: HTTP / SSE. */
+
+export interface CursorRemoteServer extends RemoteServerBase {
+  /** Static OAuth-like credentials. */
+
+  readonly auth?: CursorAuth;
+}
+
+/** Permissive object that exposes the documented Cursor auth keys and permits arbitrary additional fields. */
+
+export type CursorAuth = PermissiveConfigObject & {
+  readonly CLIENT_ID?: string;
+
+  readonly CLIENT_SECRET?: string;
+
+  readonly scopes?: readonly string[];
 };

--- a/apps/cli/src/platforms/agents/github-copilot-cli.ts
+++ b/apps/cli/src/platforms/agents/github-copilot-cli.ts
@@ -1,6 +1,12 @@
 // GitHub Copilot CLI agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type {
+  AgentDefinition,
+  McpServerMap,
+  StringList,
+  StringMap,
+  ToolList,
+} from './types.js';
 
 export const githubCopilotCli: AgentDefinition = {
   id: 'github-copilot-cli',
@@ -39,3 +45,43 @@ export const githubCopilotCli: AgentDefinition = {
   executableNames: ['copilot'],
   mcp: notImplementedMcpHandlers('github-copilot-cli'),
 };
+
+/**
+ * Local (subprocess) Copilot CLI MCP server. `type` is the literal
+ * `'local'` and the entry is keyed on it for a discriminated union.
+ */
+export interface GitHubCopilotCliLocalServer {
+  type: 'local';
+  command: string;
+  args?: StringList;
+  env?: StringMap;
+  tools?: ToolList;
+}
+
+/**
+ * Remote (HTTP) Copilot CLI MCP server. `type` is the literal `'http'`.
+ */
+export interface GitHubCopilotCliRemoteServer {
+  type: 'http';
+  url: string;
+  headers?: StringMap;
+  tools?: ToolList;
+}
+
+/**
+ * Union of every supported Copilot CLI MCP server variant. Discriminated
+ * on the `type` field.
+ */
+export type GitHubCopilotCliServer =
+  | GitHubCopilotCliLocalServer
+  | GitHubCopilotCliRemoteServer;
+
+/**
+ * Native shape of `~/.copilot/mcp-config.json` (user-global; relocatable
+ * via `COPILOT_HOME`). The top-level key is `mcpServers` (per the current
+ * official Copilot CLI docs), NOT the legacy `servers` key referenced by
+ * the stale registry metadata.
+ */
+export interface GitHubCopilotCliMcpConfig {
+  mcpServers?: McpServerMap<GitHubCopilotCliServer>;
+}

--- a/apps/cli/src/platforms/agents/github-copilot-vscode.ts
+++ b/apps/cli/src/platforms/agents/github-copilot-vscode.ts
@@ -1,7 +1,14 @@
 // GitHub Copilot in VS Code agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
-
+import type {
+  AgentDefinition,
+  McpServerMap,
+  OAuthConfig,
+  PermissiveConfigObject,
+  RequestInitConfig,
+  StdioServerBase,
+  StringMap,
+} from './types.js';
 export const githubCopilotVscode: AgentDefinition = {
   id: 'github-copilot-vscode',
   displayName: 'GitHub Copilot in VS Code',
@@ -47,3 +54,73 @@ export const githubCopilotVscode: AgentDefinition = {
   executableNames: [],
   mcp: notImplementedMcpHandlers('github-copilot-vscode'),
 };
+
+/**
+ * VS Code input variable used by `inputs[]` in `.vscode/mcp.json`.
+ * Mirrors VS Code's generic input variable shape (id/type plus metadata
+ * for prompt, default, password, and options).
+ */
+export interface GitHubCopilotVSCodeInput {
+  id: string;
+  type: string;
+  description?: string;
+  default?: string;
+  password?: boolean;
+  options?: readonly string[];
+}
+
+/**
+ * Discriminator for a VS Code MCP server entry. VS Code accepts the
+ * literal values `'stdio' | 'http' | 'sse'`; the field is documented as
+ * optional in real configs (it falls back to stdio when absent), and
+ * unknown strings are tolerated for forward compatibility.
+ */
+export interface GitHubCopilotVSCodeServerBase extends PermissiveConfigObject {
+  type?: 'stdio' | 'http' | 'sse' | (string & {});
+}
+
+/**
+ * Local (stdio) VS Code MCP server. Inherits the standard
+ * `command`/`args`/`env`/`cwd` shape and adds VS Code-specific
+ * `envFile`, `dev`, and `sandboxEnabled` knobs.
+ */
+export interface GitHubCopilotVSCodeLocalServer extends StdioServerBase {
+  type?: 'stdio' | (string & {});
+  dev?: boolean;
+  envFile?: string;
+  sandboxEnabled?: boolean;
+}
+
+/**
+ * Remote (http/sse) VS Code MCP server. Carries `url` and `headers`,
+ * plus VS Code-specific `oauth` and `requestInit` overrides. Undocumented
+ * extension fields are tolerated via the `extras` bag rather than a wide
+ * index signature, so the typed `oauth`/`requestInit` shapes remain intact.
+ */
+export interface GitHubCopilotVSCodeRemoteServer {
+  type?: 'http' | 'sse' | (string & {});
+  url: string;
+  headers?: StringMap;
+  oauth?: OAuthConfig;
+  requestInit?: RequestInitConfig;
+  extras?: PermissiveConfigObject;
+}
+
+/**
+ * Union of every supported VS Code MCP server variant. Local and remote
+ * are merged via a permissive shared base plus per-variant fields.
+ */
+export type GitHubCopilotVSCodeServer =
+  | GitHubCopilotVSCodeLocalServer
+  | GitHubCopilotVSCodeRemoteServer;
+
+/**
+ * Native shape of `.vscode/mcp.json` (workspace and user-global
+ * variants). The top-level key is `servers` (NOT `mcpServers`); an
+ * optional `inputs` array declares prompt/input variables that may be
+ * referenced from server entries.
+ */
+export interface GitHubCopilotVSCodeMcpConfig {
+  servers?: McpServerMap<GitHubCopilotVSCodeServer>;
+  inputs?: readonly GitHubCopilotVSCodeInput[];
+}

--- a/apps/cli/src/platforms/agents/mcp-config-types.spec.ts
+++ b/apps/cli/src/platforms/agents/mcp-config-types.spec.ts
@@ -1,0 +1,339 @@
+// Per-agent MCP config type-contract tests.
+//
+// This suite is a compile-time + registry-absence contract; it does NOT read
+// or write MCP files. Each supported agent exports a `*McpConfig` type that
+// is consumed by at least one `satisfies` fixture below so the strict-mode
+// `noUnusedLocals` rule does not flag the imports. Unsupported/no-local-read
+// agents must NOT export a `*McpConfig` type; that absence is asserted at
+// runtime by the file-content greps in the `unsupported-agent absence`
+// describe block. Changed-file strictness (`@ts-expect-error`/`: any`)
+// is asserted at runtime by the `strictness` describe block.
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { ClaudeCodeMcpConfig } from './claude-code.js';
+import type { ClaudeDesktopMcpConfig } from './claude-desktop.js';
+import type { OpenCodeMcpConfig } from './opencode.js';
+import type { GitHubCopilotVSCodeMcpConfig } from './github-copilot-vscode.js';
+import type { GitHubCopilotCliMcpConfig } from './github-copilot-cli.js';
+import type { CursorMcpConfig } from './cursor.js';
+import type { WindsurfMcpConfig } from './windsurf.js';
+import type { ClineMcpConfig } from './cline.js';
+import type { RooCodeMcpConfig } from './roo-code.js';
+import type { ContinueMcpConfig, ContinueYamlMcpConfig } from './continue.js';
+import type { ZedMcpConfig } from './zed.js';
+import type { OpenAICodexMcpConfig } from './openai-codex.js';
+
+describe('ClaudeCodeMcpConfig', () => {
+  it('accepts a stdio server and an http server plus a local imports map', () => {
+    const fixture: ClaudeCodeMcpConfig = {
+      mcpServers: {
+        'local-tools': {
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-memory'],
+          env: { LOG_LEVEL: 'info' },
+        },
+        'remote-tools': {
+          type: 'http',
+          url: 'https://mcp.example.com/mcp',
+          headers: { Authorization: 'Bearer token' },
+        },
+      },
+      imports: { './shared.json': '/absolute/path/to/shared.json' },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<ClaudeCodeMcpConfig>();
+  });
+});
+
+describe('ClaudeDesktopMcpConfig', () => {
+  it('accepts a stdio-only server', () => {
+    const fixture: ClaudeDesktopMcpConfig = {
+      mcpServers: {
+        memory: {
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-memory'],
+          env: { LOG_LEVEL: 'info' },
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<ClaudeDesktopMcpConfig>();
+  });
+});
+
+describe('CursorMcpConfig', () => {
+  it('accepts a stdio server with envFile and static auth', () => {
+    const fixture: CursorMcpConfig = {
+      mcpServers: {
+        'local-server': {
+          command: 'node',
+          args: ['server.js'],
+          env: { NODE_ENV: 'production' },
+          envFile: '/etc/cursor/mcp.env',
+          auth: {
+            CLIENT_ID: 'cursor-client',
+            CLIENT_SECRET: 'cursor-secret',
+            scopes: ['mcp:read', 'mcp:write'],
+          },
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<CursorMcpConfig>();
+  });
+});
+
+describe('WindsurfMcpConfig', () => {
+  it('accepts a stdio server and a remote server with both url and serverUrl', () => {
+    const fixture: WindsurfMcpConfig = {
+      mcpServers: {
+        local: { command: 'npx', args: ['-y', 'mcp-server-fetch'] },
+        remote: {
+          url: 'https://mcp.example.com/mcp',
+          serverUrl: 'https://mcp.example.com/mcp',
+          headers: { 'X-Windsurf': '1' },
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<WindsurfMcpConfig>();
+  });
+});
+
+describe('OpenCodeMcpConfig', () => {
+  it('accepts a local server (argv vector) and a remote server', () => {
+    const fixture: OpenCodeMcpConfig = {
+      mcp: {
+        local: {
+          type: 'local',
+          command: ['node', 'server.js'],
+          environment: { NODE_ENV: 'production' },
+          enabled: true,
+          timeout: 30,
+        },
+        remote: {
+          type: 'remote',
+          url: 'https://mcp.example.com/mcp',
+          headers: { Authorization: 'Bearer token' },
+          enabled: true,
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<OpenCodeMcpConfig>();
+  });
+});
+
+describe('GitHubCopilotVSCodeMcpConfig', () => {
+  it('accepts inputs plus a remote server with oauth and requestInit', () => {
+    const fixture: GitHubCopilotVSCodeMcpConfig = {
+      inputs: [
+        {
+          id: 'github-token',
+          type: 'promptString',
+          description: 'GitHub PAT',
+          password: true,
+        },
+      ],
+      servers: {
+        github: {
+          type: 'http',
+          url: 'https://api.githubcopilot.com/mcp/',
+          headers: { Authorization: 'Bearer ${input:github-token}' },
+          oauth: false,
+          requestInit: { headers: { 'X-Test': '1' } },
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<GitHubCopilotVSCodeMcpConfig>();
+  });
+});
+
+describe('GitHubCopilotCliMcpConfig', () => {
+  it('accepts a local and an http server keyed under mcpServers', () => {
+    const fixture: GitHubCopilotCliMcpConfig = {
+      mcpServers: {
+        local: {
+          type: 'local',
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-memory'],
+          env: {},
+          tools: ['*'],
+        },
+        remote: {
+          type: 'http',
+          url: 'https://mcp.example.com/mcp',
+          headers: { Authorization: 'Bearer ${MCP_TOKEN}' },
+          tools: ['tool_a'],
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<GitHubCopilotCliMcpConfig>();
+  });
+});
+
+describe('ClineMcpConfig', () => {
+  it('accepts a server with autoApprove and streamableHttp transport', () => {
+    const fixture: ClineMcpConfig = {
+      mcpServers: {
+        fetch: {
+          command: 'npx',
+          args: ['-y', 'mcp-server-fetch'],
+          env: { DEBUG: '1' },
+          transportType: 'streamableHttp',
+          url: 'https://example.com/sse',
+          autoApprove: ['fetch'],
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<ClineMcpConfig>();
+  });
+});
+
+describe('RooCodeMcpConfig', () => {
+  it('accepts a server with alwaysAllow, watchPaths, and disabledTools', () => {
+    const fixture: RooCodeMcpConfig = {
+      mcpServers: {
+        playwright: {
+          command: 'npx',
+          args: ['-y', '@microsoft/mcp-server-playwright'],
+          env: { DEBUG: '0' },
+          alwaysAllow: ['browser_navigate'],
+          timeout: 60,
+          watchPaths: ['/tmp/playwright'],
+          disabledTools: ['browser_screenshot'],
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<RooCodeMcpConfig>();
+  });
+});
+
+describe('ContinueMcpConfig', () => {
+  it('accepts a standalone YAML-style config', () => {
+    const yamlFixture: ContinueYamlMcpConfig = {
+      name: 'playwright-mcp',
+      version: '0.0.1',
+      schema: 'v1',
+      mcpServers: [
+        {
+          name: 'playwright',
+          command: 'npx',
+          args: ['-y', '@microsoft/mcp-server-playwright'],
+        },
+      ],
+    };
+    const asUnion: ContinueMcpConfig = yamlFixture;
+    expectTypeOf(asUnion).toMatchTypeOf<ContinueMcpConfig>();
+  });
+
+  it('accepts an imported-JSON-style config (ClaudeCodeMcpConfig shape)', () => {
+    const jsonFixture = {
+      mcpServers: {
+        'imported-server': {
+          command: 'npx',
+          args: ['-y', 'mcp-server'],
+        },
+      },
+    };
+    const asUnion: ContinueMcpConfig = jsonFixture;
+    expectTypeOf(asUnion).toMatchTypeOf<ContinueMcpConfig>();
+  });
+});
+
+describe('ZedMcpConfig', () => {
+  it('accepts a stdio and a remote server under context_servers', () => {
+    const fixture: ZedMcpConfig = {
+      context_servers: {
+        local: {
+          command: 'npx',
+          args: ['-y', 'mcp-server-fetch'],
+          env: { DEBUG: '1' },
+        },
+        remote: {
+          url: 'https://mcp.example.com/mcp',
+          headers: { 'X-Zed': '1' },
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<ZedMcpConfig>();
+  });
+});
+
+describe('OpenAICodexMcpConfig', () => {
+  it('accepts a stdio and a remote server with snake_case fields under mcp_servers', () => {
+    const fixture: OpenAICodexMcpConfig = {
+      mcp_servers: {
+        local: {
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-memory'],
+          env: { LOG_LEVEL: 'info' },
+          env_vars: ['HOME', 'PATH'],
+          startup_timeout_sec: 5,
+          tool_timeout_sec: 30,
+          enabled_tools: ['read_file'],
+          disabled_tools: ['write_file'],
+          scopes: ['mcp:read'],
+          oauth_resource: 'https://mcp.example.com/oauth',
+          required: false,
+          enabled: true,
+        },
+        remote: {
+          url: 'https://mcp.example.com/mcp',
+          bearer_token_env_var: 'MCP_TOKEN',
+          http_headers: { 'X-Codex': '1' },
+          env_http_headers: { 'X-Env': '1' },
+        },
+      },
+    };
+    expectTypeOf(fixture).toMatchTypeOf<OpenAICodexMcpConfig>();
+  });
+});
+
+describe('unsupported-agent absence', () => {
+  // The two agents that should NOT have an `*McpConfig` export are read
+  // as plain text; any future addition of `AiderMcpConfig` or
+  // `GitHubCopilotCloudAgentMcpConfig` will surface here.
+  const agentsDir = join(__dirname);
+
+  it('aider.ts does not export AiderMcpConfig', () => {
+    const src = readFileSync(join(agentsDir, 'aider.ts'), 'utf8');
+    expect(src).not.toMatch(/AiderMcpConfig/);
+  });
+
+  it('github-copilot-cloud-agent.ts does not export GitHubCopilotCloudAgentMcpConfig', () => {
+    const src = readFileSync(
+      join(agentsDir, 'github-copilot-cloud-agent.ts'),
+      'utf8',
+    );
+    expect(src).not.toMatch(/GitHubCopilotCloudAgentMcpConfig/);
+  });
+});
+
+describe('strictness', () => {
+  // Strictness guard: changed TypeScript files in this PR must not contain
+  // `@ts-expect-error`, `@ts-ignore`, `: any`, or `as any`. The list is
+
+  // change must be appended here intentionally.
+  const strictPaths = [
+    'claude-code.ts',
+    'claude-desktop.ts',
+    'opencode.ts',
+    'github-copilot-vscode.ts',
+    'github-copilot-cli.ts',
+    'cursor.ts',
+    'windsurf.ts',
+    'cline.ts',
+    'roo-code.ts',
+    'continue.ts',
+    'zed.ts',
+    'openai-codex.ts',
+  ];
+
+  // Composed from fragments so the spec file itself does not contain the
+  // The spec file itself is intentionally excluded from the strictness
+  // list because it must reference the forbidden patterns to test for them.
+  const forbidden = /@ts-expect-error|@ts-ignore|:\s*any\b|\bas\s+any\b/;
+
+  it.each(strictPaths)('%s contains no strictness violations', (rel) => {
+    const src = readFileSync(join(__dirname, rel), 'utf8');
+    expect(src).not.toMatch(forbidden);
+  });
+});

--- a/apps/cli/src/platforms/agents/openai-codex.ts
+++ b/apps/cli/src/platforms/agents/openai-codex.ts
@@ -1,6 +1,6 @@
 // OpenAI Codex agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type { AgentDefinition, StringMap } from './types.js';
 
 export const openaiCodex: AgentDefinition = {
   id: 'openai-codex',
@@ -47,3 +47,60 @@ export const openaiCodex: AgentDefinition = {
   executableNames: ['codex'],
   mcp: notImplementedMcpHandlers('openai-codex'),
 };
+
+/**
+ * Native OpenAI Codex MCP config shape. Codex stores MCP servers
+ * under the top-level `mcp_servers` table in TOML
+ * (`~/.codex/config.toml` and trusted project `.codex/config.toml`).
+ * Field names are preserved as snake_case to mirror the source TOML
+ * format; this type is a design contract for the parsed shape, not a
+ * normalized camelCase view.
+ */
+export interface OpenAICodexMcpConfig {
+  readonly mcp_servers?: Readonly<Record<string, OpenAICodexMcpServer>>;
+}
+
+/**
+ * OpenAI Codex MCP server entry. All fields are optional; the
+ * transport is implied by the presence of either `command` (stdio)
+ * or `url` (remote). Field names mirror the documented TOML keys
+ * (`env_vars`, `startup_timeout_sec`, `tool_timeout_sec`,
+ * `enabled_tools`, `disabled_tools`, `oauth_resource`,
+ * `bearer_token_env_var`, `http_headers`, `env_http_headers`).
+ */
+export interface OpenAICodexMcpServer {
+  /** Stdio: command to spawn. Remote servers omit this. */
+  command?: string;
+  /** Stdio: command-line arguments. */
+  args?: readonly string[];
+  /** Stdio: inline environment variables as a string map. */
+  env?: StringMap;
+  /** Stdio: names of environment variables to forward from the parent process. */
+  env_vars?: readonly string[];
+  /** Stdio: working directory for the server process. */
+  cwd?: string;
+  /** Stdio: startup timeout in seconds. */
+  startup_timeout_sec?: number;
+  /** Per-tool invocation timeout in seconds. */
+  tool_timeout_sec?: number;
+  /** Allowlist of tool names this server exposes. */
+  enabled_tools?: readonly string[];
+  /** Blocklist of tool names this server exposes. */
+  disabled_tools?: readonly string[];
+  /** OAuth scopes to request for this server. */
+  scopes?: readonly string[];
+  /** OAuth resource URL the client should target. */
+  oauth_resource?: string;
+  /** Whether this server is required by the agent. */
+  required?: boolean;
+  /** Whether this server is enabled. */
+  enabled?: boolean;
+  /** Remote: URL the MCP client connects to. */
+  url?: string;
+  /** Remote: environment variable name holding the bearer token. */
+  bearer_token_env_var?: string;
+  /** Remote: static HTTP headers attached to requests. */
+  http_headers?: StringMap;
+  /** Remote: HTTP headers sourced from environment variables. */
+  env_http_headers?: StringMap;
+}

--- a/apps/cli/src/platforms/agents/opencode.ts
+++ b/apps/cli/src/platforms/agents/opencode.ts
@@ -1,6 +1,38 @@
 // OpenCode agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type { AgentDefinition, OAuthConfig, StringMap } from './types.js';
+
+/**
+ * Discriminated union of MCP server entries supported by OpenCode's
+ * `mcp` config. The `type` field selects the transport:
+ * - `'local'`  - command spawned as a subprocess; `command` is an argv vector.
+ * - `'remote'` - URL-based transport (HTTP, SSE, etc.).
+ */
+export type OpenCodeMcpServer =
+  | {
+      type: 'local';
+      command: readonly string[];
+      environment?: StringMap;
+      enabled?: boolean;
+      timeout?: number;
+      oauth?: OAuthConfig;
+    }
+  | {
+      type: 'remote';
+      url: string;
+      headers?: StringMap;
+      enabled?: boolean;
+      timeout?: number;
+      oauth?: OAuthConfig;
+    };
+
+/**
+ * Native OpenCode MCP config shape. The top-level `mcp` key holds a
+ * read-only map of server name to {@link OpenCodeMcpServer} entries.
+ */
+export interface OpenCodeMcpConfig {
+  readonly mcp?: Readonly<Record<string, OpenCodeMcpServer>>;
+}
 
 export const opencode: AgentDefinition = {
   id: 'opencode',

--- a/apps/cli/src/platforms/agents/roo-code.ts
+++ b/apps/cli/src/platforms/agents/roo-code.ts
@@ -1,6 +1,34 @@
 // Roo Code agent definition.
 import { notImplementedMcpHandlers } from './types.js';
 import type { AgentDefinition } from './types.js';
+import type { McpServerMap, StringList, StringMap } from './types.js';
+
+/**
+ * Native Roo Code MCP server entry. Roo accepts either stdio-style servers
+ * (with `command`/`args`/`env`) or remote servers (with `url`/`headers`)
+ * and adds policy fields (`alwaysAllow`, `disabled`, `timeout`, `watchPaths`,
+ * `disabledTools`) on top.
+ */
+export interface RooCodeMcpServer {
+  command?: string;
+  args?: StringList;
+  env?: StringMap;
+  url?: string;
+  headers?: StringMap;
+  alwaysAllow?: StringList;
+  disabled?: boolean;
+  timeout?: number;
+  watchPaths?: StringList;
+  disabledTools?: StringList;
+}
+
+/**
+ * Native Roo Code MCP config shape. The top-level `mcpServers` key holds a
+ * read-only map of server name to {@link RooCodeMcpServer} entries.
+ */
+export interface RooCodeMcpConfig {
+  readonly mcpServers?: McpServerMap<RooCodeMcpServer>;
+}
 
 export const rooCode: AgentDefinition = {
   id: 'roo-code',

--- a/apps/cli/src/platforms/agents/types.ts
+++ b/apps/cli/src/platforms/agents/types.ts
@@ -61,3 +61,67 @@ export function notImplementedMcpHandlers(
     write: () => Promise.reject(message('write')),
   };
 }
+
+/** JSON scalar value: string, number, boolean, or null. */
+export type JsonPrimitive = string | number | boolean | null;
+
+/** Any valid JSON value, recursively defined and readonly. */
+export type JsonValue =
+  | JsonPrimitive
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue | undefined };
+
+/** Read-only string-to-string map (e.g. environment variables, HTTP headers). */
+export type StringMap = Readonly<Record<string, string>>;
+
+/** Read-only ordered list of strings (e.g. CLI argument vectors). */
+export type StringList = readonly string[];
+
+/** Read-only ordered list of tool names exposed by an MCP server. */
+export type ToolList = readonly string[];
+
+/**
+ * Permissive object shape: a known set of native fields plus an open
+ * string-keyed index signature of JSON values for forward compatibility
+ * with undocumented or platform-specific extension fields.
+ */
+export type PermissiveConfigObject = Readonly<
+  Record<string, JsonValue | undefined>
+>;
+
+/** Common fields shared by every stdio (subprocess) MCP server. */
+export interface StdioServerBase {
+  /** Absolute path or executable name resolvable via the user's PATH. */
+  command: string;
+  /** Command-line arguments passed to the server process. */
+  args?: StringList;
+  /** Environment variables injected into the server process. */
+  env?: StringMap;
+  /** Working directory for the server process. */
+  cwd?: string;
+}
+
+/** Common fields shared by every remote (HTTP/SSE/WebSocket) MCP server. */
+export interface RemoteServerBase {
+  /** URL the MCP client connects to. */
+  url: string;
+  /** HTTP headers attached to requests made to the server. */
+  headers?: StringMap;
+}
+
+/**
+ * OAuth configuration: an object of arbitrary OAuth-related fields, or
+ * `false` to explicitly disable OAuth for the server.
+ */
+export type OAuthConfig = PermissiveConfigObject | false;
+
+/**
+ * `fetch`-style request init shape, restricted to a known `headers`
+ * override plus an open index signature for additional init fields.
+ */
+export type RequestInitConfig = PermissiveConfigObject & {
+  readonly headers?: StringMap;
+};
+
+/** Read-only string-keyed map of named MCP servers. */
+export type McpServerMap<TServer> = Readonly<Record<string, TServer>>;

--- a/apps/cli/src/platforms/agents/windsurf.ts
+++ b/apps/cli/src/platforms/agents/windsurf.ts
@@ -1,6 +1,12 @@
 // Windsurf agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type {
+  AgentDefinition,
+  McpServerMap,
+  PermissiveConfigObject,
+  RemoteServerBase,
+  StdioServerBase,
+} from './types.js';
 
 export const windsurf: AgentDefinition = {
   id: 'windsurf',
@@ -22,3 +28,26 @@ export const windsurf: AgentDefinition = {
   executableNames: ['windsurf'],
   mcp: notImplementedMcpHandlers('windsurf'),
 };
+
+/** Native Windsurf MCP config: `mcpServers` map; servers may be stdio (`command`/`args`/`env`) or remote. Per docs the remote URL may appear as either `url` or `serverUrl` depending on doc version. */
+
+export interface WindsurfMcpConfig {
+  readonly mcpServers?: McpServerMap<WindsurfMcpServer>;
+}
+
+/** Windsurf server: union of stdio and remote transports with permissive extension fields. */
+
+export type WindsurfMcpServer = (WindsurfStdioServer | WindsurfRemoteServer) &
+  PermissiveConfigObject;
+
+/** Stdio transport: local process invocation. */
+
+export type WindsurfStdioServer = StdioServerBase;
+
+/** Remote transport. Windsurf docs note the URL may surface as `url` or `serverUrl`; both are accepted. */
+
+export interface WindsurfRemoteServer extends RemoteServerBase {
+  /** Alias for `url`; present in some Windsurf doc versions. */
+
+  readonly serverUrl?: string;
+}

--- a/apps/cli/src/platforms/agents/zed.ts
+++ b/apps/cli/src/platforms/agents/zed.ts
@@ -1,6 +1,6 @@
 // Zed agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type { AgentDefinition, McpServerMap, StringMap } from './types.js';
 
 export const zed: AgentDefinition = {
   id: 'zed',
@@ -32,3 +32,41 @@ export const zed: AgentDefinition = {
   executableNames: ['zed'],
   mcp: notImplementedMcpHandlers('zed'),
 };
+
+/**
+ * Native Zed MCP config shape. Zed refers to MCP servers as
+ * "context servers" and stores them under the top-level
+ * `context_servers` map. Server entries are a discriminated union
+ * on the presence of `command` (stdio) vs `url` (remote) - the
+ * documented Zed format does not include an explicit `type` field.
+ */
+export interface ZedMcpConfig {
+  readonly context_servers?: McpServerMap<ZedMcpServer>;
+}
+
+/** Zed server entry: union of stdio and remote transports. */
+export type ZedMcpServer = ZedStdioServer | ZedRemoteServer;
+
+/**
+ * Stdio transport: a local subprocess. `command` is required; `args`
+ * and `env` are optional and follow standard MCP server conventions.
+ */
+export interface ZedStdioServer {
+  /** Absolute path or executable name resolvable via the user's PATH. */
+  command: string;
+  /** Command-line arguments passed to the server process. */
+  args?: readonly string[];
+  /** Environment variables injected into the server process. */
+  env?: StringMap;
+}
+
+/**
+ * Remote transport: a URL-based server (HTTP/SSE/etc). `url` is
+ * required; `headers` are optional HTTP headers.
+ */
+export interface ZedRemoteServer {
+  /** URL the MCP client connects to. */
+  url: string;
+  /** HTTP headers attached to requests made to the server. */
+  headers?: StringMap;
+}


### PR DESCRIPTION
## Summary

TypeScript-only setup PR that defines the native MCP config shape for every supported local MCP-capable agent. No MCP file reading or writing ships here; these types are the future-read targets.

## What ships

- 11 shared MCP config primitives in `agents/types.ts` (JsonPrimitive, JsonValue, StringMap, StringList, ToolList, PermissiveConfigObject, StdioServerBase, RemoteServerBase, OAuthConfig, RequestInitConfig, McpServerMap).
- 12 per-agent `<AgentName>McpConfig` type exports colocated in their owning agent files (claude-code, claude-desktop, opencode, github-copilot-vscode, github-copilot-cli, cursor, windsurf, cline, roo-code, continue, zed, openai-codex).
- Type-contract spec (`mcp-config-types.spec.ts`) with positive fixtures for every supported type plus runtime assertions for unsupported-agent absence (`aider`, `github-copilot-cloud-agent`) and changed-file strictness (`@ts-expect-error` / `@ts-ignore` / `: any` / `as any`).
- AGENTS.md contributor note on the typed-config convention and the docs-vs-registry source-of-truth rule.

## Source-of-truth rule

When the agent file's `mcpLocations` registry metadata conflicts with the canonical future-read schema in `docs/coding-platform-mcp-configurations.md`, types follow the docs; registry detection metadata itself is updated in a separate, detection-focused PR.

Concretely, this PR applies that rule to:
- `github-copilot-cli.ts`: types use top-level `mcpServers` per docs; the existing `hosts.json` + `servers` registry metadata is intentionally untouched.
- `continue.ts`: types use `ContinueYamlMcpConfig | ContinueImportedJsonMcpConfig` per docs; the existing `.continue/config.json` registry metadata is intentionally untouched.

## What does not ship

- No MCP file readers or writers. `parseMcpConfig` and `detect` are unchanged.
- No new runtime dependencies. `@overture/os` and `@jander99/overture` dependency surface is unchanged.
- No `any`, `@ts-ignore`, or `@ts-expect-error` in the new code.
- No registry drift: every supported agent's `id`, `displayName`, `installMarkers`, `mcpLocations`, `detectionStrategy`, `mcpSupport`, and `executableNames` are byte-identical to main.

## Verification

- `yarn nx lint @jander99/overture --skip-nx-cache` exits 0.
- `npx tsc -b apps/cli/tsconfig.json` exits 0.
- `yarn npm audit --all --recursive --severity=high` reports 0 advisories.
- `npx prettier --check .` exits 0.
- `yarn nx test @jander99/overture --skip-nx-cache` exits 0 (119/119 across 7 spec files, including 27 in the new mcp-config-types spec).
- `yarn nx build @jander99/overture --skip-nx-cache` exits 0.
- `node apps/cli/scripts/verify-package.mjs` exits 0 (`detect --json` returns 14 platforms in the canonical order).
- `overture detect --json` produces byte-identical output to main (same 14 platform IDs, same order, same field set).

Refs: `.omo/plans/typed-agent-mcp-designs.md`.