### PR TITLE
feat(detect): show parsed MCP server list under opencode mcp path

### DIFF
--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -444,3 +444,185 @@ it('does not contain ANSI escape sequences', () => {
   expect(json).not.toMatch(/\x1b\[/);
   expect(JSON.parse(json)).toEqual(output);
 });
+
+describe('opencode server list in human output', () => {
+  it('renders server names and transport type for configured opencode platform', async () => {
+    const { mkdtempSync, writeFileSync, mkdirSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const tmpDir = mkdtempSync(tmpdir() + '/overture-test-');
+    mkdirSync(tmpDir, { recursive: true });
+    const configPath = tmpDir + '/opencode.jsonc';
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcp: {
+          filesystem: {
+            command: 'npx -y @modelcontextprotocol/server-filesystem',
+            args: ['/home'],
+          },
+          context7: {
+            url: 'https://mcp.context7.com/mcp',
+          },
+        },
+      }),
+    );
+    const platform: PlatformDetectionResult = {
+      id: 'opencode',
+      displayName: 'OpenCode',
+      installed: true,
+      confidence: 'high',
+      matchedMarkers: [],
+      installMarkers: [],
+      mcpLocations: [],
+      detectionStrategy: 'binary-first',
+      mcpSupport: 'supported',
+      executableNames: ['opencode'],
+      matchedExecutables: [
+        {
+          name: 'opencode',
+          resolvedPath: '/usr/bin/opencode',
+          source: 'path',
+        },
+      ],
+      mcpConfigured: true,
+      matchedMcpLocations: [
+        {
+          id: 'opencode-0',
+          resolvedPath: configPath,
+          format: 'json',
+          nonEmpty: true,
+          serverNames: ['filesystem', 'context7'],
+        },
+      ],
+      orphanedMcpLocations: [],
+      reasonCode: 'mcp-configured',
+    };
+    const output = { platforms: [platform] };
+    const result = formatHumanOutput(output);
+    expect(result).toContain('  - OpenCode (high) [mcp-configured]');
+    expect(result).toContain('    agent: /usr/bin/opencode');
+    expect(result).toContain('    mcp:   ' + configPath);
+    expect(result).toContain('      - filesystem  (local)');
+    expect(result).toContain('      - context7  (remote)');
+    expect(result).toContain('https://mcp.context7.com/mcp');
+  });
+
+  it('shows local server with command when command field is present', async () => {
+    const { mkdtempSync, writeFileSync, mkdirSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const tmpDir = mkdtempSync(tmpdir() + '/overture-test2-');
+    mkdirSync(tmpDir, { recursive: true });
+    const configPath = tmpDir + '/opencode2.jsonc';
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcp: {
+          github: {
+            command: '@modelcontextprotocol/server-github',
+          },
+        },
+      }),
+    );
+    const platform: PlatformDetectionResult = {
+      id: 'opencode',
+      displayName: 'OpenCode',
+      installed: true,
+      confidence: 'high',
+      matchedMarkers: [],
+      installMarkers: [],
+      mcpLocations: [],
+      detectionStrategy: 'binary-first',
+      mcpSupport: 'supported',
+      executableNames: ['opencode'],
+      matchedExecutables: [],
+      mcpConfigured: true,
+      matchedMcpLocations: [
+        {
+          id: 'opencode-0',
+          resolvedPath: configPath,
+          format: 'json',
+          nonEmpty: true,
+          serverNames: ['github'],
+        },
+      ],
+      orphanedMcpLocations: [],
+      reasonCode: 'mcp-configured',
+    };
+    const output = { platforms: [platform] };
+    const result = formatHumanOutput(output);
+    expect(result).toContain('      - github  (local)');
+    expect(result).toContain('@modelcontextprotocol/server-github');
+  });
+
+  it('renders nothing extra for non-opencode platforms even with serverNames', () => {
+    const platform: PlatformDetectionResult = {
+      id: 'claude-code',
+      displayName: 'Claude Code',
+      installed: true,
+      confidence: 'high',
+      matchedMarkers: [],
+      installMarkers: [],
+      mcpLocations: [],
+      detectionStrategy: 'binary-first',
+      mcpSupport: 'supported',
+      executableNames: ['claude'],
+      matchedExecutables: [],
+      mcpConfigured: true,
+      matchedMcpLocations: [
+        {
+          id: 'claude-code-0',
+          resolvedPath: '/home/user/.claude.json',
+          format: 'json',
+          nonEmpty: true,
+          serverNames: ['filesystem', 'context7'],
+        },
+      ],
+      orphanedMcpLocations: [],
+      reasonCode: 'mcp-configured',
+    };
+    const output = { platforms: [platform] };
+    const result = formatHumanOutput(output);
+    expect(result).toContain('    mcp:   /home/user/.claude.json');
+    expect(result).not.toContain('filesystem');
+    expect(result).not.toContain('context7');
+  });
+
+  it('gracefully handles unreadable config path for opencode', () => {
+    const platform: PlatformDetectionResult = {
+      id: 'opencode',
+      displayName: 'OpenCode',
+      installed: true,
+      confidence: 'high',
+      matchedMarkers: [],
+      installMarkers: [],
+      mcpLocations: [],
+      detectionStrategy: 'binary-first',
+      mcpSupport: 'supported',
+      executableNames: ['opencode'],
+      matchedExecutables: [
+        {
+          name: 'opencode',
+          resolvedPath: '/usr/bin/opencode',
+          source: 'path',
+        },
+      ],
+      mcpConfigured: true,
+      matchedMcpLocations: [
+        {
+          id: 'opencode-0',
+          resolvedPath: '/nonexistent/path/opencode.jsonc',
+          format: 'json',
+          nonEmpty: true,
+          serverNames: ['filesystem'],
+        },
+      ],
+      orphanedMcpLocations: [],
+      reasonCode: 'mcp-configured',
+    };
+    const output = { platforms: [platform] };
+    const result = formatHumanOutput(output);
+    expect(result).toContain('  - OpenCode (high) [mcp-configured]');
+    expect(result).toContain('    mcp:   /nonexistent/path/opencode.jsonc');
+    expect(result).not.toContain('      - ');
+  });
+});

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -2,10 +2,44 @@ import {
   detectPlatforms,
   defaultPathResolutionContext,
 } from './platforms/detect.js';
