### PR TITLE
refactor(agents): rename ServerEntry to McpServerEntry and parseOpenCodeServers to parseOpenCodeMcpServers

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -3,7 +3,7 @@ import {
   defaultPathResolutionContext,
 } from './platforms/detect.js';
 import { agentRegistry } from './platforms/agents/index.js';
-import type { ServerEntry } from './platforms/agents/types.js';
+import type { McpServerEntry } from './platforms/agents/types.js';
 import type { DetectJsonOutput } from './platforms/types.js';
 
 export function formatJsonOutput(output: DetectJsonOutput): string {
@@ -11,12 +11,12 @@ export function formatJsonOutput(output: DetectJsonOutput): string {
 }
 
 /**
- * Render a single `ServerEntry` for human-readable output. Local
+ * Render a single `McpServerEntry` for human-readable output. Local
  * servers show the argv vector joined with spaces; remote servers show
  * the URL. Returns the text without the leading indentation (caller
  * adds it).
  */
-function formatServerLine(entry: ServerEntry): string {
+function formatServerLine(entry: McpServerEntry): string {
   if (entry.transport === 'remote') {
     return `- ${entry.name}  (remote)   ${entry.url ?? ''}`;
   }
@@ -36,7 +36,7 @@ function formatServerLine(entry: ServerEntry): string {
 function parseServersForAgent(
   agentId: string,
   resolvedPath: string,
-): readonly ServerEntry[] {
+): readonly McpServerEntry[] {
   const agent = agentRegistry.find((a) => a.id === agentId);
   if (!agent?.mcp.parseServers) return [];
   return agent.mcp.parseServers(resolvedPath);

--- a/apps/cli/src/platforms/agents/opencode.ts
+++ b/apps/cli/src/platforms/agents/opencode.ts
@@ -6,7 +6,7 @@ import type {
   AgentDefinition,
   AgentMcpParseServersHandler,
   OAuthConfig,
-  ServerEntry,
+  McpServerEntry,
   StringMap,
   AgentMcpReadResult,
 } from './types.js';
@@ -43,7 +43,7 @@ export type OpenCodeMcpServer =
  * Returns an empty array on any read or parse failure (silent
  * degradation — the CLI just omits the server list).
  */
-export const parseOpenCodeServers: AgentMcpParseServersHandler = (
+export const parseOpenCodeMcpServers: AgentMcpParseServersHandler = (
   resolvedPath,
 ) => {
   try {
@@ -53,7 +53,7 @@ export const parseOpenCodeServers: AgentMcpParseServersHandler = (
     });
     const mcp = (parsed as Record<string, unknown> | undefined)?.mcp;
     if (!mcp || typeof mcp !== 'object') return [];
-    const servers: ServerEntry[] = [];
+    const servers: McpServerEntry[] = [];
     for (const [name, entry] of Object.entries(mcp)) {
       if (!entry || typeof entry !== 'object') continue;
       const e = entry as Record<string, unknown>;
@@ -186,7 +186,7 @@ export const opencode: AgentDefinition = {
   mcp: {
     read: (ctx) => readAgentMcpConfig(opencode, ctx),
     write: notImplementedMcpHandlers('opencode').write,
-    parseServers: parseOpenCodeServers,
+    parseServers: parseOpenCodeMcpServers,
   },
 };
 

--- a/apps/cli/src/platforms/agents/types.ts
+++ b/apps/cli/src/platforms/agents/types.ts
@@ -158,7 +158,7 @@ export type OAuthConfig = PermissiveConfigObject | false;
  * servers. The CLI renders these under the `mcp:` path line in human
  * output.
  */
-export interface ServerEntry {
+export interface McpServerEntry {
   readonly name: string;
   readonly transport: 'local' | 'remote';
   readonly command?: readonly string[];
@@ -174,7 +174,7 @@ export interface ServerEntry {
  */
 export type AgentMcpParseServersHandler = (
   resolvedPath: string,
-) => readonly ServerEntry[];
+) => readonly McpServerEntry[];
 
 /**
  * `fetch`-style request init shape, restricted to a known `headers`


### PR DESCRIPTION
## Summary

Naming consistency for the upcoming wave of per-agent `parseServers` implementations. Each per-agent file now follows the same shape:

- exports a per-agent-named function: `parse<AgentName>McpServers`
- returns the shared `McpServerEntry` interface (the `Mcp` prefix matches `McpServerMap`, `McpLocation`, etc.)

## Changes

| File | Change |
|------|--------|
| `apps/cli/src/platforms/agents/types.ts` | `ServerEntry` -> `McpServerEntry` (matches `McpServerMap` / `McpLocation` convention) |
| `apps/cli/src/platforms/agents/opencode.ts` | `parseOpenCodeServers` -> `parseOpenCodeMcpServers` (matches `readOpenCodeMcpConfig` convention) |
| `apps/cli/src/cli.ts` | import + 3 references updated |

## Why

When we add `parseClaudeCodeMcpServers`, `parseCursorMcpServers`, `parseWindsurfMcpServers`, etc., they will all:

- Be exported from the per-agent file with a `parse<AgentName>McpServers` name (matches `read<AgentName>McpConfig`)
- Return `readonly McpServerEntry[]` (the shared contract every agent satisfies)
- Be wired into their agent's `mcp.parseServers` field

No new types, no new interfaces, no behavioral change. Just naming.

## Gates

- Typecheck: PASS
- Lint: PASS (0 issues)
- Tests: 166/166 PASS
- Build: PASS
- Prettier: PASS
- Package verify: 4/4 golden entries, install+smoke PASS
- Live CLI smoke: opencode still renders its 5 servers correctly