### PR TITLE
feat(agents): typed mcp config readers

### DIFF
--- a/apps/cli/src/platforms/agents/claude-code.ts
+++ b/apps/cli/src/platforms/agents/claude-code.ts
@@ -7,8 +7,11 @@ import type {
   RemoteServerBase,
   StdioServerBase,
   StringMap,
+  AgentMcpReadResult,
 } from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 export const claudeCode: AgentDefinition = {
   id: 'claude-code',
   displayName: 'Claude Code',
@@ -52,7 +55,10 @@ export const claudeCode: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['claude'],
-  mcp: notImplementedMcpHandlers('claude-code'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(claudeCode, ctx),
+    write: notImplementedMcpHandlers('claude-code').write,
+  },
 };
 
 /** Native Claude Code MCP config: `mcpServers` map; each server is either a stdio transport or a remote transport (HTTP / streamable-http / SSE / WebSocket). The top level may also carry a local `imports` map (Claude Code's local-imports feature). */
@@ -85,4 +91,19 @@ export interface ClaudeCodeStdioServer extends StdioServerBase {
 export interface ClaudeCodeRemoteServer extends RemoteServerBase {
   /** Transport discriminator. Literal values include 'http', 'streamable-http', 'sse', 'ws'; unknown strings are tolerated for forward compatibility. */
   readonly type?: string;
+}
+
+/**
+ * Read the agent's MCP config into the typed `ClaudeCodeMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `claudeCode.mcp.read`, but with the generic `config` field
+ * narrowed to `ClaudeCodeMcpConfig | null`.
+ */
+export async function readClaudeCodeMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<ClaudeCodeMcpConfig>> {
+  return readAgentMcpConfig(claudeCode, ctx) as Promise<
+    AgentMcpReadResult<ClaudeCodeMcpConfig>
+  >;
 }

--- a/apps/cli/src/platforms/agents/claude-desktop.ts
+++ b/apps/cli/src/platforms/agents/claude-desktop.ts
@@ -4,8 +4,11 @@ import type {
   AgentDefinition,
   McpServerMap,
   StdioServerBase,
+  AgentMcpReadResult,
 } from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 export const claudeDesktop: AgentDefinition = {
   id: 'claude-desktop',
   displayName: 'Claude Desktop',
@@ -73,7 +76,10 @@ export const claudeDesktop: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-  mcp: notImplementedMcpHandlers('claude-desktop'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(claudeDesktop, ctx),
+    write: notImplementedMcpHandlers('claude-desktop').write,
+  },
 };
 
 /** Native Claude Desktop MCP config: `mcpServers` map; each server is stdio-only (no remote transport supported). */
@@ -85,3 +91,18 @@ export interface ClaudeDesktopMcpConfig {
 /** Claude Desktop server: local process invocation via stdio. */
 
 export type ClaudeDesktopMcpServer = StdioServerBase;
+
+/**
+ * Read the agent's MCP config into the typed `ClaudeDesktopMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `claudeDesktop.mcp.read`, but with the generic `config` field
+ * narrowed to `ClaudeDesktopMcpConfig | null`.
+ */
+export async function readClaudeDesktopMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<ClaudeDesktopMcpConfig>> {
+  return readAgentMcpConfig(claudeDesktop, ctx) as Promise<
+    AgentMcpReadResult<ClaudeDesktopMcpConfig>
+  >;
+}

--- a/apps/cli/src/platforms/agents/cline.ts
+++ b/apps/cli/src/platforms/agents/cline.ts
@@ -1,8 +1,10 @@
 // Cline agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type { AgentDefinition, AgentMcpReadResult } from './types.js';
 import type { McpServerMap, StringList, StringMap } from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 /**
  * Native Cline MCP server entry. Cline accepts either stdio-style servers
  * (with `command`/`args`/`env`) or remote servers (with `url`/`headers`)
@@ -99,5 +101,23 @@ export const cline: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-  mcp: notImplementedMcpHandlers('cline'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(cline, ctx),
+    write: notImplementedMcpHandlers('cline').write,
+  },
 };
+
+/**
+ * Read the agent's MCP config into the typed `ClineMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `cline.mcp.read`, but with the generic `config` field
+ * narrowed to `ClineMcpConfig | null`.
+ */
+export async function readClineMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<ClineMcpConfig>> {
+  return readAgentMcpConfig(cline, ctx) as Promise<
+    AgentMcpReadResult<ClineMcpConfig>
+  >;
+}

--- a/apps/cli/src/platforms/agents/continue.ts
+++ b/apps/cli/src/platforms/agents/continue.ts
@@ -1,11 +1,13 @@
 // Continue agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type { AgentDefinition, AgentMcpReadResult } from './types.js';
 import type { RequestInitConfig, StringList, StringMap } from './types.js';
 import type { ClaudeCodeMcpConfig } from './claude-code.js';
 import type { CursorMcpConfig } from './cursor.js';
 import type { ClineMcpConfig } from './cline.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 /**
  * Native Continue MCP server entry inside a standalone YAML config.
  * The `name` field is required because Continue identifies servers by
@@ -91,5 +93,23 @@ export const continueDef: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-  mcp: notImplementedMcpHandlers('continue'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(continueDef, ctx),
+    write: notImplementedMcpHandlers('continue').write,
+  },
 };
+
+/**
+ * Read the agent's MCP config into the typed `ContinueMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `continueDef.mcp.read`, but with the generic `config` field
+ * narrowed to `ContinueMcpConfig | null`.
+ */
+export async function readContinueMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<ContinueMcpConfig>> {
+  return readAgentMcpConfig(continueDef, ctx) as Promise<
+    AgentMcpReadResult<ContinueMcpConfig>
+  >;
+}

--- a/apps/cli/src/platforms/agents/cursor.ts
+++ b/apps/cli/src/platforms/agents/cursor.ts
@@ -6,8 +6,11 @@ import type {
   PermissiveConfigObject,
   RemoteServerBase,
   StdioServerBase,
+  AgentMcpReadResult,
 } from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 export const cursor: AgentDefinition = {
   id: 'cursor',
   displayName: 'Cursor',
@@ -51,7 +54,10 @@ export const cursor: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: ['cursor'],
-  mcp: notImplementedMcpHandlers('cursor'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(cursor, ctx),
+    write: notImplementedMcpHandlers('cursor').write,
+  },
 };
 
 /** Native Cursor MCP config: `mcpServers` map; servers may be stdio (with `command`/`args`/`env`) or remote (with `url`/`headers`). Per-server `envFile` overrides; static OAuth-like credentials live under `auth`. */
@@ -94,3 +100,18 @@ export type CursorAuth = PermissiveConfigObject & {
 
   readonly scopes?: readonly string[];
 };
+
+/**
+ * Read the agent's MCP config into the typed `CursorMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `cursor.mcp.read`, but with the generic `config` field
+ * narrowed to `CursorMcpConfig | null`.
+ */
+export async function readCursorMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<CursorMcpConfig>> {
+  return readAgentMcpConfig(cursor, ctx) as Promise<
+    AgentMcpReadResult<CursorMcpConfig>
+  >;
+}

--- a/apps/cli/src/platforms/agents/fixtures/mcp-configs/claude-desktop.json
+++ b/apps/cli/src/platforms/agents/fixtures/mcp-configs/claude-desktop.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "REDACTED"
+      }
+    }
+  }
+}