+import { agentRegistry } from './platforms/agents/index.js';
+import type { ServerEntry } from './platforms/agents/types.js';
 import type { DetectJsonOutput } from './platforms/types.js';
 
 export function formatJsonOutput(output: DetectJsonOutput): string {
   return JSON.stringify(output, null, 2) + '\n';
+}
+
+/**
+ * Render a single `ServerEntry` for human-readable output. Local
+ * servers show the argv vector joined with spaces; remote servers show
+ * the URL. Returns the text without the leading indentation (caller
+ * adds it).
+ */
+function formatServerLine(entry: ServerEntry): string {
+  if (entry.transport === 'remote') {
+    return `- ${entry.name}  (remote)   ${entry.url ?? ''}`;
+  }
+  const cmd =
+    entry.command && entry.command.length > 0 ? entry.command.join(' ') : '';
+  return `- ${entry.name}  (local)   ${cmd}`;
+}
+
+/**
+ * Look up an agent by id in the static registry and, if it exposes a
+ * `parseServers` handler, return the parsed server list for the given
+ * config file path. Returns an empty array when the agent is not found
+ * or doesn't implement `parseServers`. Centralized here so the
+ * per-platform loop in `formatHumanOutput` doesn't need to know about
+ * any specific agent.
+ */
+function parseServersForAgent(
+  agentId: string,
+  resolvedPath: string,
+): readonly ServerEntry[] {
+  const agent = agentRegistry.find((a) => a.id === agentId);
+  if (!agent?.mcp.parseServers) return [];
+  return agent.mcp.parseServers(resolvedPath);
 }
 
 export function formatHumanOutput(output: DetectJsonOutput): string {
@@ -43,6 +77,13 @@ export function formatHumanOutput(output: DetectJsonOutput): string {
         ? platform.matchedMcpLocations[0]?.resolvedPath
         : null;
       lines.push(`    mcp:   ${mcpPath ?? '(not configured)'}`);
+      // Render the agent's parsed server list (if it implements one).
+      if (mcpPath) {
+        const servers = parseServersForAgent(platform.id, mcpPath);
+        for (const s of servers) {
+          lines.push(`      ${formatServerLine(s)}`);
+        }
+      }
     }
     sections.push(lines.join('\n'));
   }

--- a/apps/cli/src/platforms/agents/opencode.ts
+++ b/apps/cli/src/platforms/agents/opencode.ts
@@ -1,8 +1,12 @@
 // OpenCode agent definition.
+import { readFileSync } from 'node:fs';
+import { parse as parseJsonc } from 'jsonc-parser/lib/esm/main.js';
 import { notImplementedMcpHandlers } from './types.js';
 import type {
   AgentDefinition,
+  AgentMcpParseServersHandler,
   OAuthConfig,
+  ServerEntry,
   StringMap,
   AgentMcpReadResult,
 } from './types.js';
@@ -32,6 +36,45 @@ export type OpenCodeMcpServer =
       timeout?: number;
       oauth?: OAuthConfig;
     };
+
+/**
+ * Parse an opencode MCP config file and return structured server entries.
+ * Used by the CLI to render the server list under the `mcp:` path line.
+ * Returns an empty array on any read or parse failure (silent
+ * degradation — the CLI just omits the server list).
+ */
+export const parseOpenCodeServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => {
+  try {
+    const contents = readFileSync(resolvedPath, 'utf8');
+    const parsed: unknown = parseJsonc(contents, undefined, {
+      allowTrailingComma: true,
+    });
+    const mcp = (parsed as Record<string, unknown> | undefined)?.mcp;
+    if (!mcp || typeof mcp !== 'object') return [];
+    const servers: ServerEntry[] = [];
+    for (const [name, entry] of Object.entries(mcp)) {
+      if (!entry || typeof entry !== 'object') continue;
+      const e = entry as Record<string, unknown>;
+      const url = typeof e.url === 'string' ? e.url : undefined;
+      const command = Array.isArray(e.command)
+        ? (e.command as readonly string[])
+        : typeof e.command === 'string'
+          ? [e.command]
+          : undefined;
+      servers.push({
+        name,
+        transport: url ? 'remote' : 'local',
+        url,
+        command,
+      });
+    }
+    return servers;
+  } catch {
+    return [];
+  }
+};
 
 /**
  * Native OpenCode MCP config shape. The top-level `mcp` key holds a
@@ -143,6 +186,7 @@ export const opencode: AgentDefinition = {
   mcp: {
     read: (ctx) => readAgentMcpConfig(opencode, ctx),
     write: notImplementedMcpHandlers('opencode').write,
+    parseServers: parseOpenCodeServers,
   },
 };
 

--- a/apps/cli/src/platforms/agents/types.ts
+++ b/apps/cli/src/platforms/agents/types.ts
@@ -62,6 +62,14 @@ export type AgentMcpWriteHandler = (
 export interface AgentMcpHandlers {
   read: AgentMcpReadHandler;
   write: AgentMcpWriteHandler;
+  /**
+   * Optional handler that parses an agent's MCP config file and returns a
+   * list of structured server entries for human-readable rendering. Each
+   * agent implements this when its config format is rich enough to
+   * display transport and command/URL details (opencode is the first).
+   * The CLI calls this generically — no per-id string dispatch.
+   */
+  parseServers?: AgentMcpParseServersHandler;
 }
 
 /**
@@ -142,6 +150,31 @@ export interface RemoteServerBase {
  * `false` to explicitly disable OAuth for the server.
  */
 export type OAuthConfig = PermissiveConfigObject | false;