--- a/apps/cli/src/platforms/agents/fixtures/mcp-configs/openai-codex.toml
+++ b/apps/cli/src/platforms/agents/fixtures/mcp-configs/openai-codex.toml
@@ -1,0 +1,12 @@
+# Real OpenAI Codex MCP config fixture used by the smoke tests in
+# apps/cli/src/platforms/agents/mcp-config-readers.spec.ts.
+# The shape mirrors the documented `mcp_servers` table in `.codex/config.toml`.
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+startup_timeout_sec = 30
+
+[mcp_servers.fetch]
+url = "https://mcp.example.com/fetch"
+bearer_token_env_var = "MCP_FETCH_TOKEN"

--- a/apps/cli/src/platforms/agents/github-copilot-cli.ts
+++ b/apps/cli/src/platforms/agents/github-copilot-cli.ts
@@ -6,8 +6,11 @@ import type {
   StringList,
   StringMap,
   ToolList,
+  AgentMcpReadResult,
 } from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 export const githubCopilotCli: AgentDefinition = {
   id: 'github-copilot-cli',
   displayName: 'GitHub Copilot CLI',
@@ -35,15 +38,19 @@ export const githubCopilotCli: AgentDefinition = {
       base: 'config',
       relativePath: 'github-copilot/hosts.json',
       format: 'json',
-      topLevelKey: 'servers',
-      notes: 'User-global MCP servers under servers key',
+      topLevelKey: 'mcpServers',
+      notes:
+        'User-global MCP servers under mcpServers key (matches the typed config contract; the historical `servers` key in the registry metadata is stale per the Copilot CLI docs)',
     },
   ],
   defaultConfidence: 'medium',
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['copilot'],
-  mcp: notImplementedMcpHandlers('github-copilot-cli'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(githubCopilotCli, ctx),
+    write: notImplementedMcpHandlers('github-copilot-cli').write,
+  },
 };
 
 /**
@@ -84,4 +91,19 @@ export type GitHubCopilotCliServer =
  */
 export interface GitHubCopilotCliMcpConfig {
   mcpServers?: McpServerMap<GitHubCopilotCliServer>;
+}
+
+/**
+ * Read the agent's MCP config into the typed `GitHubCopilotCliMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `githubCopilotCli.mcp.read`, but with the generic `config` field
+ * narrowed to `GitHubCopilotCliMcpConfig | null`.
+ */
+export async function readGitHubCopilotCliMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<GitHubCopilotCliMcpConfig>> {
+  return readAgentMcpConfig(githubCopilotCli, ctx) as Promise<
+    AgentMcpReadResult<GitHubCopilotCliMcpConfig>
+  >;
 }

--- a/apps/cli/src/platforms/agents/github-copilot-vscode.ts
+++ b/apps/cli/src/platforms/agents/github-copilot-vscode.ts
@@ -8,7 +8,10 @@ import type {
   RequestInitConfig,
   StdioServerBase,
   StringMap,
+  AgentMcpReadResult,
 } from './types.js';
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 export const githubCopilotVscode: AgentDefinition = {
   id: 'github-copilot-vscode',
   displayName: 'GitHub Copilot in VS Code',
@@ -52,7 +55,10 @@ export const githubCopilotVscode: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-  mcp: notImplementedMcpHandlers('github-copilot-vscode'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(githubCopilotVscode, ctx),
+    write: notImplementedMcpHandlers('github-copilot-vscode').write,
+  },
 };
 
 /**
@@ -123,4 +129,19 @@ export type GitHubCopilotVSCodeServer =
 export interface GitHubCopilotVSCodeMcpConfig {
   servers?: McpServerMap<GitHubCopilotVSCodeServer>;
   inputs?: readonly GitHubCopilotVSCodeInput[];
+}
+
+/**
+ * Read the agent's MCP config into the typed `GitHubCopilotVSCodeMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `githubCopilotVscode.mcp.read`, but with the generic `config` field
+ * narrowed to `GitHubCopilotVSCodeMcpConfig | null`.
+ */
+export async function readGitHubCopilotVSCodeMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<GitHubCopilotVSCodeMcpConfig>> {
+  return readAgentMcpConfig(githubCopilotVscode, ctx) as Promise<
+    AgentMcpReadResult<GitHubCopilotVSCodeMcpConfig>
+  >;
 }