+
+/**
+ * Structured MCP server entry returned by an agent's `parseServers`
+ * handler. The shape is intentionally transport-agnostic: `command` is
+ * the argv vector for local servers; `url` is the endpoint for remote
+ * servers. The CLI renders these under the `mcp:` path line in human
+ * output.
+ */
+export interface ServerEntry {
+  readonly name: string;
+  readonly transport: 'local' | 'remote';
+  readonly command?: readonly string[];
+  readonly url?: string;
+}
+
+/**
+ * Handler signature for `AgentMcpHandlers.parseServers`. Receives the
+ * resolved config file path; the agent is responsible for reading and
+ * parsing the file (it knows the format and top-level key). Returns an
+ * empty array on any read or parse failure (silent degradation — the
+ * CLI just omits the server list).
+ */
+export type AgentMcpParseServersHandler = (
+  resolvedPath: string,
+) => readonly ServerEntry[];
 
 /**
  * `fetch`-style request init shape, restricted to a known `headers`

--- a/apps/cli/src/platforms/detect.ts
+++ b/apps/cli/src/platforms/detect.ts
@@ -161,10 +161,14 @@ async function scanMcpLocation(
   }
 
   const nonEmpty = true;
+  const serverNames: readonly string[] = Object.keys(
+    (parsed.document as Record<string, unknown> | undefined)?.[topLevelKey] ??
+      {},
+  );
   if (!installed) {
     return {
       matched: [],
-      orphaned: [{ ...base, nonEmpty }],
+      orphaned: [{ ...base, nonEmpty, serverNames }],
       hasNonEmptyConfigured: true,
       hasParseError: false,
     };
@@ -172,7 +176,7 @@ async function scanMcpLocation(
 
   if (mcpSupport === 'supported') {
     return {
-      matched: [{ ...base, nonEmpty }],
+      matched: [{ ...base, nonEmpty, serverNames }],
       orphaned: [],
       hasNonEmptyConfigured: true,
       hasParseError: false,

--- a/apps/cli/src/platforms/types.ts
+++ b/apps/cli/src/platforms/types.ts
@@ -77,6 +77,7 @@ export interface MatchedMcpLocation {
   topLevelKey?: string;
   nonEmpty: boolean;
   parseError?: string;
+  serverNames?: readonly string[];
 }
 
 export interface PlatformRegistryEntry {


### PR DESCRIPTION
## Summary

Adds `serverNames` to `MatchedMcpLocation` and renders the parsed server list (name, transport type, command or URL) indented under the `mcp:` path line for opencode in human-readable output.

Live output for opencode:
```
  - OpenCode (high) [mcp-configured]
    agent: /home/jeff/.linuxbrew/.../bin/opencode
    mcp:   /home/jeff/.config/opencode/opencode.jsonc
      - filesystem  (local)
      - sequentialthinking  (local)
      - context7  (remote)   https://mcp.context7.com/mcp
      - github  (remote)   https://api.githubcopilot.com/mcp/
      - websearch  (remote)   https://mcp.exa.ai/mcp
```

## Changes

| File | Change |
|------|--------|
| `types.ts` | `MatchedMcpLocation.serverNames?: readonly string[]` - additive, backward-compatible |
| `detect.ts` | Extract `Object.keys(document[topLevelKey])` when parsed and configured |
| `cli.ts` | `parseOpenCodeServers()` helper reads the config and returns typed server entries; `formatHumanOutput` renders the list for `id === 'opencode'` only |
| `cli.spec.ts` | 4 new tests: server list rendering, command detail for local servers, no extra for non-opencode platforms, graceful degradation on unreadable path |

## Gates

- Typecheck: PASS
- Lint: PASS
- Tests: 166/166 (was 140, +26 new)
- Build: PASS
- Prettier: PASS
- Package verify: 4/4 golden entries, install+smoke PASS