--- a/apps/cli/src/platforms/agents/mcp-config-readers.spec.ts
+++ b/apps/cli/src/platforms/agents/mcp-config-readers.spec.ts
@@ -1,0 +1,519 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve as pathResolve } from 'node:path';
+import type { AgentDefinition } from './types.js';
+import type { PathResolutionContext, PlatformId } from '../types.js';
+
+// Per-test scratch directory. The reader resolves paths against
+// PathResolutionContext, so we point homeDir/configDir/workspaceDir at a
+// fresh tmpdir and seed fixture files there. Real-fs tests are more
+// reliable than module-mocked tests in the @nx/vitest executor's pool
+// configuration (cross-file module cache can defeat vi.mock for
+// node:fs/promises).
+let scratchDir = '';
+
+// Import after the test setup so each test gets a fresh scratch dir
+// before exercising the readers.
+import { claudeCode } from './claude-code.js';
+import { claudeDesktop } from './claude-desktop.js';
+import { opencode } from './opencode.js';
+import { githubCopilotVscode } from './github-copilot-vscode.js';
+import { githubCopilotCli } from './github-copilot-cli.js';
+import { cursor } from './cursor.js';
+import { windsurf } from './windsurf.js';
+import { cline } from './cline.js';
+import { rooCode } from './roo-code.js';
+import { continueDef } from './continue.js';
+import { zed } from './zed.js';
+import { openaiCodex } from './openai-codex.js';
+import { aider } from './aider.js';
+import { githubCopilotCloudAgent } from './github-copilot-cloud-agent.js';
+
+beforeEach(async () => {
+  scratchDir = await mkdtemp(join(tmpdir(), 'overture-reader-'));
+  // Pre-create the per-platform config subdirs so the reader can resolve
+  // base:'config' and base:'workspace' lookups without hitting ENOENT
+  // for the parent.
+  await mkdir(join(scratchDir, '.config'), { recursive: true });
+  await mkdir(join(scratchDir, 'workspace'), { recursive: true });
+});
+
+afterEach(async () => {
+  if (scratchDir) {
+    await rm(scratchDir, { recursive: true, force: true });
+  }
+});
+
+function readerCtx(
+  overrides: Partial<PathResolutionContext> = {},
+): PathResolutionContext {
+  return {
+    homeDir: scratchDir,
+    configDir: join(scratchDir, '.config'),
+    workspaceDir: join(scratchDir, 'workspace'),
+    platform: 'linux',
+    ...overrides,
+  };
+}
+
+async function seed(
+  base: 'home' | 'config' | 'workspace',
+  relativePath: string,
+  contents: string,
+  ctx: PathResolutionContext,
+): Promise<string> {
+  const dir =
+    base === 'home'
+      ? ctx.homeDir
+      : base === 'config'
+        ? ctx.configDir
+        : ctx.workspaceDir;
+  const fullPath = join(dir, relativePath);
+  await mkdir(dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, contents, 'utf8');
+  return fullPath;
+}
+
+describe('per-agent mcp.read returns typed *McpConfig shape', () => {
+  it('claude-code reads mcpServers from .claude.json', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'home',
+      '.claude.json',
+      JSON.stringify({ mcpServers: { x: { command: 'y' } } }),
+      ctx,
+    );
+    const result = await claudeCode.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    expect(result.parseError).toBeUndefined();
+    if (result.config !== null) {
+      const config = result.config as {
+        mcpServers?: { x?: { command?: string } };
+      };
+      expect(config.mcpServers?.x?.command).toBe('y');
+    }
+  });
+
+  it('claude-desktop reads mcpServers from Linux config path', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'config',
+      'Claude/claude_desktop_config.json',
+      JSON.stringify({
+        mcpServers: { s: { command: 'node', args: ['m.js'] } },
+      }),
+      ctx,
+    );
+    const result = await claudeDesktop.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcpServers?: { s?: { command?: string } };
+      };
+      expect(config.mcpServers?.s?.command).toBe('node');
+    }
+  });
+
+  it('opencode reads mcp map from opencode.json', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'config',
+      'opencode/opencode.json',
+      JSON.stringify({
+        mcp: { s: { type: 'local', command: ['npx', '-y', 'mcp'] } },
+      }),
+      ctx,
+    );
+    const result = await opencode.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as { mcp?: { s?: { type?: string } } };
+      expect(config.mcp?.s?.type).toBe('local');
+    }
+  });
+
+  it('github-copilot-vscode reads servers map from .vscode/mcp.json', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'home',
+      '.vscode/mcp.json',
+      JSON.stringify({ servers: { s: { type: 'stdio', command: 'c' } } }),
+      ctx,
+    );
+    const result = await githubCopilotVscode.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        servers?: { s?: { command?: string } };
+      };
+      expect(config.servers?.s?.command).toBe('c');
+    }
+  });
+
+  it('github-copilot-cli reads mcpServers from hosts.json', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'config',
+      'github-copilot/hosts.json',
+      JSON.stringify({ mcpServers: { s: { type: 'local', command: 'c' } } }),
+      ctx,
+    );
+    const result = await githubCopilotCli.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcpServers?: { s?: { type?: string } };
+      };
+      expect(config.mcpServers?.s?.type).toBe('local');
+    }
+  });
+
+  it('cursor reads mcpServers from .cursor/mcp.json', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'home',
+      '.cursor/mcp.json',
+      JSON.stringify({ mcpServers: { s: { command: 'c' } } }),
+      ctx,
+    );
+    const result = await cursor.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcpServers?: { s?: { command?: string } };
+      };
+      expect(config.mcpServers?.s?.command).toBe('c');
+    }
+  });
+
+  it('windsurf reads mcpServers from .codeium/windsurf/mcp_config.json', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'home',
+      '.codeium/windsurf/mcp_config.json',
+      JSON.stringify({ mcpServers: { s: { command: 'c' } } }),
+      ctx,
+    );
+    const result = await windsurf.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcpServers?: { s?: { command?: string } };
+      };
+      expect(config.mcpServers?.s?.command).toBe('c');
+    }
+  });
+
+  it('cline reads mcpServers from Cline global storage', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'config',
+      'Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json',
+      JSON.stringify({ mcpServers: { s: { command: 'c' } } }),
+      ctx,
+    );
+    const result = await cline.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcpServers?: { s?: { command?: string } };
+      };
+      expect(config.mcpServers?.s?.command).toBe('c');
+    }
+  });
+
+  it('roo-code reads mcpServers from Roo Code global storage', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'config',
+      'Code/User/globalStorage/roo-cline.roo-cline/settings/mcp_settings.json',
+      JSON.stringify({ mcpServers: { s: { command: 'c' } } }),
+      ctx,
+    );
+    const result = await rooCode.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcpServers?: { s?: { command?: string } };
+      };
+      expect(config.mcpServers?.s?.command).toBe('c');
+    }
+  });
+
+  it('continue reads mcpServers from .continue/config.json', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'home',
+      '.continue/config.json',
+      JSON.stringify({ mcpServers: { s: { command: 'c' } } }),
+      ctx,
+    );
+    const result = await continueDef.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcpServers?: { s?: { command?: string } };
+      };
+      expect(config.mcpServers?.s?.command).toBe('c');
+    }
+  });
+
+  it('zed reads context_servers from zed/settings.json', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'config',
+      'zed/settings.json',
+      JSON.stringify({ context_servers: { s: { command: 'c' } } }),
+      ctx,
+    );
+    const result = await zed.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        context_servers?: { s?: { command?: string } };
+      };
+      expect(config.context_servers?.s?.command).toBe('c');
+    }
+  });
+
+  it('openai-codex reads mcp_servers TOML from .codex/config.toml', async () => {
+    const ctx = readerCtx();
+    await seed(
+      'home',
+      '.codex/config.toml',
+      '[mcp_servers.s]\ncommand = "codex-mcp"\n',
+      ctx,
+    );
+    const result = await openaiCodex.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcp_servers?: { s?: { command?: string } };
+      };
+      expect(config.mcp_servers?.s?.command).toBe('codex-mcp');
+    }
+  });
+});
+
+// Missing-file semantics: every applicable location ENOENT, reader reports
+// "not configured" without throwing.
+describe('per-agent mcp.read handles missing files', () => {
+  const supported: readonly {
+    id: PlatformId;
+    agent: AgentDefinition;
+  }[] = [
+    { id: 'claude-code', agent: claudeCode },
+    { id: 'claude-desktop', agent: claudeDesktop },
+    { id: 'opencode', agent: opencode },
+    { id: 'github-copilot-vscode', agent: githubCopilotVscode },
+    { id: 'github-copilot-cli', agent: githubCopilotCli },
+    { id: 'cursor', agent: cursor },
+    { id: 'windsurf', agent: windsurf },
+    { id: 'cline', agent: cline },
+    { id: 'roo-code', agent: rooCode },
+    { id: 'continue', agent: continueDef },
+    { id: 'zed', agent: zed },
+    { id: 'openai-codex', agent: openaiCodex },
+  ];
+
+  for (const { id, agent } of supported) {
+    it(`${id}: ENOENT yields config=null, nonEmpty=false, no parseError`, async () => {
+      const result = await agent.mcp.read(readerCtx({ platform: 'linux' }));
+      expect(result.config).toBeNull();
+      expect(result.nonEmpty).toBe(false);
+      expect(result.parseError).toBeUndefined();
+    });
+  }
+});
+
+// Malformed input: parse error surfaced, no typed value.
+describe('per-agent mcp.read surfaces parseError on malformed input', () => {
+  it('claude-code: invalid JSON returns parseError, no config', async () => {
+    const ctx = readerCtx();
+    await seed('home', '.claude.json', '{ "mcpServers": ', ctx);
+    const result = await claudeCode.mcp.read(ctx);
+    expect(result.config).toBeNull();
+    expect(result.nonEmpty).toBe(false);
+    expect(result.parseError).toBeTruthy();
+  });
+
+  it('openai-codex: invalid TOML returns parseError, no config', async () => {
+    const ctx = readerCtx();
+    await seed('home', '.codex/config.toml', '[[[invalid', ctx);
+    const result = await openaiCodex.mcp.read(ctx);
+    expect(result.config).toBeNull();
+    expect(result.nonEmpty).toBe(false);
+    expect(result.parseError).toBeTruthy();
+  });
+});
+
+// Empty / missing top-level key: no parseError, no typed config.
+describe('per-agent mcp.read handles empty config', () => {
+  it('claude-code: empty mcpServers returns config=null, nonEmpty=false', async () => {
+    const ctx = readerCtx();
+    await seed('home', '.claude.json', '{"mcpServers": {}}', ctx);
+    const result = await claudeCode.mcp.read(ctx);
+    expect(result.config).toBeNull();
+    expect(result.nonEmpty).toBe(false);
+    expect(result.parseError).toBeUndefined();
+  });
+
+  it('claude-code: missing top-level key returns config=null, no parseError', async () => {
+    const ctx = readerCtx();
+    await seed('home', '.claude.json', '{}', ctx);
+    const result = await claudeCode.mcp.read(ctx);
+    expect(result.config).toBeNull();
+    expect(result.nonEmpty).toBe(false);
+    expect(result.parseError).toBeUndefined();
+  });
+});
+
+// Platform filtering: only mcpLocations matching ctx.platform are probed.
+describe('per-agent mcp.read respects platform filter', () => {
+  it('claude-desktop: linux ctx reads only the Linux mcpLocation', async () => {
+    const ctx = readerCtx({ platform: 'linux' });
+    await seed(
+      'config',
+      'Claude/claude_desktop_config.json',
+      JSON.stringify({ mcpServers: { s: { command: 'c' } } }),
+      ctx,
+    );
+    const result = await claudeDesktop.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.location?.resolvedPath).toBe(
+      join(ctx.configDir, 'Claude/claude_desktop_config.json'),
+    );
+  });
+
+  it('claude-desktop: macos ctx reads only the macOS mcpLocation', async () => {
+    const ctx = readerCtx({ platform: 'darwin' });
+    await seed(
+      'home',
+      'Library/Application Support/Claude/claude_desktop_config.json',
+      JSON.stringify({ mcpServers: { s: { command: 'c' } } }),
+      ctx,
+    );
+    const result = await claudeDesktop.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.location?.resolvedPath).toBe(
+      join(
+        ctx.homeDir,
+        'Library/Application Support/Claude/claude_desktop_config.json',
+      ),
+    );
+  });
+});
+
+// Unsupported agents: still placeholder behavior, NOT silent success.
+describe('per-agent mcp.read falls back to placeholder for unsupported agents', () => {
+  it('aider: mcp.read rejects with "not implemented"', async () => {
+    await expect(aider.mcp.read(readerCtx())).rejects.toThrow(
+      /MCP read for agent 'aider' is not implemented yet/,
+    );
+  });
+
+  it('github-copilot-cloud-agent: mcp.read rejects with "not implemented"', async () => {
+    await expect(githubCopilotCloudAgent.mcp.read(readerCtx())).rejects.toThrow(
+      /MCP read for agent 'github-copilot-cloud-agent' is not implemented yet/,
+    );
+  });
+});
+
+// Multi-location agents: first mcpLocation missing, second present — the
+// reader should return the second location's result.
+describe('per-agent mcp.read skips missing locations', () => {
+  it('claude-code: first mcpLocation missing, second present', async () => {
+    const ctx = readerCtx();
+    // .claude.json (home) is missing; .mcp.json (workspace) is present.
+    await seed(
+      'workspace',
+      '.mcp.json',
+      JSON.stringify({ mcpServers: { s: { command: 'c' } } }),
+      ctx,
+    );
+    const result = await claudeCode.mcp.read(ctx);
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    expect(result.location?.resolvedPath).toBe(
+      join(ctx.workspaceDir, '.mcp.json'),
+    );
+  });
+});
+
+// Real-fs smoke tests using the fixtures/ directory. These tests prove
+// the reader pipeline works against actual disk files (not just
+// per-test tmpdirs) and can be reused by future integration tests.
+//
+// Fixture path is relative to this spec file: ./fixtures/mcp-configs/.
+import { readFile as readFileRaw } from 'node:fs/promises';
+
+const fixtureDir = pathResolve(
+  process.cwd(),
+  'apps/cli/src/platforms/agents/fixtures/mcp-configs',
+);
+
+describe('per-agent mcp.read smoke: real-fs fixtures', () => {
+  it('claude-desktop reads the fixture file and returns the typed config', async () => {
+    const contents = await readFileRaw(
+      pathResolve(fixtureDir, 'claude-desktop.json'),
+      'utf8',
+    );
+    const dest = join(
+      scratchDir,
+      '.config',
+      'Claude',
+      'claude_desktop_config.json',
+    );
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFile(dest, contents, 'utf8');
+
+    const result = await claudeDesktop.mcp.read(
+      readerCtx({ platform: 'linux' }),
+    );
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcpServers?: Record<string, { command?: string }>;
+      };
+      expect(config.mcpServers?.filesystem?.command).toBe('npx');
+      expect(config.mcpServers?.github?.command).toBe('npx');
+    }
+  });
+
+  it('openai-codex reads the fixture TOML and returns the typed config', async () => {
+    const contents = await readFileRaw(
+      pathResolve(fixtureDir, 'openai-codex.toml'),
+      'utf8',
+    );
+    const dest = join(scratchDir, '.codex', 'config.toml');
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFile(dest, contents, 'utf8');
+
+    const result = await openaiCodex.mcp.read(readerCtx({ platform: 'linux' }));
+    expect(result.config).not.toBeNull();
+    expect(result.nonEmpty).toBe(true);
+    if (result.config !== null) {
+      const config = result.config as {
+        mcp_servers?: Record<string, { command?: string; url?: string }>;
+      };
+      expect(config.mcp_servers?.filesystem?.command).toBe('npx');
+      expect(config.mcp_servers?.fetch?.url).toBe(
+        'https://mcp.example.com/fetch',
+      );
+    }
+  });
+});

--- a/apps/cli/src/platforms/agents/openai-codex.ts
+++ b/apps/cli/src/platforms/agents/openai-codex.ts
@@ -1,7 +1,13 @@
 // OpenAI Codex agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition, StringMap } from './types.js';
+import type {
+  AgentDefinition,
+  StringMap,
+  AgentMcpReadResult,
+} from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 export const openaiCodex: AgentDefinition = {
   id: 'openai-codex',
   displayName: 'OpenAI Codex',
@@ -45,7 +51,10 @@ export const openaiCodex: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['codex'],
-  mcp: notImplementedMcpHandlers('openai-codex'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(openaiCodex, ctx),
+    write: notImplementedMcpHandlers('openai-codex').write,
+  },
 };
 
 /**
@@ -103,4 +112,19 @@ export interface OpenAICodexMcpServer {
   http_headers?: StringMap;
   /** Remote: HTTP headers sourced from environment variables. */
   env_http_headers?: StringMap;
+}
+
+/**
+ * Read the agent's MCP config into the typed `OpenAICodexMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `openaiCodex.mcp.read`, but with the generic `config` field
+ * narrowed to `OpenAICodexMcpConfig | null`.
+ */
+export async function readOpenAICodexMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<OpenAICodexMcpConfig>> {
+  return readAgentMcpConfig(openaiCodex, ctx) as Promise<
+    AgentMcpReadResult<OpenAICodexMcpConfig>
+  >;
 }

--- a/apps/cli/src/platforms/agents/opencode.ts
+++ b/apps/cli/src/platforms/agents/opencode.ts
@@ -1,7 +1,14 @@
 // OpenCode agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition, OAuthConfig, StringMap } from './types.js';
+import type {
+  AgentDefinition,
+  OAuthConfig,
+  StringMap,
+  AgentMcpReadResult,
+} from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 /**
  * Discriminated union of MCP server entries supported by OpenCode's
  * `mcp` config. The `type` field selects the transport:
@@ -77,5 +84,23 @@ export const opencode: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['opencode'],
-  mcp: notImplementedMcpHandlers('opencode'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(opencode, ctx),
+    write: notImplementedMcpHandlers('opencode').write,
+  },
 };
+
+/**
+ * Read the agent's MCP config into the typed `OpenCodeMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `opencode.mcp.read`, but with the generic `config` field
+ * narrowed to `OpenCodeMcpConfig | null`.
+ */
+export async function readOpenCodeMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<OpenCodeMcpConfig>> {
+  return readAgentMcpConfig(opencode, ctx) as Promise<
+    AgentMcpReadResult<OpenCodeMcpConfig>
+  >;
+}

--- a/apps/cli/src/platforms/agents/read-mcp-config.ts
+++ b/apps/cli/src/platforms/agents/read-mcp-config.ts
@@ -1,0 +1,159 @@
+import { readFile } from 'node:fs/promises';
+import { parseMcpConfig, type McpConfigParseResult } from '../mcp-config.js';
+import type { AgentDefinition, AgentMcpReadResult } from './types.js';
+import type { McpLocation, PathResolutionContext } from '../types.js';
+
+const SWALLOWED_CODES = new Set([
+  'ENOENT',
+  'EACCES',
+  'EPERM',
+  'ELOOP',
+  'ENOTDIR',
+]);
+
+function isSwallowed(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    'code' in err &&
+    typeof err.code === 'string' &&
+    SWALLOWED_CODES.has(err.code)
+  );
+}
+
+/**
+ * Resolves an `McpLocation` against a `PathResolutionContext`. Mirrors the
+ * private `resolveMcpLocationPath` inside `detect.ts`; duplicated here so
+ * this module is self-contained and does not require `detect.ts` to
+ * export any helper. The two implementations are intentionally kept in
+ * lockstep; if `detect.ts`'s resolution rules ever change, this helper
+ * must change too.
+ */
+function resolveMcpLocationPath(
+  loc: McpLocation,
+  ctx: PathResolutionContext,
+): string {
+  switch (loc.base) {
+    case 'home':
+      return `${ctx.homeDir}/${loc.relativePath}`;
+    case 'config':
+      return `${ctx.configDir}/${loc.relativePath}`;
+    case 'workspace':
+      return `${ctx.workspaceDir}/${loc.relativePath}`;
+    case 'absolute':
+      return loc.relativePath;
+    default: {
+      const _exhaustive: never = loc.base;
+      throw new Error(`Unsupported path base: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function locationIsApplicable(
+  loc: McpLocation,
+  ctx: PathResolutionContext,
+): boolean {
+  return loc.platforms === undefined || loc.platforms.includes(ctx.platform);
+}
+
+function nonEmptyContainer(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.keys(value).length > 0;
+  }
+  return false;
+}
+
+function toReadResultFromParse(
+  parse: McpConfigParseResult,
+  resolvedPath: string,
+  loc: McpLocation,
+): AgentMcpReadResult<unknown> {
+  const baseLocation = {
+    resolvedPath,
+    format: loc.format,
+    ...(loc.topLevelKey !== undefined ? { topLevelKey: loc.topLevelKey } : {}),
+  } as const;
+
+  if (!parse.parsed) {
+    return {
+      config: null,
+      nonEmpty: false,
+      parseError: parse.parseError ?? 'parse error',
+      location: baseLocation,
+    };
+  }
+
+  if (!parse.configured) {
+    return {
+      config: null,
+      nonEmpty: false,
+      location: baseLocation,
+    };
+  }
+
+  return {
+    config: parse.document ?? null,
+    nonEmpty: nonEmptyContainer(parse.document),
+    location: baseLocation,
+  };
+}
+
+/**
+ * Iterates the entry's `mcpLocations` filtered by `ctx.platform`, reads
+ * and parses each applicable file, and returns the first non-empty
+ * result. Missing files (`ENOENT`) are silently skipped; a missing
+ * top-level key or empty section is reported as `nonEmpty: false` with
+ * no `parseError`. A parse error on any location short-circuits and is
+ * surfaced immediately (preserving the first error encountered).
+ *
+ * Returns the typed `config` view that the per-agent reader casts to
+ * its own `*McpConfig` shape.
+ */
+export async function readAgentMcpConfig(
+  entry: AgentDefinition,
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<unknown>> {
+  const applicable = entry.mcpLocations.filter((loc) =>
+    locationIsApplicable(loc, ctx),
+  );
+
+  if (applicable.length === 0) {
+    return { config: null, nonEmpty: false };
+  }
+
+  for (const loc of applicable) {
+    const resolvedPath = resolveMcpLocationPath(loc, ctx);
+    let contents: string;
+    try {
+      contents = await readFile(resolvedPath, 'utf8');
+    } catch (err) {
+      if (isSwallowed(err)) {
+        continue;
+      }
+      return {
+        config: null,
+        nonEmpty: false,
+        parseError: `read failed: ${err instanceof Error ? err.message : String(err)}`,
+        location: { resolvedPath, format: loc.format },
+      };
+    }
+    const parse = parseMcpConfig({
+      contents,
+      format: loc.format,
+      topLevelKey: loc.topLevelKey ?? '',
+    });
+    if (!parse.parsed) {
+      return toReadResultFromParse(parse, resolvedPath, loc);
+    }
+    // The file exists at this location; report its result even if empty.
+    // We do NOT fall through to the next location because that would
+    // overwrite a present-but-empty file with a missing-file result,
+    // which contradicts the user's "I have a config but it is empty"
+    // intent.
+    return toReadResultFromParse(parse, resolvedPath, loc);
+  }
+
+  return { config: null, nonEmpty: false };
+}

--- a/apps/cli/src/platforms/agents/roo-code.ts
+++ b/apps/cli/src/platforms/agents/roo-code.ts
@@ -1,8 +1,10 @@
 // Roo Code agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition } from './types.js';
+import type { AgentDefinition, AgentMcpReadResult } from './types.js';
 import type { McpServerMap, StringList, StringMap } from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 /**
  * Native Roo Code MCP server entry. Roo accepts either stdio-style servers
  * (with `command`/`args`/`env`) or remote servers (with `url`/`headers`)
@@ -101,5 +103,23 @@ export const rooCode: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-  mcp: notImplementedMcpHandlers('roo-code'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(rooCode, ctx),
+    write: notImplementedMcpHandlers('roo-code').write,
+  },
 };
+
+/**
+ * Read the agent's MCP config into the typed `RooCodeMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `rooCode.mcp.read`, but with the generic `config` field
+ * narrowed to `RooCodeMcpConfig | null`.
+ */
+export async function readRooCodeMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<RooCodeMcpConfig>> {
+  return readAgentMcpConfig(rooCode, ctx) as Promise<
+    AgentMcpReadResult<RooCodeMcpConfig>
+  >;
+}

--- a/apps/cli/src/platforms/agents/types.ts
+++ b/apps/cli/src/platforms/agents/types.ts
@@ -3,10 +3,28 @@ import type {
   PlatformId,
   PlatformRegistryEntry,
 } from '../types.js';
+import type { McpLocationFormat } from '../types.js';
 
-/** Read result for a per-agent MCP read. Placeholder for now. */
-export interface AgentMcpReadResult {
-  servers: readonly unknown[];
+/**
+ * Read result for a per-agent MCP read.
+ * - `config` is the typed shape (`TConfig`) when at least one applicable
+ *   mcp location was found, parsed, and contained a non-empty top-level
+ *   key. `null` indicates "not configured" (file missing, empty, or only
+ *   parse errors).
+ * - `nonEmpty` is `true` when the chosen mcp location had at least one entry
+ *   under the top-level key.
+ * - `parseError` is set when a file was read but unparseable.
+ * - `location` records the resolved mcp location that produced the result.
+ */
+export interface AgentMcpReadResult<TConfig = unknown> {
+  readonly config: TConfig | null;
+  readonly nonEmpty: boolean;
+  readonly parseError?: string;
+  readonly location?: Readonly<{
+    readonly resolvedPath: string;
+    readonly format: McpLocationFormat;
+    readonly topLevelKey?: string;
+  }>;
 }
 
 /** Write input for a per-agent MCP write. Placeholder for now. */
@@ -19,10 +37,20 @@ export interface AgentMcpWriteResult {
   written: number;
 }
 
+/**
+ * Per-agent typed read handler. Each per-agent file can also export a
+ * `read<AgentName>McpConfig(ctx: PathResolutionContext):
+ * Promise<AgentMcpReadResult<<AgentName>McpConfig>>` so callers can opt
+ * into the per-agent typed shape without going through the registry.
+ */
+export type AgentMcpReadHandlerTyped<TConfig> = (
+  ctx: PathResolutionContext,
+) => Promise<AgentMcpReadResult<TConfig>>;
+
 /** Read handler signature. */
 export type AgentMcpReadHandler = (
   ctx: PathResolutionContext,
-) => Promise<AgentMcpReadResult>;
+) => Promise<AgentMcpReadResult<unknown>>;
 
 /** Write handler signature. */
 export type AgentMcpWriteHandler = (

--- a/apps/cli/src/platforms/agents/windsurf.ts
+++ b/apps/cli/src/platforms/agents/windsurf.ts
@@ -2,12 +2,15 @@
 import { notImplementedMcpHandlers } from './types.js';
 import type {
   AgentDefinition,
+  AgentMcpReadResult,
   McpServerMap,
   PermissiveConfigObject,
   RemoteServerBase,
   StdioServerBase,
 } from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 export const windsurf: AgentDefinition = {
   id: 'windsurf',
   displayName: 'Windsurf',
@@ -26,7 +29,10 @@ export const windsurf: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['windsurf'],
-  mcp: notImplementedMcpHandlers('windsurf'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(windsurf, ctx),
+    write: notImplementedMcpHandlers('windsurf').write,
+  },
 };
 
 /** Native Windsurf MCP config: `mcpServers` map; servers may be stdio (`command`/`args`/`env`) or remote. Per docs the remote URL may appear as either `url` or `serverUrl` depending on doc version. */
@@ -50,4 +56,19 @@ export interface WindsurfRemoteServer extends RemoteServerBase {
   /** Alias for `url`; present in some Windsurf doc versions. */
 
   readonly serverUrl?: string;
+}
+
+/**
+ * Read the agent's MCP config into the typed `WindsurfMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `windsurf.mcp.read`, but with the generic `config` field
+ * narrowed to `WindsurfMcpConfig | null`.
+ */
+export async function readWindsurfMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<WindsurfMcpConfig>> {
+  return readAgentMcpConfig(windsurf, ctx) as Promise<
+    AgentMcpReadResult<WindsurfMcpConfig>
+  >;
 }

--- a/apps/cli/src/platforms/agents/zed.ts
+++ b/apps/cli/src/platforms/agents/zed.ts
@@ -1,7 +1,14 @@
 // Zed agent definition.
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition, McpServerMap, StringMap } from './types.js';
+import type {
+  AgentDefinition,
+  McpServerMap,
+  StringMap,
+  AgentMcpReadResult,
+} from './types.js';
 
+import { readAgentMcpConfig } from './read-mcp-config.js';
+import type { PathResolutionContext } from '../types.js';
 export const zed: AgentDefinition = {
   id: 'zed',
   displayName: 'Zed',
@@ -30,7 +37,10 @@ export const zed: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: ['zed'],
-  mcp: notImplementedMcpHandlers('zed'),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(zed, ctx),
+    write: notImplementedMcpHandlers('zed').write,
+  },
 };
 
 /**
@@ -69,4 +79,19 @@ export interface ZedRemoteServer {
   url: string;
   /** HTTP headers attached to requests made to the server. */
   headers?: StringMap;
+}
+
+/**
+ * Read the agent's MCP config into the typed `ZedMcpConfig` shape.
+ * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
+ * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
+ * as `zed.mcp.read`, but with the generic `config` field
+ * narrowed to `ZedMcpConfig | null`.
+ */
+export async function readZedMcpConfig(
+  ctx: PathResolutionContext,
+): Promise<AgentMcpReadResult<ZedMcpConfig>> {
+  return readAgentMcpConfig(zed, ctx) as Promise<
+    AgentMcpReadResult<ZedMcpConfig>
+  >;
 }

--- a/apps/cli/src/platforms/mcp-config.ts
+++ b/apps/cli/src/platforms/mcp-config.ts
@@ -34,6 +34,16 @@ export interface McpConfigParseResult {
   parsed: boolean;
   /** Parser-reported error message (if any). */
   parseError?: string;
+  /**
+   * The parsed top-level document, when the parse succeeded and the
+   * configured top-level key was present and non-empty. Set ONLY when
+   * `parsed && configured` is true; undefined on empty, missing-key,
+   * parse-error, or topLevelKey-required paths.
+   *
+   * The per-agent MCP reader casts this into the agent's `*McpConfig`
+   * shape without re-parsing the file.
+   */
+  readonly document?: unknown;
 }
 
 export interface ParseMcpConfigOptions {
@@ -113,9 +123,13 @@ export function parseMcpConfig(
       return { configured: false, parsed: true };
     }
     const section = result[topLevelKey];
+    if (!nonEmptyContainer(section)) {
+      return { configured: false, parsed: true };
+    }
     return {
-      configured: nonEmptyContainer(section),
+      configured: true,
       parsed: true,
+      document: result,
     };
   }
 
@@ -138,9 +152,13 @@ export function parseMcpConfig(
     if (!isContainer(section)) {
       return { configured: false, parsed: true };
     }
+    if (Object.keys(section).length === 0) {
+      return { configured: false, parsed: true };
+    }
     return {
-      configured: Object.keys(section).length > 0,
+      configured: true,
       parsed: true,
+      document: result,
     };
   }
 

--- a/apps/cli/src/platforms/registry.spec.ts
+++ b/apps/cli/src/platforms/registry.spec.ts
@@ -210,6 +210,12 @@ describe('platformRegistry', () => {
     });
 
     it('every agent satisfies the AgentDefinition contract (placeholder MCP handlers present)', async () => {
+      const ctx = {
+        homeDir: '/h',
+        configDir: '/c',
+        workspaceDir: '/w',
+        platform: 'linux',
+      } as const;
       for (const a of agentRegistry) {
         expect(a.id, `agent.id`).toBeTruthy();
         expect(
@@ -220,14 +226,13 @@ describe('platformRegistry', () => {
         expect(['supported', 'unsupported', 'unknown']).toContain(a.mcpSupport);
         expect(typeof a.mcp.read, `mcp.read for ${a.id}`).toBe('function');
         expect(typeof a.mcp.write, `mcp.write for ${a.id}`).toBe('function');
-        await expect(
-          a.mcp.read({
-            homeDir: '/h',
-            configDir: '/c',
-            workspaceDir: '/w',
-            platform: 'linux',
-          }),
-        ).rejects.toThrow(/not implemented/i);
+        if (a.mcpSupport === 'unsupported') {
+          await expect(a.mcp.read(ctx)).rejects.toThrow(/not implemented/i);
+        } else {
+          const result = await a.mcp.read(ctx);
+          expect(result).toHaveProperty('config');
+          expect(result).toHaveProperty('nonEmpty');
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
Read each supported agent's MCP config into the typed `*McpConfig` shape from PR #75. Read-only, no detect/cli/sync integration in this PR. Tests are the only integration surface.

## Changes
- Add `AgentMcpReadResult<TConfig = unknown>` generic + `AgentMcpReadHandlerTyped<TConfig>` in `agents/types.ts`
- Add optional `document?: unknown` to `McpConfigParseResult` (only set when `parsed && configured`)
- Add shared read helper `readAgentMcpConfig(entry, ctx)` in `agents/read-mcp-config.ts`
- Wire 12 per-agent `mcp.read` handlers + export typed `read<Agent>McpConfig()` for each
- Correct `github-copilot-cli` registry `topLevelKey` from `'servers'` to `'mcpServers'` to match PR #75 typed contract
- 33 inline real-fs tests in `agents/mcp-config-readers.spec.ts` (no `vi.mock` for cross-file isolation)
- 2 fixture files + 2 smoke tests in `agents/fixtures/mcp-configs/`

## Scope
- 12 supported agents: typed `mcp.read` returns `{ config, nonEmpty, parseError?, location? }` with the parsed JSON document cast to `unknown` (per-agent `read<Agent>McpConfig()` cast to the typed shape)
- `aider`, `github-copilot-cloud-agent`: still placeholder (`notImplementedMcpHandlers`)
- `detect.ts`, `cli.ts`, `main.ts`: UNCHANGED

## Verification
- 154/154 tests pass (yarn nx test)
- lint clean (yarn nx lint)
- build green (yarn nx build)
- prettier clean (yarn prettier --check .)
- package verify (yarn verify-package.mjs): PASS
- scope guard: `git diff --stat main -- detect.ts cli.ts main.ts` is empty
- detect `--json` output: differs by ONE intentional registry data fix (`github-copilot-cli` `topLevelKey` `'servers'` → `'mcpServers'` to match the PR #75 typed contract). No logic changes.

## Test count
Before: 119 (118 passing + 1 envelope)
After: 154 (all passing)

## Followups
- Per-agent writers (out of scope for this PR)
- Sync/`overture sync` command (out of scope)
- YAML parser (yaml format currently returns parseError)