### PR TITLE
feat(agents): add parseServers handlers for all 12 MCP agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,12 @@ To add a new agent:
    trailing `mcp: notImplementedMcpHandlers('<id>')` field. The
    placeholder `mcp.read` / `mcp.write` handlers will be replaced
    with real implementations in a follow-up PR — see
-   `packages/agents/src/types.ts`.
+   `packages/agents/src/types.ts`. Every supported agent should
+   also wire a `mcp.parseServers` handler (one of the shared
+   helpers from `packages/agents/src/parse-mcp-servers.ts`, or
+   `opencode`'s inline impl) so the CLI can render the server list
+   under the `mcp:` path line. Skipping `parseServers` is a silent
+   UX regression.
 3. Insert the new import + array entry in
    `packages/agents/src/index.ts` at the canonical
    position. **Order matters**: the legacy `expectedIds` assertion

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -135,9 +135,13 @@
       },
       "lint": {
         "executor": "@nx/eslint:lint",
-        "outputs": ["{options.outputFile}"],
+        "outputs": [
+          "{options.outputFile}"
+        ],
         "options": {
-          "lintFilePatterns": ["apps/cli/**/*.ts"],
+          "lintFilePatterns": [
+            "apps/cli/**/*.ts"
+          ],
           "maxWarnings": 0,
           "cache": true,
           "cacheStrategy": "content",
@@ -157,6 +161,7 @@
   },
   "dependencies": {
     "jsonc-parser": "^3.3.1",
-    "smol-toml": "^1.6.1"
+    "smol-toml": "^1.6.1",
+    "yaml": "^2.9.0"
   }
 }

--- a/packages/agents/src/claude-code.ts
+++ b/packages/agents/src/claude-code.ts
@@ -61,11 +61,11 @@ export const claudeCode: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['claude'],
-mcp: {
-read: (ctx) => readAgentMcpConfig(claudeCode, ctx),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(claudeCode, ctx),
     write: notImplementedMcpHandlers('claude-code').write,
     parseServers: parseClaudeCodeMcpServers,
-},
+  },
 };
 
 /** Native Claude Code MCP config: `mcpServers` map; each server is either a stdio transport or a remote transport (HTTP / streamable-http / SSE / WebSocket). The top level may also carry a local `imports` map (Claude Code's local-imports feature). */

--- a/packages/agents/src/claude-code.ts
+++ b/packages/agents/src/claude-code.ts
@@ -1,17 +1,23 @@
 // Claude Code agent definition.
+import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { notImplementedMcpHandlers } from './types.js';
 import type {
   AgentDefinition,
+  AgentMcpParseServersHandler,
+  AgentMcpReadResult,
   McpServerMap,
   PermissiveConfigObject,
   RemoteServerBase,
   StdioServerBase,
   StringMap,
-  AgentMcpReadResult,
 } from './types.js';
-
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+
+export const parseClaudeCodeMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => parseJsoncMcpServerMap(resolvedPath, 'mcpServers');
+
 export const claudeCode: AgentDefinition = {
   id: 'claude-code',
   displayName: 'Claude Code',
@@ -55,10 +61,11 @@ export const claudeCode: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['claude'],
-  mcp: {
-    read: (ctx) => readAgentMcpConfig(claudeCode, ctx),
+mcp: {
+read: (ctx) => readAgentMcpConfig(claudeCode, ctx),
     write: notImplementedMcpHandlers('claude-code').write,
-  },
+    parseServers: parseClaudeCodeMcpServers,
+},
 };
 
 /** Native Claude Code MCP config: `mcpServers` map; each server is either a stdio transport or a remote transport (HTTP / streamable-http / SSE / WebSocket). The top level may also carry a local `imports` map (Claude Code's local-imports feature). */

--- a/packages/agents/src/claude-desktop.ts
+++ b/packages/agents/src/claude-desktop.ts
@@ -1,14 +1,21 @@
 // Claude Desktop agent definition.
 import { notImplementedMcpHandlers } from './types.js';
+import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import type {
   AgentDefinition,
   McpServerMap,
   StdioServerBase,
   AgentMcpReadResult,
+  AgentMcpParseServersHandler,
 } from './types.js';
 
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+
+export const parseClaudeDesktopMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => parseJsoncMcpServerMap(resolvedPath, 'mcpServers');
+
 export const claudeDesktop: AgentDefinition = {
   id: 'claude-desktop',
   displayName: 'Claude Desktop',
@@ -79,6 +86,7 @@ export const claudeDesktop: AgentDefinition = {
   mcp: {
     read: (ctx) => readAgentMcpConfig(claudeDesktop, ctx),
     write: notImplementedMcpHandlers('claude-desktop').write,
+    parseServers: parseClaudeDesktopMcpServers,
   },
 };
 

--- a/packages/agents/src/cline.ts
+++ b/packages/agents/src/cline.ts
@@ -121,11 +121,11 @@ export const cline: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-mcp: {
-read: (ctx) => readAgentMcpConfig(cline, ctx),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(cline, ctx),
     write: notImplementedMcpHandlers('cline').write,
     parseServers: parseClineMcpServers,
-},
+  },
 };
 
 /**

--- a/packages/agents/src/cline.ts
+++ b/packages/agents/src/cline.ts
@@ -1,10 +1,21 @@
 // Cline agent definition.
+import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition, AgentMcpReadResult } from './types.js';
-import type { McpServerMap, StringList, StringMap } from './types.js';
-
+import type {
+  AgentDefinition,
+  AgentMcpParseServersHandler,
+  AgentMcpReadResult,
+  McpServerMap,
+  StringList,
+  StringMap,
+} from './types.js';
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+
+export const parseClineMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => parseJsoncMcpServerMap(resolvedPath, 'mcpServers');
+
 /**
  * Native Cline MCP server entry. Cline accepts either stdio-style servers
  * (with `command`/`args`/`env`) or remote servers (with `url`/`headers`)
@@ -110,10 +121,11 @@ export const cline: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-  mcp: {
-    read: (ctx) => readAgentMcpConfig(cline, ctx),
+mcp: {
+read: (ctx) => readAgentMcpConfig(cline, ctx),
     write: notImplementedMcpHandlers('cline').write,
-  },
+    parseServers: parseClineMcpServers,
+},
 };
 
 /**

--- a/packages/agents/src/continue.ts
+++ b/packages/agents/src/continue.ts
@@ -104,10 +104,10 @@ export const continueDef: AgentDefinition = {
       base: 'workspace',
       relativePath: '.continue/mcpServers/mcp.json',
       format: 'json',
-      topLevelKey: 'mcpServers',
+topLevelKey: 'mcpServers',
       notes:
-        "Continue imports MCP config files from this directory; the canonical imported filename is mcp.json. Continue also accepts standalone YAML files at <workspace>/.continue/mcpServers/*.yaml with a top-level mcpServers list, but overture's reader does not yet support YAML parsing (future PR).",
-    },
+        'Continue imports MCP config files from this directory; the canonical imported filename is mcp.json. Continue also accepts standalone YAML files at <workspace>/.continue/mcpServers/*.yaml with a top-level mcpServers list. The YAML parser is implemented in parseContinueMcpServers, but the detectors mcpLocations model is per-file-path, so arbitrary per-server YAML files are not yet auto-discovered. Tracked as a follow-up.',
+},
   ],
   defaultConfidence: 'medium',
   detectionStrategy: 'marker-only',

--- a/packages/agents/src/continue.ts
+++ b/packages/agents/src/continue.ts
@@ -1,13 +1,32 @@
 // Continue agent definition.
+import {
+  parseJsoncMcpServerMap,
+  parseYamlMcpServerList,
+} from './parse-mcp-servers.js';
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition, AgentMcpReadResult } from './types.js';
+import type {
+  AgentDefinition,
+  AgentMcpParseServersHandler,
+  AgentMcpReadResult,
+} from './types.js';
 import type { RequestInitConfig, StringList, StringMap } from './types.js';
 import type { ClaudeCodeMcpConfig } from './claude-code.js';
 import type { CursorMcpConfig } from './cursor.js';
 import type { ClineMcpConfig } from './cline.js';
-
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+
+export const parseContinueMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => {
+  // Continue accepts both YAML standalone files and JSON imports copied
+  // from clients like Claude/Cursor/Cline. Pick the parser by extension.
+  if (resolvedPath.endsWith('.yaml') || resolvedPath.endsWith('.yml')) {
+    return parseYamlMcpServerList(resolvedPath, 'mcpServers');
+  }
+  return parseJsoncMcpServerMap(resolvedPath, 'mcpServers');
+};
+
 /**
  * Native Continue MCP server entry inside a standalone YAML config.
  * The `name` field is required because Continue identifies servers by
@@ -94,10 +113,11 @@ export const continueDef: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-  mcp: {
-    read: (ctx) => readAgentMcpConfig(continueDef, ctx),
+mcp: {
+read: (ctx) => readAgentMcpConfig(continueDef, ctx),
     write: notImplementedMcpHandlers('continue').write,
-  },
+    parseServers: parseContinueMcpServers,
+},
 };
 
 /**

--- a/packages/agents/src/continue.ts
+++ b/packages/agents/src/continue.ts
@@ -113,11 +113,11 @@ export const continueDef: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-mcp: {
-read: (ctx) => readAgentMcpConfig(continueDef, ctx),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(continueDef, ctx),
     write: notImplementedMcpHandlers('continue').write,
     parseServers: parseContinueMcpServers,
-},
+  },
 };
 
 /**

--- a/packages/agents/src/continue.ts
+++ b/packages/agents/src/continue.ts
@@ -104,10 +104,10 @@ export const continueDef: AgentDefinition = {
       base: 'workspace',
       relativePath: '.continue/mcpServers/mcp.json',
       format: 'json',
-topLevelKey: 'mcpServers',
+      topLevelKey: 'mcpServers',
       notes:
         'Continue imports MCP config files from this directory; the canonical imported filename is mcp.json. Continue also accepts standalone YAML files at <workspace>/.continue/mcpServers/*.yaml with a top-level mcpServers list. The YAML parser is implemented in parseContinueMcpServers, but the detectors mcpLocations model is per-file-path, so arbitrary per-server YAML files are not yet auto-discovered. Tracked as a follow-up.',
-},
+    },
   ],
   defaultConfidence: 'medium',
   detectionStrategy: 'marker-only',

--- a/packages/agents/src/cursor.ts
+++ b/packages/agents/src/cursor.ts
@@ -1,7 +1,9 @@
 // Cursor agent definition.
+import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { notImplementedMcpHandlers } from './types.js';
 import type {
   AgentDefinition,
+  AgentMcpParseServersHandler,
   McpServerMap,
   PermissiveConfigObject,
   RemoteServerBase,
@@ -11,6 +13,10 @@ import type {
 
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+export const parseCursorMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => parseJsoncMcpServerMap(resolvedPath, 'mcpServers');
+
 export const cursor: AgentDefinition = {
   id: 'cursor',
   displayName: 'Cursor',
@@ -57,6 +63,7 @@ export const cursor: AgentDefinition = {
   mcp: {
     read: (ctx) => readAgentMcpConfig(cursor, ctx),
     write: notImplementedMcpHandlers('cursor').write,
+    parseServers: parseCursorMcpServers,
   },
 };
 

--- a/packages/agents/src/github-copilot-cli.ts
+++ b/packages/agents/src/github-copilot-cli.ts
@@ -1,16 +1,22 @@
 // GitHub Copilot CLI agent definition.
+import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
+import { readAgentMcpConfig } from './read-mcp-config.js';
 import { notImplementedMcpHandlers } from './types.js';
 import type {
   AgentDefinition,
+  AgentMcpParseServersHandler,
+  AgentMcpReadResult,
   McpServerMap,
+  PathResolutionContext,
   StringList,
   StringMap,
   ToolList,
-  AgentMcpReadResult,
 } from './types.js';
 
-import { readAgentMcpConfig } from './read-mcp-config.js';
-import type { PathResolutionContext } from './types.js';
+export const parseGitHubCopilotCliMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => parseJsoncMcpServerMap(resolvedPath, 'mcpServers');
+
 export const githubCopilotCli: AgentDefinition = {
   id: 'github-copilot-cli',
   displayName: 'GitHub Copilot CLI',
@@ -51,6 +57,7 @@ export const githubCopilotCli: AgentDefinition = {
   mcp: {
     read: (ctx) => readAgentMcpConfig(githubCopilotCli, ctx),
     write: notImplementedMcpHandlers('github-copilot-cli').write,
+    parseServers: parseGitHubCopilotCliMcpServers,
   },
 };
 

--- a/packages/agents/src/github-copilot-vscode.ts
+++ b/packages/agents/src/github-copilot-vscode.ts
@@ -62,11 +62,11 @@ export const githubCopilotVscode: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-mcp: {
-read: (ctx) => readAgentMcpConfig(githubCopilotVscode, ctx),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(githubCopilotVscode, ctx),
     write: notImplementedMcpHandlers('github-copilot-vscode').write,
     parseServers: parseGitHubCopilotVSCodeMcpServers,
-},
+  },
 };
 
 /**

--- a/packages/agents/src/github-copilot-vscode.ts
+++ b/packages/agents/src/github-copilot-vscode.ts
@@ -1,17 +1,24 @@
 // GitHub Copilot in VS Code agent definition.
+import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { notImplementedMcpHandlers } from './types.js';
 import type {
   AgentDefinition,
+  AgentMcpParseServersHandler,
+  AgentMcpReadResult,
   McpServerMap,
   OAuthConfig,
   PermissiveConfigObject,
   RequestInitConfig,
   StdioServerBase,
   StringMap,
-  AgentMcpReadResult,
 } from './types.js';
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+
+export const parseGitHubCopilotVSCodeMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => parseJsoncMcpServerMap(resolvedPath, 'servers');
+
 export const githubCopilotVscode: AgentDefinition = {
   id: 'github-copilot-vscode',
   displayName: 'GitHub Copilot in VS Code',
@@ -55,10 +62,11 @@ export const githubCopilotVscode: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-  mcp: {
-    read: (ctx) => readAgentMcpConfig(githubCopilotVscode, ctx),
+mcp: {
+read: (ctx) => readAgentMcpConfig(githubCopilotVscode, ctx),
     write: notImplementedMcpHandlers('github-copilot-vscode').write,
-  },
+    parseServers: parseGitHubCopilotVSCodeMcpServers,
+},
 };
 
 /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -82,19 +82,31 @@ import { aider } from './aider.js';
 
 export { readAgentMcpConfig } from './read-mcp-config.js';
 
-export { parseClaudeCodeMcpServers, readClaudeCodeMcpConfig } from './claude-code.js';
+export {
+  parseClaudeCodeMcpServers,
+  readClaudeCodeMcpConfig,
+} from './claude-code.js';
 export type { ClaudeCodeMcpConfig } from './claude-code.js';
 
-export { parseClaudeDesktopMcpServers, readClaudeDesktopMcpConfig } from './claude-desktop.js';
+export {
+  parseClaudeDesktopMcpServers,
+  readClaudeDesktopMcpConfig,
+} from './claude-desktop.js';
 export type { ClaudeDesktopMcpConfig } from './claude-desktop.js';
 
 export { parseOpenCodeMcpServers, readOpenCodeMcpConfig } from './opencode.js';
 export type { OpenCodeMcpConfig } from './opencode.js';
 
-export { parseGitHubCopilotVSCodeMcpServers, readGitHubCopilotVSCodeMcpConfig } from './github-copilot-vscode.js';
+export {
+  parseGitHubCopilotVSCodeMcpServers,
+  readGitHubCopilotVSCodeMcpConfig,
+} from './github-copilot-vscode.js';
 export type { GitHubCopilotVSCodeMcpConfig } from './github-copilot-vscode.js';
 
-export { parseGitHubCopilotCliMcpServers, readGitHubCopilotCliMcpConfig } from './github-copilot-cli.js';
+export {
+  parseGitHubCopilotCliMcpServers,
+  readGitHubCopilotCliMcpConfig,
+} from './github-copilot-cli.js';
 export type { GitHubCopilotCliMcpConfig } from './github-copilot-cli.js';
 
 export { parseCursorMcpServers, readCursorMcpConfig } from './cursor.js';
@@ -120,7 +132,10 @@ export type {
 export { parseZedMcpServers, readZedMcpConfig } from './zed.js';
 export type { ZedMcpConfig } from './zed.js';
 
-export { parseOpenAICodexMcpServers, readOpenAICodexMcpConfig } from './openai-codex.js';
+export {
+  parseOpenAICodexMcpServers,
+  readOpenAICodexMcpConfig,
+} from './openai-codex.js';
 export type { OpenAICodexMcpConfig } from './openai-codex.js';
 
 export const agentRegistry: readonly AgentDefinition[] = [

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -4,8 +4,9 @@
  * Exports the static registry of every supported MCP-capable agent, the
  * `AgentDefinition` contract, the shared MCP config primitives used by
  * per-agent readers (McpServerEntry, StdioServerBase, etc.), the
- * `notImplementedMcpHandlers` helper for new agents, and every
- * per-agent `read<Agent>McpConfig` typed helper.
+ * `notImplementedMcpHandlers` helper for new agents, every per-agent
+ * `read<Agent>McpConfig` typed helper, and every per-agent
+ * `parse<Agent>McpServers` handler.
  *
  * Order matters: the agent id order in the `agentRegistry` aggregate
  * below is the canonical positional order downstream consumers (CLI
@@ -54,6 +55,13 @@ export type {
 } from './types.js';
 export { notImplementedMcpHandlers } from './types.js';
 
+export {
+  parseJsoncMcpServerMap,
+  parseTomlMcpServerMap,
+  parseYamlMcpServerList,
+  type ParseServerMapOptions,
+} from './parse-mcp-servers.js';
+
 import { claudeCode } from './claude-code.js';
 import { claudeDesktop } from './claude-desktop.js';
 import { opencode } from './opencode.js';
@@ -74,34 +82,34 @@ import { aider } from './aider.js';
 
 export { readAgentMcpConfig } from './read-mcp-config.js';
 
-export { readClaudeCodeMcpConfig } from './claude-code.js';
+export { parseClaudeCodeMcpServers, readClaudeCodeMcpConfig } from './claude-code.js';
 export type { ClaudeCodeMcpConfig } from './claude-code.js';
 
-export { readClaudeDesktopMcpConfig } from './claude-desktop.js';
+export { parseClaudeDesktopMcpServers, readClaudeDesktopMcpConfig } from './claude-desktop.js';
 export type { ClaudeDesktopMcpConfig } from './claude-desktop.js';
 
 export { parseOpenCodeMcpServers, readOpenCodeMcpConfig } from './opencode.js';
 export type { OpenCodeMcpConfig } from './opencode.js';
 
-export { readGitHubCopilotVSCodeMcpConfig } from './github-copilot-vscode.js';
+export { parseGitHubCopilotVSCodeMcpServers, readGitHubCopilotVSCodeMcpConfig } from './github-copilot-vscode.js';
 export type { GitHubCopilotVSCodeMcpConfig } from './github-copilot-vscode.js';
 
-export { readGitHubCopilotCliMcpConfig } from './github-copilot-cli.js';
+export { parseGitHubCopilotCliMcpServers, readGitHubCopilotCliMcpConfig } from './github-copilot-cli.js';
 export type { GitHubCopilotCliMcpConfig } from './github-copilot-cli.js';
 
-export { readCursorMcpConfig } from './cursor.js';
+export { parseCursorMcpServers, readCursorMcpConfig } from './cursor.js';
 export type { CursorMcpConfig } from './cursor.js';
 
-export { readWindsurfMcpConfig } from './windsurf.js';
+export { parseWindsurfMcpServers, readWindsurfMcpConfig } from './windsurf.js';
 export type { WindsurfMcpConfig } from './windsurf.js';
 
-export { readClineMcpConfig } from './cline.js';
+export { parseClineMcpServers, readClineMcpConfig } from './cline.js';
 export type { ClineMcpConfig } from './cline.js';
 
-export { readRooCodeMcpConfig } from './roo-code.js';
+export { parseRooCodeMcpServers, readRooCodeMcpConfig } from './roo-code.js';
 export type { RooCodeMcpConfig } from './roo-code.js';
 
-export { readContinueMcpConfig } from './continue.js';
+export { parseContinueMcpServers, readContinueMcpConfig } from './continue.js';
 export type {
   ContinueImportedJsonMcpConfig,
   ContinueMcpConfig,
@@ -109,10 +117,10 @@ export type {
   ContinueYamlMcpConfig,
 } from './continue.js';
 
-export { readZedMcpConfig } from './zed.js';
+export { parseZedMcpServers, readZedMcpConfig } from './zed.js';
 export type { ZedMcpConfig } from './zed.js';
 
-export { readOpenAICodexMcpConfig } from './openai-codex.js';
+export { parseOpenAICodexMcpServers, readOpenAICodexMcpConfig } from './openai-codex.js';
 export type { OpenAICodexMcpConfig } from './openai-codex.js';
 
 export const agentRegistry: readonly AgentDefinition[] = [

--- a/packages/agents/src/openai-codex.ts
+++ b/packages/agents/src/openai-codex.ts
@@ -1,13 +1,19 @@
 // OpenAI Codex agent definition.
+import { parseTomlMcpServerMap } from './parse-mcp-servers.js';
 import { notImplementedMcpHandlers } from './types.js';
 import type {
   AgentDefinition,
-  StringMap,
+  AgentMcpParseServersHandler,
   AgentMcpReadResult,
+  StringMap,
 } from './types.js';
-
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+
+export const parseOpenAICodexMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => parseTomlMcpServerMap(resolvedPath, 'mcp_servers');
+
 export const openaiCodex: AgentDefinition = {
   id: 'openai-codex',
   displayName: 'OpenAI Codex',
@@ -51,10 +57,11 @@ export const openaiCodex: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['codex'],
-  mcp: {
-    read: (ctx) => readAgentMcpConfig(openaiCodex, ctx),
+mcp: {
+read: (ctx) => readAgentMcpConfig(openaiCodex, ctx),
     write: notImplementedMcpHandlers('openai-codex').write,
-  },
+    parseServers: parseOpenAICodexMcpServers,
+},
 };
 
 /**

--- a/packages/agents/src/openai-codex.ts
+++ b/packages/agents/src/openai-codex.ts
@@ -57,11 +57,11 @@ export const openaiCodex: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['codex'],
-mcp: {
-read: (ctx) => readAgentMcpConfig(openaiCodex, ctx),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(openaiCodex, ctx),
     write: notImplementedMcpHandlers('openai-codex').write,
     parseServers: parseOpenAICodexMcpServers,
-},
+  },
 };
 
 /**

--- a/packages/agents/src/parse-mcp-servers.spec.ts
+++ b/packages/agents/src/parse-mcp-servers.spec.ts
@@ -146,8 +146,16 @@ describe('parseJsoncMcpServerMap', () => {
     ).toEqual([{ name: 'r', transport: 'remote', url: 'https://example.com' }]);
   });
 
-  it('returns [] when the top-level value is an array, not a map (JSON variant)', () => {
-    const p = writeFile('arr.json', JSON.stringify({ mcpServers: [] }));
+  it('returns [] when the JSON top-level value is a list (list shape is YAML-only)', () => {
+    // Pre-fix, this would have been parsed as a YAML-list and returned
+    // one entry per item. With allowListShape defaulting to false for
+    // JSON, the helper now returns [].
+    const p = writeFile(
+      'arr.json',
+      JSON.stringify({
+        mcpServers: [{ name: 'foo', command: 'npx' }],
+      }),
+    );
     expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([]);
   });
 });

--- a/packages/agents/src/parse-mcp-servers.spec.ts
+++ b/packages/agents/src/parse-mcp-servers.spec.ts
@@ -1,0 +1,312 @@
+// Tests for the shared MCP server parse helpers in parse-mcp-servers.ts.
+// Each helper is tested for: happy path (local), happy path (remote),
+// BOM tolerance, missing file, malformed content, and explicit
+// transport-type overrides.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  parseJsoncMcpServerMap,
+  parseTomlMcpServerMap,
+  parseYamlMcpServerList,
+} from './parse-mcp-servers.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-mcp-servers-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseJsoncMcpServerMap', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseJsoncMcpServerMap('/no/such/file', 'mcpServers')).toEqual([]);
+  });
+
+  it('returns [] for an empty file', () => {
+    const p = writeFile('empty.jsonc', '');
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('bad.json', '{ this is not json');
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([]);
+  });
+
+  it('returns [] when the top-level key is missing', () => {
+    const p = writeFile('nokey.json', JSON.stringify({ other: {} }));
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([]);
+  });
+
+  it('strips a leading UTF-8 BOM', () => {
+    const p = writeFile('bom.json', '\uFEFF{"mcpServers":{"fs":{}}}');
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([
+      { name: 'fs', transport: 'local' },
+    ]);
+  });
+
+  it('tolerates JSONC trailing commas and comments', () => {
+    const body = `{
+      // leading comment
+      "mcpServers": {
+        "fs": {
+          "command": "npx",
+          "args": ["-y", "fs"],
+        },
+        /* block */
+      },
+    }`;
+    const p = writeFile('jsonc.json', body);
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([
+      { name: 'fs', transport: 'local', command: ['npx', '-y', 'fs'] },
+    ]);
+  });
+
+  it('extracts local servers with command+args argv', () => {
+    const p = writeFile(
+      'local.json',
+      JSON.stringify({
+        mcpServers: {
+          fs: { command: 'npx', args: ['-y', 'server-fs'] },
+        },
+      }),
+    );
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([
+      { name: 'fs', transport: 'local', command: ['npx', '-y', 'server-fs'] },
+    ]);
+  });
+
+  it('extracts remote servers from explicit type field', () => {
+    const p = writeFile(
+      'remote.json',
+      JSON.stringify({
+        mcpServers: {
+          gh: { type: 'http', url: 'https://api.githubcopilot.com/mcp' },
+        },
+      }),
+    );
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([
+      {
+        name: 'gh',
+        transport: 'remote',
+        url: 'https://api.githubcopilot.com/mcp',
+      },
+    ]);
+  });
+
+  it('infers remote transport from url field when no type is set', () => {
+    const p = writeFile(
+      'inferred.json',
+      JSON.stringify({
+        mcpServers: { context7: { url: 'https://mcp.context7.com/mcp' } },
+      }),
+    );
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([
+      {
+        name: 'context7',
+        transport: 'remote',
+        url: 'https://mcp.context7.com/mcp',
+      },
+    ]);
+  });
+
+  it('skips entries whose shape is not a record', () => {
+    const p = writeFile(
+      'skip.json',
+      JSON.stringify({
+        mcpServers: { good: { command: 'x' }, bad: 'not-a-record' },
+      }),
+    );
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([
+      { name: 'good', transport: 'local', command: ['x'] },
+    ]);
+  });
+
+  it('respects custom urlFields option', () => {
+    const p = writeFile(
+      'windsurf.json',
+      JSON.stringify({
+        mcpServers: { r: { serverUrl: 'https://example.com' } },
+      }),
+    );
+    expect(
+      parseJsoncMcpServerMap(p, 'mcpServers', {
+        urlFields: ['url', 'serverUrl'],
+      }),
+    ).toEqual([
+      { name: 'r', transport: 'remote', url: 'https://example.com' },
+    ]);
+  });
+
+  it('returns [] when the top-level value is an array, not a map (JSON variant)', () => {
+    const p = writeFile('arr.json', JSON.stringify({ mcpServers: [] }));
+    expect(parseJsoncMcpServerMap(p, 'mcpServers')).toEqual([]);
+  });
+});
+
+describe('parseTomlMcpServerMap', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseTomlMcpServerMap('/no/such/file', 'mcp_servers')).toEqual([]);
+  });
+
+  it('returns [] for malformed TOML', () => {
+    const p = writeFile('bad.toml', 'this is = not = valid toml [');
+    expect(parseTomlMcpServerMap(p, 'mcp_servers')).toEqual([]);
+  });
+
+  it('returns [] when the table is missing', () => {
+    const p = writeFile('nokey.toml', '[other]\nfoo = "bar"\n');
+    expect(parseTomlMcpServerMap(p, 'mcp_servers')).toEqual([]);
+  });
+
+  it('strips a leading UTF-8 BOM', () => {
+    const p = writeFile('bom.toml', '\uFEFF[mcp_servers.fs]\ncommand = "npx"\n');
+    expect(parseTomlMcpServerMap(p, 'mcp_servers')).toEqual([
+      { name: 'fs', transport: 'local', command: ['npx'] },
+    ]);
+  });
+
+  it('extracts a local server with command+args', () => {
+    const p = writeFile(
+      'local.toml',
+      `
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/home"]
+`,
+    );
+    expect(parseTomlMcpServerMap(p, 'mcp_servers')).toEqual([
+      {
+        name: 'filesystem',
+        transport: 'local',
+        command: [
+          'npx',
+          '-y',
+          '@modelcontextprotocol/server-filesystem',
+          '/home',
+        ],
+      },
+    ]);
+  });
+
+  it('extracts a remote server with url', () => {
+    const p = writeFile(
+      'remote.toml',
+      `
+[mcp_servers.remote_server]
+url = "https://mcp.example.com/mcp"
+bearer_token_env_var = "MCP_TOKEN"
+`,
+    );
+    expect(parseTomlMcpServerMap(p, 'mcp_servers')).toEqual([
+      {
+        name: 'remote_server',
+        transport: 'remote',
+        url: 'https://mcp.example.com/mcp',
+      },
+    ]);
+  });
+});
+
+describe('parseYamlMcpServerList', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseYamlMcpServerList('/no/such/file', 'mcpServers')).toEqual([]);
+  });
+
+  it('returns [] for malformed YAML', () => {
+    const p = writeFile('bad.yaml', 'name: [unterminated: : :');
+    expect(parseYamlMcpServerList(p, 'mcpServers')).toEqual([]);
+  });
+
+  it('strips a leading UTF-8 BOM', () => {
+    const p = writeFile(
+      'bom.yaml',
+      `
+\uFEFFname: sample
+mcpServers:
+  - name: fs
+    command: npx
+    args:
+      - -y
+      - server-fs
+`,
+    );
+    expect(parseYamlMcpServerList(p, 'mcpServers')).toEqual([
+      { name: 'fs', transport: 'local', command: ['npx', '-y', 'server-fs'] },
+    ]);
+  });
+
+  it('extracts a YAML list of local servers', () => {
+    const p = writeFile(
+      'local.yaml',
+      `
+name: sample
+schema: v1
+mcpServers:
+  - name: playwright
+    command: npx
+    args:
+      - -y
+      - '@microsoft/mcp-server-playwright'
+  - name: memory
+    command: npx
+    args:
+      - -y
+      - '@modelcontextprotocol/server-memory'
+`,
+    );
+    expect(parseYamlMcpServerList(p, 'mcpServers')).toEqual([
+      {
+        name: 'playwright',
+        transport: 'local',
+        command: ['npx', '-y', '@microsoft/mcp-server-playwright'],
+      },
+      {
+        name: 'memory',
+        transport: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-memory'],
+      },
+    ]);
+  });
+
+  it('extracts a YAML list of remote servers', () => {
+    const p = writeFile(
+      'remote.yaml',
+      `
+name: sample
+mcpServers:
+  - name: r
+    type: streamable-http
+    url: https://mcp.example.com/mcp
+`,
+    );
+    expect(parseYamlMcpServerList(p, 'mcpServers')).toEqual([
+      {
+        name: 'r',
+        transport: 'remote',
+        url: 'https://mcp.example.com/mcp',
+      },
+    ]);
+  });
+
+  it('skips YAML list items missing the `name` field', () => {
+    const p = writeFile(
+      'skipname.yaml',
+      `
+mcpServers:
+  - command: npx
+`,
+    );
+    expect(parseYamlMcpServerList(p, 'mcpServers')).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-mcp-servers.spec.ts
+++ b/packages/agents/src/parse-mcp-servers.spec.ts
@@ -143,9 +143,7 @@ describe('parseJsoncMcpServerMap', () => {
       parseJsoncMcpServerMap(p, 'mcpServers', {
         urlFields: ['url', 'serverUrl'],
       }),
-    ).toEqual([
-      { name: 'r', transport: 'remote', url: 'https://example.com' },
-    ]);
+    ).toEqual([{ name: 'r', transport: 'remote', url: 'https://example.com' }]);
   });
 
   it('returns [] when the top-level value is an array, not a map (JSON variant)', () => {
@@ -170,7 +168,10 @@ describe('parseTomlMcpServerMap', () => {
   });
 
   it('strips a leading UTF-8 BOM', () => {
-    const p = writeFile('bom.toml', '\uFEFF[mcp_servers.fs]\ncommand = "npx"\n');
+    const p = writeFile(
+      'bom.toml',
+      '\uFEFF[mcp_servers.fs]\ncommand = "npx"\n',
+    );
     expect(parseTomlMcpServerMap(p, 'mcp_servers')).toEqual([
       { name: 'fs', transport: 'local', command: ['npx'] },
     ]);

--- a/packages/agents/src/parse-mcp-servers.ts
+++ b/packages/agents/src/parse-mcp-servers.ts
@@ -1,0 +1,230 @@
+// Shared helpers used by every per-agent `parseServers` handler.
+//
+// Each helper reads an MCP config file at `resolvedPath`, extracts the
+// server entries at the platform's top-level key/table, normalizes them
+// into `McpServerEntry[]`, and returns `[]` on any read or parse failure
+// (silent degradation — the CLI just omits the server list).
+//
+// All helpers are synchronous because the CLI's `parseServersForAgent`
+// dispatches synchronously, and the underlying parsers (jsonc-parser,
+// smol-toml, yaml) all support sync parse.
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { parse as parseJsonc } from 'jsonc-parser/lib/esm/main.js';
+import type { McpServerEntry } from './types.js';
+
+const require = createRequire(import.meta.url);
+// Load yaml the same way smol-toml is loaded in mcp-config-parser.ts:
+// as a runtime dep installed alongside @jander99/overture, loaded at
+// module-init time via createRequire so the bundle stays a single file
+// and consumers get the parser via `npm install`.
+const yaml: { parse: (text: string) => unknown } = require('yaml');
+const smolToml: { parse: (text: string) => unknown } = require('smol-toml');
+
+/**
+ * Per-agent overrides for transport inference. Most agents use the
+ * defaults; windsurf needs `serverUrl` accepted as a remote URL
+ * (it appears in older doc versions), and the copilot CLI family
+ * uses `local`/`http` (already in defaults).
+ */
+export interface ParseServerMapOptions {
+  /** Field names that mark an entry as remote when present and string-shaped. Default: `['url']`. */
+  readonly urlFields?: readonly string[];
+  /** `type` values that mark an entry as remote. Default: HTTP/SSE/streamable/remote/ws. */
+  readonly remoteTypes?: readonly string[];
+  /** `type` values that mark an entry as local. Default: `['local', 'stdio']`. */
+  readonly localTypes?: readonly string[];
+}
+
+const DEFAULT_URL_FIELDS = ['url'] as const;
+const DEFAULT_REMOTE_TYPES = [
+  'http',
+  'sse',
+  'remote',
+  'streamable-http',
+  'ws',
+] as const;
+const DEFAULT_LOCAL_TYPES = ['local', 'stdio'] as const;
+
+const UTF8_BOM = '\uFEFF';
+
+function stripBom(text: string): string {
+  return text.startsWith(UTF8_BOM) ? text.slice(1) : text;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asStringArray(value: unknown): readonly string[] | undefined {
+  if (Array.isArray(value)) {
+    const strings = value.filter((v): v is string => typeof v === 'string');
+    return strings.length === value.length ? strings : undefined;
+  }
+  return undefined;
+}
+
+function normalizeCommand(entry: Record<string, unknown>): readonly string[] | undefined {
+  // OpenAI Codex uses bare `command` as a string + `args` array.
+  const cmdStr = asString(entry.command);
+  if (cmdStr) {
+    const args = asStringArray(entry.args);
+    return args ? [cmdStr, ...args] : [cmdStr];
+  }
+  // OpenCode uses `command` as an argv vector (no separate args).
+  const cmdArr = asStringArray(entry.command);
+  if (cmdArr) {
+    const args = asStringArray(entry.args);
+    return args ? [...cmdArr, ...args] : cmdArr;
+  }
+  return undefined;
+}
+
+function inferTransport(
+  entry: Record<string, unknown>,
+  options: Required<ParseServerMapOptions>,
+): 'local' | 'remote' {
+  const type = asString(entry.type);
+  if (type) {
+    if (options.remoteTypes.includes(type)) return 'remote';
+    if (options.localTypes.includes(type)) return 'local';
+    // Unknown type value: fall through to URL-field inference.
+  }
+  for (const field of options.urlFields) {
+    if (asString(entry[field])) return 'remote';
+  }
+  return 'local';
+}
+
+function normalizeServerEntry(
+  name: string,
+  raw: unknown,
+  options: Required<ParseServerMapOptions>,
+): McpServerEntry | null {
+  if (!isRecord(raw)) return null;
+  const transport = inferTransport(raw, options);
+  const urlField = options.urlFields
+    .map((f) => asString(raw[f]))
+    .find((v): v is string => Boolean(v));
+  const command = transport === 'local' ? normalizeCommand(raw) : undefined;
+  return {
+    name,
+    transport,
+    ...(urlField ? { url: urlField } : {}),
+    ...(command ? { command } : {}),
+  };
+}
+
+function resolveOptions(options?: ParseServerMapOptions): Required<ParseServerMapOptions> {
+  return {
+    urlFields: options?.urlFields ?? DEFAULT_URL_FIELDS,
+    remoteTypes: options?.remoteTypes ?? DEFAULT_REMOTE_TYPES,
+    localTypes: options?.localTypes ?? DEFAULT_LOCAL_TYPES,
+  };
+}
+
+function iterateServerMap(
+  document: unknown,
+  topLevelKey: string,
+  options: Required<ParseServerMapOptions>,
+): readonly McpServerEntry[] {
+  if (!isRecord(document)) return [];
+  const map = document[topLevelKey];
+  if (!isRecord(map) && !Array.isArray(map)) return [];
+
+  if (Array.isArray(map)) {
+    // YAML-list shape (continue): each item has its own `name` field.
+    const out: McpServerEntry[] = [];
+    for (const item of map) {
+      if (!isRecord(item)) continue;
+      const itemName = asString(item.name);
+      if (!itemName) continue;
+      const entry = normalizeServerEntry(itemName, item, options);
+      if (entry) out.push(entry);
+    }
+    return out;
+  }
+
+  const out: McpServerEntry[] = [];
+  for (const [name, raw] of Object.entries(map)) {
+    const entry = normalizeServerEntry(name, raw, options);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+/**
+ * Parse a JSON/JSONC MCP config file. Tolerates trailing commas and
+ * `//` / `/* * /` comments. Strips a leading UTF-8 BOM.
+ *
+ * Returns `[]` on any read or parse failure.
+ */
+export function parseJsoncMcpServerMap(
+  resolvedPath: string,
+  topLevelKey: string,
+  options?: ParseServerMapOptions,
+): readonly McpServerEntry[] {
+  const resolved = resolveOptions(options);
+  try {
+    const raw = readFileSync(resolvedPath, 'utf8');
+    const cleaned = stripBom(raw);
+    const errors: unknown[] = [];
+    const parsed: unknown = parseJsonc(cleaned, errors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    });
+    if (errors.length > 0) return [];
+    return iterateServerMap(parsed, topLevelKey, resolved);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parse a TOML MCP config file. Strips a leading UTF-8 BOM.
+ *
+ * Returns `[]` on any read or parse failure.
+ */
+export function parseTomlMcpServerMap(
+  resolvedPath: string,
+  topLevelKey: string,
+  options?: ParseServerMapOptions,
+): readonly McpServerEntry[] {
+  const resolved = resolveOptions(options);
+  try {
+    const raw = readFileSync(resolvedPath, 'utf8');
+    const cleaned = stripBom(raw);
+    const parsed: unknown = smolToml.parse(cleaned);
+    return iterateServerMap(parsed, topLevelKey, resolved);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parse a YAML MCP config file. Used by Continue, which stores
+ * server entries as a YAML list (not a map). The list shape is
+ * handled by {@link iterateServerMap} when it sees an array at the
+ * top-level key.
+ *
+ * Returns `[]` on any read or parse failure.
+ */
+export function parseYamlMcpServerList(
+  resolvedPath: string,
+  topLevelKey: string,
+  options?: ParseServerMapOptions,
+): readonly McpServerEntry[] {
+  const resolved = resolveOptions(options);
+  try {
+    const raw = readFileSync(resolvedPath, 'utf8');
+    const cleaned = stripBom(raw);
+    const parsed: unknown = yaml.parse(cleaned);
+    return iterateServerMap(parsed, topLevelKey, resolved);
+  } catch {
+    return [];
+  }
+}

--- a/packages/agents/src/parse-mcp-servers.ts
+++ b/packages/agents/src/parse-mcp-servers.ts
@@ -10,10 +10,7 @@
 // smol-toml, yaml) all support sync parse.
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import {
-  parse as parseJsonc,
-  type ParseError,
-} from 'jsonc-parser/lib/esm/main.js';
+import { parse as parseJsonc, type ParseError } from 'jsonc-parser/lib/esm/main.js';
 import type { McpServerEntry } from './types.js';
 
 const localRequire = createRequire(__filename);
@@ -38,6 +35,13 @@ export interface ParseServerMapOptions {
   readonly remoteTypes?: readonly string[];
   /** `type` values that mark an entry as local. Default: `['local', 'stdio']`. */
   readonly localTypes?: readonly string[];
+  /**
+   * Allow a list-shaped value at the top-level key (each item must
+   * carry its own `name` field). Continue's YAML configs use this
+   * shape; JSON and TOML configs are always map-shaped. Default: `false`.
+   * The YAML helper forces this to `true` regardless of caller input.
+   */
+  readonly allowListShape?: boolean;
 }
 
 const DEFAULT_URL_FIELDS = ['url'] as const;
@@ -132,6 +136,7 @@ function resolveOptions(
     urlFields: options?.urlFields ?? DEFAULT_URL_FIELDS,
     remoteTypes: options?.remoteTypes ?? DEFAULT_REMOTE_TYPES,
     localTypes: options?.localTypes ?? DEFAULT_LOCAL_TYPES,
+    allowListShape: options?.allowListShape ?? false,
   };
 }
 
@@ -145,6 +150,11 @@ function iterateServerMap(
   if (!isRecord(map) && !Array.isArray(map)) return [];
 
   if (Array.isArray(map)) {
+    if (!options.allowListShape) {
+      // JSON/TOML configs are always map-shaped; a list here is
+      // almost certainly a malformed/empty config, not a YAML list.
+      return [];
+    }
     // YAML-list shape (continue): each item has its own `name` field.
     const out: McpServerEntry[] = [];
     for (const item of map) {
@@ -166,10 +176,12 @@ function iterateServerMap(
 }
 
 /**
- * Parse a JSON/JSONC MCP config file. Tolerates trailing commas and
- * `//` / `/* * /` comments. Strips a leading UTF-8 BOM.
+ * Parse a JSON/JSONC MCP config file. Tolerates trailing commas,
+ * line comments, and block comments. Strips a leading UTF-8 BOM.
  *
- * Returns `[]` on any read or parse failure.
+ * Returns `[]` on any read or parse failure. The top-level value is
+ * always expected to be a map (not a list) — a list at the top-level
+ * key returns `[]` (see `allowListShape` for the YAML-list shape).
  */
 export function parseJsoncMcpServerMap(
   resolvedPath: string,
@@ -195,7 +207,9 @@ export function parseJsoncMcpServerMap(
 /**
  * Parse a TOML MCP config file. Strips a leading UTF-8 BOM.
  *
- * Returns `[]` on any read or parse failure.
+ * Returns `[]` on any read or parse failure. The top-level value is
+ * always expected to be a map (not a list) — a list at the top-level
+ * key returns `[]` (see `allowListShape` for the YAML-list shape).
  */
 export function parseTomlMcpServerMap(
   resolvedPath: string,
@@ -216,8 +230,9 @@ export function parseTomlMcpServerMap(
 /**
  * Parse a YAML MCP config file. Used by Continue, which stores
  * server entries as a YAML list (not a map). The list shape is
- * handled by {@link iterateServerMap} when it sees an array at the
- * top-level key.
+ * handled by `iterateServerMap` when it sees an array at the
+ * top-level key — this helper forces `allowListShape: true` so
+ * the list shape is accepted (JSON and TOML helpers default to false).
  *
  * Returns `[]` on any read or parse failure.
  */
@@ -226,7 +241,9 @@ export function parseYamlMcpServerList(
   topLevelKey: string,
   options?: ParseServerMapOptions,
 ): readonly McpServerEntry[] {
-  const resolved = resolveOptions(options);
+  // YAML is the one format where the top-level value can be a list
+  // (Continue's standalone config), so opt in to list handling here.
+  const resolved = { ...resolveOptions(options), allowListShape: true };
   try {
     const raw = readFileSync(resolvedPath, 'utf8');
     const cleaned = stripBom(raw);

--- a/packages/agents/src/parse-mcp-servers.ts
+++ b/packages/agents/src/parse-mcp-servers.ts
@@ -10,8 +10,7 @@
 // smol-toml, yaml) all support sync parse.
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { parse as parseJsonc } from 'jsonc-parser/lib/esm/main.js';
-import type { McpServerEntry } from './types.js';
+import { parse as parseJsonc, type ParseError } from 'jsonc-parser/lib/esm/main.js';
 import type { McpServerEntry } from './types.js';
 
 const localRequire = createRequire(__filename);

--- a/packages/agents/src/parse-mcp-servers.ts
+++ b/packages/agents/src/parse-mcp-servers.ts
@@ -12,14 +12,15 @@ import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { parse as parseJsonc } from 'jsonc-parser/lib/esm/main.js';
 import type { McpServerEntry } from './types.js';
+import type { McpServerEntry } from './types.js';
 
-const require = createRequire(import.meta.url);
+const localRequire = createRequire(__filename);
 // Load yaml the same way smol-toml is loaded in mcp-config-parser.ts:
 // as a runtime dep installed alongside @jander99/overture, loaded at
 // module-init time via createRequire so the bundle stays a single file
 // and consumers get the parser via `npm install`.
-const yaml: { parse: (text: string) => unknown } = require('yaml');
-const smolToml: { parse: (text: string) => unknown } = require('smol-toml');
+const yaml: { parse: (text: string) => unknown } = localRequire('yaml');
+const smolToml: { parse: (text: string) => unknown } = localRequire('smol-toml');
 
 /**
  * Per-agent overrides for transport inference. Most agents use the
@@ -172,7 +173,7 @@ export function parseJsoncMcpServerMap(
   try {
     const raw = readFileSync(resolvedPath, 'utf8');
     const cleaned = stripBom(raw);
-    const errors: unknown[] = [];
+    const errors: ParseError[] = [];
     const parsed: unknown = parseJsonc(cleaned, errors, {
       allowTrailingComma: true,
       disallowComments: false,

--- a/packages/agents/src/parse-mcp-servers.ts
+++ b/packages/agents/src/parse-mcp-servers.ts
@@ -10,7 +10,10 @@
 // smol-toml, yaml) all support sync parse.
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { parse as parseJsonc, type ParseError } from 'jsonc-parser/lib/esm/main.js';
+import {
+  parse as parseJsonc,
+  type ParseError,
+} from 'jsonc-parser/lib/esm/main.js';
 import type { McpServerEntry } from './types.js';
 
 const localRequire = createRequire(__filename);
@@ -19,7 +22,8 @@ const localRequire = createRequire(__filename);
 // module-init time via createRequire so the bundle stays a single file
 // and consumers get the parser via `npm install`.
 const yaml: { parse: (text: string) => unknown } = localRequire('yaml');
-const smolToml: { parse: (text: string) => unknown } = localRequire('smol-toml');
+const smolToml: { parse: (text: string) => unknown } =
+  localRequire('smol-toml');
 
 /**
  * Per-agent overrides for transport inference. Most agents use the
@@ -68,7 +72,9 @@ function asStringArray(value: unknown): readonly string[] | undefined {
   return undefined;
 }
 
-function normalizeCommand(entry: Record<string, unknown>): readonly string[] | undefined {
+function normalizeCommand(
+  entry: Record<string, unknown>,
+): readonly string[] | undefined {
   // OpenAI Codex uses bare `command` as a string + `args` array.
   const cmdStr = asString(entry.command);
   if (cmdStr) {
@@ -119,7 +125,9 @@ function normalizeServerEntry(
   };
 }
 
-function resolveOptions(options?: ParseServerMapOptions): Required<ParseServerMapOptions> {
+function resolveOptions(
+  options?: ParseServerMapOptions,
+): Required<ParseServerMapOptions> {
   return {
     urlFields: options?.urlFields ?? DEFAULT_URL_FIELDS,
     remoteTypes: options?.remoteTypes ?? DEFAULT_REMOTE_TYPES,

--- a/packages/agents/src/parse-mcp-servers.ts
+++ b/packages/agents/src/parse-mcp-servers.ts
@@ -10,7 +10,10 @@
 // smol-toml, yaml) all support sync parse.
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { parse as parseJsonc, type ParseError } from 'jsonc-parser/lib/esm/main.js';
+import {
+  parse as parseJsonc,
+  type ParseError,
+} from 'jsonc-parser/lib/esm/main.js';
 import type { McpServerEntry } from './types.js';
 
 const localRequire = createRequire(__filename);

--- a/packages/agents/src/parse-servers.claude-code.spec.ts
+++ b/packages/agents/src/parse-servers.claude-code.spec.ts
@@ -1,0 +1,74 @@
+// Tests for the claude-code parseServers handler.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseClaudeCodeMcpServers } from './claude-code.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-claude-code-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseClaudeCodeMcpServers', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseClaudeCodeMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('bad.json', '{ not valid');
+    expect(parseClaudeCodeMcpServers(p)).toEqual([]);
+  });
+
+  it('extracts a local stdio server', () => {
+    const p = writeFile(
+      'local.json',
+      JSON.stringify({
+        mcpServers: {
+          shared: { command: '/path/to/server', args: [], env: {} },
+        },
+      }),
+    );
+    expect(parseClaudeCodeMcpServers(p)).toEqual([
+      { name: 'shared', transport: 'local', command: ['/path/to/server'] },
+    ]);
+  });
+
+  it('extracts a remote HTTP server with headers', () => {
+    const p = writeFile(
+      'remote.json',
+      JSON.stringify({
+        mcpServers: {
+          remote: {
+            type: 'http',
+            url: 'https://mcp.example.com/mcp',
+            headers: { Authorization: 'Bearer ${MCP_TOKEN}' },
+          },
+        },
+      }),
+    );
+    expect(parseClaudeCodeMcpServers(p)).toEqual([
+      {
+        name: 'remote',
+        transport: 'remote',
+        url: 'https://mcp.example.com/mcp',
+      },
+    ]);
+  });
+
+  it('returns [] when the top-level key is absent', () => {
+    const p = writeFile('nokey.json', JSON.stringify({ other: {} }));
+    expect(parseClaudeCodeMcpServers(p)).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.claude-desktop.spec.ts
+++ b/packages/agents/src/parse-servers.claude-desktop.spec.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseClaudeDesktopMcpServers } from './claude-desktop.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'claude-desktop-parse-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const path = join(workdir, name);
+  writeFileSync(path, contents);
+  return path;
+}
+
+describe('parseClaudeDesktopMcpServers', () => {
+  it('parses local-only npx servers', () => {
+    const path = writeFile(
+      'claude_desktop_config.json',
+      JSON.stringify({
+        mcpServers: {
+          filesystem: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem'] },
+        },
+      }),
+    );
+
+    expect(parseClaudeDesktopMcpServers(path)).toEqual([
+      {
+        name: 'filesystem',
+        transport: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-filesystem'],
+      },
+    ]);
+  });
+
+  it('returns [] for a missing file', () => {
+    expect(parseClaudeDesktopMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const path = writeFile('bad.json', '{"mcpServers": {');
+    expect(parseClaudeDesktopMcpServers(path)).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.claude-desktop.spec.ts
+++ b/packages/agents/src/parse-servers.claude-desktop.spec.ts
@@ -43,6 +43,26 @@ describe('parseClaudeDesktopMcpServers', () => {
     ]);
   });
 
+  it('infers a remote server from a `url` field (no explicit type)', () => {
+    // Claude Desktop's documented config is local-only, but the
+    // shared helper infers remote from `url` for forward-compat
+    // with future transport support. This test pins the behavior.
+    const path = writeFile(
+      'remote.json',
+      JSON.stringify({
+        mcpServers: { remote: { url: 'https://mcp.example.com/mcp' } },
+      }),
+    );
+
+    expect(parseClaudeDesktopMcpServers(path)).toEqual([
+      {
+        name: 'remote',
+        transport: 'remote',
+        url: 'https://mcp.example.com/mcp',
+      },
+    ]);
+  });
+
   it('returns [] for a missing file', () => {
     expect(parseClaudeDesktopMcpServers('/no/such/file')).toEqual([]);
   });

--- a/packages/agents/src/parse-servers.claude-desktop.spec.ts
+++ b/packages/agents/src/parse-servers.claude-desktop.spec.ts
@@ -47,13 +47,13 @@ describe('parseClaudeDesktopMcpServers', () => {
     expect(parseClaudeDesktopMcpServers('/no/such/file')).toEqual([]);
   });
 
-it('returns [] for malformed JSON', () => {
-const path = writeFile('bad.json', '{"mcpServers": {');
-expect(parseClaudeDesktopMcpServers(path)).toEqual([]);
+  it('returns [] for malformed JSON', () => {
+    const path = writeFile('bad.json', '{"mcpServers": {');
+    expect(parseClaudeDesktopMcpServers(path)).toEqual([]);
   });
 
   it('returns [] when the top-level key is absent', () => {
     const path = writeFile('nokey.json', JSON.stringify({ other: {} }));
     expect(parseClaudeDesktopMcpServers(path)).toEqual([]);
-});
+  });
 });

--- a/packages/agents/src/parse-servers.claude-desktop.spec.ts
+++ b/packages/agents/src/parse-servers.claude-desktop.spec.ts
@@ -47,8 +47,13 @@ describe('parseClaudeDesktopMcpServers', () => {
     expect(parseClaudeDesktopMcpServers('/no/such/file')).toEqual([]);
   });
 
-  it('returns [] for malformed JSON', () => {
-    const path = writeFile('bad.json', '{"mcpServers": {');
-    expect(parseClaudeDesktopMcpServers(path)).toEqual([]);
+it('returns [] for malformed JSON', () => {
+const path = writeFile('bad.json', '{"mcpServers": {');
+expect(parseClaudeDesktopMcpServers(path)).toEqual([]);
   });
+
+  it('returns [] when the top-level key is absent', () => {
+    const path = writeFile('nokey.json', JSON.stringify({ other: {} }));
+    expect(parseClaudeDesktopMcpServers(path)).toEqual([]);
+});
 });

--- a/packages/agents/src/parse-servers.claude-desktop.spec.ts
+++ b/packages/agents/src/parse-servers.claude-desktop.spec.ts
@@ -26,7 +26,10 @@ describe('parseClaudeDesktopMcpServers', () => {
       'claude_desktop_config.json',
       JSON.stringify({
         mcpServers: {
-          filesystem: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem'] },
+          filesystem: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-filesystem'],
+          },
         },
       }),
     );

--- a/packages/agents/src/parse-servers.cline.spec.ts
+++ b/packages/agents/src/parse-servers.cline.spec.ts
@@ -1,0 +1,78 @@
+// Tests for the cline parseServers handler.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseClineMcpServers } from './cline.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-cline-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseClineMcpServers', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseClineMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('bad.json', '{ not valid');
+    expect(parseClineMcpServers(p)).toEqual([]);
+  });
+
+  it('extracts a local stdio server (ignores the `disabled` field)', () => {
+    const p = writeFile(
+      'local.json',
+      JSON.stringify({
+        mcpServers: {
+          memory: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-memory'],
+            env: {},
+            disabled: false,
+          },
+        },
+      }),
+    );
+    expect(parseClineMcpServers(p)).toEqual([
+      {
+        name: 'memory',
+        transport: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-memory'],
+      },
+    ]);
+  });
+
+  it('extracts a remote server with explicit `transportType`', () => {
+    const p = writeFile(
+      'remote.json',
+      JSON.stringify({
+        mcpServers: {
+          r: {
+            url: 'https://mcp.example.com/mcp',
+            headers: { Authorization: 'Bearer ${TOKEN}' },
+          },
+        },
+      }),
+    );
+    expect(parseClineMcpServers(p)).toEqual([
+      { name: 'r', transport: 'remote', url: 'https://mcp.example.com/mcp' },
+    ]);
+  });
+
+  it('returns [] when the top-level key is absent', () => {
+    const p = writeFile('nokey.json', JSON.stringify({ other: {} }));
+    expect(parseClineMcpServers(p)).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.continue.spec.ts
+++ b/packages/agents/src/parse-servers.continue.spec.ts
@@ -1,0 +1,103 @@
+// Tests for the continue parseServers handler.
+// This agent accepts both YAML standalone files (.yaml/.yml) and
+// JSON imports copied from clients like Claude/Cursor/Cline.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseContinueMcpServers } from './continue.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-continue-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseContinueMcpServers', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseContinueMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('parses a YAML list of local servers (YAML standalone)', () => {
+    const p = writeFile(
+      'playwright.yaml',
+      `
+name: playwright-mcp
+version: 0.0.1
+schema: v1
+mcpServers:
+  - name: playwright
+    command: npx
+    args:
+      - -y
+      - '@microsoft/mcp-server-playwright'
+`,
+    );
+    expect(parseContinueMcpServers(p)).toEqual([
+      {
+        name: 'playwright',
+        transport: 'local',
+        command: ['npx', '-y', '@microsoft/mcp-server-playwright'],
+      },
+    ]);
+  });
+
+  it('parses a YAML list of remote servers', () => {
+    const p = writeFile(
+      'remote.yml',
+      `
+name: remote-mcp
+schema: v1
+mcpServers:
+  - name: remote-server
+    type: streamable-http
+    url: https://mcp.example.com/mcp
+`,
+    );
+    expect(parseContinueMcpServers(p)).toEqual([
+      {
+        name: 'remote-server',
+        transport: 'remote',
+        url: 'https://mcp.example.com/mcp',
+      },
+    ]);
+  });
+
+  it('parses a JSON file imported from another client (JSON fallback)', () => {
+    const p = writeFile(
+      'mcp.json',
+      JSON.stringify({
+        mcpServers: {
+          fs: { command: 'npx', args: ['-y', 'fs-server'] },
+        },
+      }),
+    );
+    expect(parseContinueMcpServers(p)).toEqual([
+      {
+        name: 'fs',
+        transport: 'local',
+        command: ['npx', '-y', 'fs-server'],
+      },
+    ]);
+  });
+
+  it('returns [] for malformed YAML', () => {
+    const p = writeFile('bad.yaml', 'name: [unterminated: : :');
+    expect(parseContinueMcpServers(p)).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('mcp.json', '{ not valid');
+    expect(parseContinueMcpServers(p)).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.cursor.spec.ts
+++ b/packages/agents/src/parse-servers.cursor.spec.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseCursorMcpServers } from './cursor.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-cursor-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseCursorMcpServers', () => {
+  it('returns local-only servers', () => {
+    const p = writeFile(
+      'local.json',
+      JSON.stringify({
+        mcpServers: {
+          fs: { command: 'npx', args: ['-y', 'server-fs'] },
+        },
+      }),
+    );
+
+    expect(parseCursorMcpServers(p)).toEqual([
+      { name: 'fs', transport: 'local', command: ['npx', '-y', 'server-fs'] },
+    ]);
+  });
+
+  it('returns remote-only servers inferred from url', () => {
+    const p = writeFile(
+      'remote.json',
+      JSON.stringify({
+        mcpServers: {
+          gh: { url: 'https://api.githubcopilot.com/mcp' },
+        },
+      }),
+    );
+
+    expect(parseCursorMcpServers(p)).toEqual([
+      {
+        name: 'gh',
+        transport: 'remote',
+        url: 'https://api.githubcopilot.com/mcp',
+      },
+    ]);
+  });
+
+  it('returns [] for a missing file', () => {
+    expect(parseCursorMcpServers('/no/such/file')).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.cursor.spec.ts
+++ b/packages/agents/src/parse-servers.cursor.spec.ts
@@ -1,3 +1,4 @@
+// Tests for the cursor parseServers handler.
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -57,5 +58,15 @@ describe('parseCursorMcpServers', () => {
 
   it('returns [] for a missing file', () => {
     expect(parseCursorMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('bad.json', '{ not valid');
+    expect(parseCursorMcpServers(p)).toEqual([]);
+  });
+
+  it('returns [] when the top-level key is absent', () => {
+    const p = writeFile('nokey.json', JSON.stringify({ other: {} }));
+    expect(parseCursorMcpServers(p)).toEqual([]);
   });
 });

--- a/packages/agents/src/parse-servers.github-copilot-cli.spec.ts
+++ b/packages/agents/src/parse-servers.github-copilot-cli.spec.ts
@@ -1,0 +1,101 @@
+// Tests for the github-copilot-cli parseServers handler.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseGitHubCopilotCliMcpServers } from './github-copilot-cli.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-copilot-cli-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseGitHubCopilotCliMcpServers', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseGitHubCopilotCliMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('bad.json', '{ not valid');
+    expect(parseGitHubCopilotCliMcpServers(p)).toEqual([]);
+  });
+
+  it('extracts a local server with explicit type=local', () => {
+    const p = writeFile(
+      'local.json',
+      JSON.stringify({
+        mcpServers: {
+          memory: {
+            type: 'local',
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-memory'],
+            env: {},
+            tools: ['*'],
+          },
+        },
+      }),
+    );
+    expect(parseGitHubCopilotCliMcpServers(p)).toEqual([
+      {
+        name: 'memory',
+        transport: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-memory'],
+      },
+    ]);
+  });
+
+  it('extracts a remote server with type=http', () => {
+    const p = writeFile(
+      'remote.json',
+      JSON.stringify({
+        mcpServers: {
+          r: {
+            type: 'http',
+            url: 'https://mcp.example.com/mcp',
+            headers: { Authorization: 'Bearer ${MCP_TOKEN}' },
+            tools: ['tool_a', 'tool_b'],
+          },
+        },
+      }),
+    );
+    expect(parseGitHubCopilotCliMcpServers(p)).toEqual([
+      { name: 'r', transport: 'remote', url: 'https://mcp.example.com/mcp' },
+    ]);
+  });
+
+  it('extracts a mixed local+remote config', () => {
+    const p = writeFile(
+      'mixed.json',
+      JSON.stringify({
+        mcpServers: {
+          local: { type: 'local', command: 'npx', args: ['-y', 'a'] },
+          remote: { type: 'http', url: 'https://example.com/mcp' },
+        },
+      }),
+    );
+    expect(parseGitHubCopilotCliMcpServers(p)).toEqual([
+      { name: 'local', transport: 'local', command: ['npx', '-y', 'a'] },
+      {
+        name: 'remote',
+        transport: 'remote',
+        url: 'https://example.com/mcp',
+      },
+    ]);
+  });
+
+  it('returns [] when the top-level key is absent', () => {
+    const p = writeFile('nokey.json', JSON.stringify({ other: {} }));
+    expect(parseGitHubCopilotCliMcpServers(p)).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.github-copilot-vscode.spec.ts
+++ b/packages/agents/src/parse-servers.github-copilot-vscode.spec.ts
@@ -1,0 +1,83 @@
+// Tests for the github-copilot-vscode parseServers handler.
+// This agent uses the top-level 'servers' key (not 'mcpServers').
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseGitHubCopilotVSCodeMcpServers } from './github-copilot-vscode.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-copilot-vscode-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseGitHubCopilotVSCodeMcpServers', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseGitHubCopilotVSCodeMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('bad.json', '{ not valid');
+    expect(parseGitHubCopilotVSCodeMcpServers(p)).toEqual([]);
+  });
+
+  it('extracts a remote HTTP server from the `servers` top-level key', () => {
+    const p = writeFile(
+      'mcp.json',
+      JSON.stringify({
+        servers: {
+          github: { type: 'http', url: 'https://api.githubcopilot.com/mcp' },
+        },
+      }),
+    );
+    expect(parseGitHubCopilotVSCodeMcpServers(p)).toEqual([
+      {
+        name: 'github',
+        transport: 'remote',
+        url: 'https://api.githubcopilot.com/mcp',
+      },
+    ]);
+  });
+
+  it('extracts a local stdio server from the `servers` top-level key', () => {
+    const p = writeFile(
+      'mcp.json',
+      JSON.stringify({
+        servers: {
+          playwright: {
+            command: 'npx',
+            args: ['-y', '@microsoft/mcp-server-playwright'],
+          },
+        },
+      }),
+    );
+    expect(parseGitHubCopilotVSCodeMcpServers(p)).toEqual([
+      {
+        name: 'playwright',
+        transport: 'local',
+        command: ['npx', '-y', '@microsoft/mcp-server-playwright'],
+      },
+    ]);
+  });
+
+  it('returns [] when the file has `mcpServers` instead of `servers`', () => {
+    const p = writeFile(
+      'mcp.json',
+      JSON.stringify({
+        mcpServers: { foo: { command: 'x' } },
+      }),
+    );
+    expect(parseGitHubCopilotVSCodeMcpServers(p)).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.openai-codex.spec.ts
+++ b/packages/agents/src/parse-servers.openai-codex.spec.ts
@@ -1,0 +1,81 @@
+// Tests for the openai-codex parseServers handler.
+// This agent stores MCP config in TOML tables keyed [mcp_servers.<name>].
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseOpenAICodexMcpServers } from './openai-codex.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-openai-codex-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseOpenAICodexMcpServers', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseOpenAICodexMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed TOML', () => {
+    const p = writeFile('bad.toml', 'this is = not = valid toml [');
+    expect(parseOpenAICodexMcpServers(p)).toEqual([]);
+  });
+
+  it('extracts a local stdio server from a TOML table', () => {
+    const p = writeFile(
+      'config.toml',
+      `
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/home"]
+enabled = true
+`,
+    );
+    expect(parseOpenAICodexMcpServers(p)).toEqual([
+      {
+        name: 'filesystem',
+        transport: 'local',
+        command: [
+          'npx',
+          '-y',
+          '@modelcontextprotocol/server-filesystem',
+          '/home',
+        ],
+      },
+    ]);
+  });
+
+  it('extracts a remote server from a TOML table', () => {
+    const p = writeFile(
+      'config.toml',
+      `
+[mcp_servers.remote_server]
+url = "https://mcp.example.com/mcp"
+bearer_token_env_var = "MCP_TOKEN"
+`,
+    );
+    expect(parseOpenAICodexMcpServers(p)).toEqual([
+      {
+        name: 'remote_server',
+        transport: 'remote',
+        url: 'https://mcp.example.com/mcp',
+      },
+    ]);
+  });
+
+  it('returns [] when the [mcp_servers] table is absent', () => {
+    const p = writeFile('config.toml', '[other]\nfoo = "bar"\n');
+    expect(parseOpenAICodexMcpServers(p)).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.roo-code.spec.ts
+++ b/packages/agents/src/parse-servers.roo-code.spec.ts
@@ -1,0 +1,84 @@
+// Tests for the roo-code parseServers handler.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseRooCodeMcpServers } from './roo-code.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-roo-code-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseRooCodeMcpServers', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseRooCodeMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('bad.json', '{ not valid');
+    expect(parseRooCodeMcpServers(p)).toEqual([]);
+  });
+
+  it('extracts a local stdio server (ignores the policy extras)', () => {
+    const p = writeFile(
+      'local.json',
+      JSON.stringify({
+        mcpServers: {
+          memory: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-memory'],
+            cwd: '/home/me/project',
+            env: {},
+            alwaysAllow: [],
+            disabled: false,
+            timeout: 60,
+            watchPaths: [],
+            disabledTools: [],
+          },
+        },
+      }),
+    );
+    expect(parseRooCodeMcpServers(p)).toEqual([
+      {
+        name: 'memory',
+        transport: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-memory'],
+      },
+    ]);
+  });
+
+  it('extracts a remote streamable-http server', () => {
+    const p = writeFile(
+      'remote.json',
+      JSON.stringify({
+        mcpServers: {
+          r: {
+            type: 'streamable-http',
+            url: 'https://mcp.example.com/mcp',
+            headers: { Authorization: 'Bearer ${MCP_TOKEN}' },
+          },
+        },
+      }),
+    );
+    expect(parseRooCodeMcpServers(p)).toEqual([
+      { name: 'r', transport: 'remote', url: 'https://mcp.example.com/mcp' },
+    ]);
+  });
+
+  it('returns [] when the top-level key is absent', () => {
+    const p = writeFile('nokey.json', JSON.stringify({ other: {} }));
+    expect(parseRooCodeMcpServers(p)).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.windsurf.spec.ts
+++ b/packages/agents/src/parse-servers.windsurf.spec.ts
@@ -51,7 +51,12 @@ describe('parseWindsurfMcpServers', () => {
       {
         name: 'filesystem',
         transport: 'local',
-        command: ['npx', '-y', '@modelcontextprotocol/server-filesystem', '/home'],
+        command: [
+          'npx',
+          '-y',
+          '@modelcontextprotocol/server-filesystem',
+          '/home',
+        ],
       },
       {
         name: 'memory',

--- a/packages/agents/src/parse-servers.windsurf.spec.ts
+++ b/packages/agents/src/parse-servers.windsurf.spec.ts
@@ -1,0 +1,92 @@
+// Tests for the windsurf parseServers handler.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseWindsurfMcpServers } from './windsurf.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-windsurf-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseWindsurfMcpServers', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseWindsurfMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('bad.json', '{ not valid');
+    expect(parseWindsurfMcpServers(p)).toEqual([]);
+  });
+
+  it('extracts local stdio servers (filesystem + memory)', () => {
+    const p = writeFile(
+      'local.json',
+      JSON.stringify({
+        mcpServers: {
+          filesystem: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-filesystem', '/home'],
+          },
+          memory: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-memory'],
+          },
+        },
+      }),
+    );
+    expect(parseWindsurfMcpServers(p)).toEqual([
+      {
+        name: 'filesystem',
+        transport: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-filesystem', '/home'],
+      },
+      {
+        name: 'memory',
+        transport: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-memory'],
+      },
+    ]);
+  });
+
+  it('extracts a remote server with `url`', () => {
+    const p = writeFile(
+      'remote-url.json',
+      JSON.stringify({
+        mcpServers: { r: { url: 'https://mcp.example.com/mcp' } },
+      }),
+    );
+    expect(parseWindsurfMcpServers(p)).toEqual([
+      { name: 'r', transport: 'remote', url: 'https://mcp.example.com/mcp' },
+    ]);
+  });
+
+  it('extracts a remote server with `serverUrl` (Windsurf-specific alias)', () => {
+    const p = writeFile(
+      'remote-serverurl.json',
+      JSON.stringify({
+        mcpServers: { r: { serverUrl: 'https://mcp.example.com/mcp' } },
+      }),
+    );
+    expect(parseWindsurfMcpServers(p)).toEqual([
+      { name: 'r', transport: 'remote', url: 'https://mcp.example.com/mcp' },
+    ]);
+  });
+
+  it('returns [] when the top-level key is absent', () => {
+    const p = writeFile('nokey.json', JSON.stringify({ other: {} }));
+    expect(parseWindsurfMcpServers(p)).toEqual([]);
+  });
+});

--- a/packages/agents/src/parse-servers.zed.spec.ts
+++ b/packages/agents/src/parse-servers.zed.spec.ts
@@ -1,0 +1,85 @@
+// Tests for the zed parseServers handler.
+// This agent uses the top-level 'context_servers' key.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseZedMcpServers } from './zed.js';
+
+let workdir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), 'parse-servers-zed-'));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe('parseZedMcpServers', () => {
+  it('returns [] for an unreadable path', () => {
+    expect(parseZedMcpServers('/no/such/file')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const p = writeFile('bad.json', '{ not valid');
+    expect(parseZedMcpServers(p)).toEqual([]);
+  });
+
+  it('extracts a local stdio server from context_servers', () => {
+    const p = writeFile(
+      'settings.json',
+      JSON.stringify({
+        context_servers: {
+          'local-mcp-server': {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-memory'],
+            env: {},
+          },
+        },
+      }),
+    );
+    expect(parseZedMcpServers(p)).toEqual([
+      {
+        name: 'local-mcp-server',
+        transport: 'local',
+        command: ['npx', '-y', '@modelcontextprotocol/server-memory'],
+      },
+    ]);
+  });
+
+  it('extracts a remote server (inferred from url since Zed has no `type` field)', () => {
+    const p = writeFile(
+      'settings.json',
+      JSON.stringify({
+        context_servers: {
+          'remote-mcp-server': {
+            url: 'https://mcp.example.com/mcp',
+            headers: { Authorization: 'Bearer ${MCP_TOKEN}' },
+          },
+        },
+      }),
+    );
+    expect(parseZedMcpServers(p)).toEqual([
+      {
+        name: 'remote-mcp-server',
+        transport: 'remote',
+        url: 'https://mcp.example.com/mcp',
+      },
+    ]);
+  });
+
+  it('returns [] when the top-level key is mcpServers instead of context_servers', () => {
+    const p = writeFile(
+      'settings.json',
+      JSON.stringify({ mcpServers: { foo: { command: 'x' } } }),
+    );
+    expect(parseZedMcpServers(p)).toEqual([]);
+  });
+});

--- a/packages/agents/src/roo-code.ts
+++ b/packages/agents/src/roo-code.ts
@@ -123,11 +123,11 @@ export const rooCode: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-mcp: {
-read: (ctx) => readAgentMcpConfig(rooCode, ctx),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(rooCode, ctx),
     write: notImplementedMcpHandlers('roo-code').write,
     parseServers: parseRooCodeMcpServers,
-},
+  },
 };
 
 /**

--- a/packages/agents/src/roo-code.ts
+++ b/packages/agents/src/roo-code.ts
@@ -1,10 +1,21 @@
 // Roo Code agent definition.
+import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { notImplementedMcpHandlers } from './types.js';
-import type { AgentDefinition, AgentMcpReadResult } from './types.js';
-import type { McpServerMap, StringList, StringMap } from './types.js';
-
+import type {
+  AgentDefinition,
+  AgentMcpParseServersHandler,
+  AgentMcpReadResult,
+  McpServerMap,
+  StringList,
+  StringMap,
+} from './types.js';
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+
+export const parseRooCodeMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => parseJsoncMcpServerMap(resolvedPath, 'mcpServers');
+
 /**
  * Native Roo Code MCP server entry. Roo accepts either stdio-style servers
  * (with `command`/`args`/`env`) or remote servers (with `url`/`headers`)
@@ -112,10 +123,11 @@ export const rooCode: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: [],
-  mcp: {
-    read: (ctx) => readAgentMcpConfig(rooCode, ctx),
+mcp: {
+read: (ctx) => readAgentMcpConfig(rooCode, ctx),
     write: notImplementedMcpHandlers('roo-code').write,
-  },
+    parseServers: parseRooCodeMcpServers,
+},
 };
 
 /**

--- a/packages/agents/src/windsurf.ts
+++ b/packages/agents/src/windsurf.ts
@@ -38,11 +38,11 @@ export const windsurf: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['windsurf'],
-mcp: {
-read: (ctx) => readAgentMcpConfig(windsurf, ctx),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(windsurf, ctx),
     write: notImplementedMcpHandlers('windsurf').write,
     parseServers: parseWindsurfMcpServers,
-},
+  },
 };
 
 /** Native Windsurf MCP config: `mcpServers` map; servers may be stdio (`command`/`args`/`env`) or remote. Per docs the remote URL may appear as either `url` or `serverUrl` depending on doc version. */

--- a/packages/agents/src/windsurf.ts
+++ b/packages/agents/src/windsurf.ts
@@ -1,16 +1,25 @@
 // Windsurf agent definition.
+import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { notImplementedMcpHandlers } from './types.js';
 import type {
   AgentDefinition,
+  AgentMcpParseServersHandler,
   AgentMcpReadResult,
   McpServerMap,
   PermissiveConfigObject,
   RemoteServerBase,
   StdioServerBase,
 } from './types.js';
-
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+
+export const parseWindsurfMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) =>
+  parseJsoncMcpServerMap(resolvedPath, 'mcpServers', {
+    urlFields: ['url', 'serverUrl'],
+  });
+
 export const windsurf: AgentDefinition = {
   id: 'windsurf',
   displayName: 'Windsurf',
@@ -29,10 +38,11 @@ export const windsurf: AgentDefinition = {
   detectionStrategy: 'binary-first',
   mcpSupport: 'supported',
   executableNames: ['windsurf'],
-  mcp: {
-    read: (ctx) => readAgentMcpConfig(windsurf, ctx),
+mcp: {
+read: (ctx) => readAgentMcpConfig(windsurf, ctx),
     write: notImplementedMcpHandlers('windsurf').write,
-  },
+    parseServers: parseWindsurfMcpServers,
+},
 };
 
 /** Native Windsurf MCP config: `mcpServers` map; servers may be stdio (`command`/`args`/`env`) or remote. Per docs the remote URL may appear as either `url` or `serverUrl` depending on doc version. */

--- a/packages/agents/src/zed.ts
+++ b/packages/agents/src/zed.ts
@@ -11,9 +11,8 @@ import type {
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
 
-export const parseZedMcpServers: AgentMcpParseServersHandler = (
-  resolvedPath,
-) => parseJsoncMcpServerMap(resolvedPath, 'context_servers');
+export const parseZedMcpServers: AgentMcpParseServersHandler = (resolvedPath) =>
+  parseJsoncMcpServerMap(resolvedPath, 'context_servers');
 
 export const zed: AgentDefinition = {
   id: 'zed',
@@ -51,11 +50,11 @@ export const zed: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: ['zed'],
-mcp: {
-read: (ctx) => readAgentMcpConfig(zed, ctx),
+  mcp: {
+    read: (ctx) => readAgentMcpConfig(zed, ctx),
     write: notImplementedMcpHandlers('zed').write,
     parseServers: parseZedMcpServers,
-},
+  },
 };
 
 /**

--- a/packages/agents/src/zed.ts
+++ b/packages/agents/src/zed.ts
@@ -1,14 +1,20 @@
 // Zed agent definition.
+import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { notImplementedMcpHandlers } from './types.js';
 import type {
   AgentDefinition,
+  AgentMcpParseServersHandler,
+  AgentMcpReadResult,
   McpServerMap,
   StringMap,
-  AgentMcpReadResult,
 } from './types.js';
-
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import type { PathResolutionContext } from './types.js';
+
+export const parseZedMcpServers: AgentMcpParseServersHandler = (
+  resolvedPath,
+) => parseJsoncMcpServerMap(resolvedPath, 'context_servers');
+
 export const zed: AgentDefinition = {
   id: 'zed',
   displayName: 'Zed',
@@ -45,10 +51,11 @@ export const zed: AgentDefinition = {
   detectionStrategy: 'marker-only',
   mcpSupport: 'supported',
   executableNames: ['zed'],
-  mcp: {
-    read: (ctx) => readAgentMcpConfig(zed, ctx),
+mcp: {
+read: (ctx) => readAgentMcpConfig(zed, ctx),
     write: notImplementedMcpHandlers('zed').write,
-  },
+    parseServers: parseZedMcpServers,
+},
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,6 +2101,7 @@ __metadata:
   dependencies:
     jsonc-parser: "npm:^3.3.1"
     smol-toml: "npm:^1.6.1"
+    yaml: "npm:^2.9.0"
   bin:
     overture: ./dist/main.js
   languageName: unknown
@@ -8964,7 +8965,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:2.9.0":
+"yaml@npm:2.9.0, yaml@npm:^2.9.0":
   version: 2.9.0
   resolution: "yaml@npm:2.9.0"
   bin:


### PR DESCRIPTION
## Summary

Build `parse<AgentName>McpServers` handlers for all 12 MCP-capable agents, modeled after the existing `parseOpenCodeMcpServers`. The CLI's dispatch in `apps/cli/src/cli.ts:parseServersForAgent` is already generic — adding the handlers to each agent's `mcp: { ..., parseServers }` slot makes the CLI render the server list for every installed agent automatically, with zero CLI changes.

## Live evidence

Before this PR, only opencode showed a server list. After:

```
  - Claude Code (high) [mcp-configured]
    agent: /home/.../claude
    mcp:   /home/jeff/.claude.json
      - filesystem  (local)   npx -y @modelcontextprotocol/server-filesystem /home
      - memory  (local)   npx -y @modelcontextprotocol/server-memory
      - sequentialthinking  (local)   npx -y @modelcontextprotocol/server-sequential-thinking@latest
      - context7  (local)   npx -y @upstash/context7-mcp@latest
  - OpenCode (high) [mcp-configured]
    agent: /home/.../opencode
    mcp:   /home/jeff/.config/opencode/opencode.jsonc
      - filesystem  (local)   ...
      - sequentialthinking  (local)   ...
      - context7  (remote)   https://mcp.context7.com/mcp
      - github  (remote)   https://api.githubcopilot.com/mcp/
      - websearch  (remote)   https://mcp.exa.ai/mcp
  - GitHub Copilot CLI (high) [mcp-configured]
    agent: /home/.../copilot
    mcp:   /home/jeff/.copilot/mcp-config.json
      - sequentialthinking  (local)   ...
      - context7  (local)   ...
      - filesystem  (local)   ...
      - memory  (local)   ...
      - nx-mcp  (local)   npx nx mcp
```

Opencode output is byte-identical to before (5 servers, regression preserved). Claude Code and Copilot CLI now also render their full server lists.

## Architecture

### Shared helpers — `packages/agents/src/parse-mcp-servers.ts`

Three format-specific helpers, one per file format:

```ts
parseJsoncMcpServerMap(path, topLevelKey, options?)   // JSON + JSONC, tolerates trailing commas/comments
parseTomlMcpServerMap(path, topLevelKey, options?)    // TOML tables
parseYamlMcpServerList(path, topLevelKey, options?)   // YAML (list or map shape)
```

All three:
- Return `[]` on any read or parse failure (silent degradation)
- Use sync parsers (the CLI's `parseServersForAgent` is sync)
- Accept an optional `ParseServerMapOptions` for transport inference overrides:
  - `urlFields: readonly string[]` — defaults to `['url']`; windsurf passes `['url', 'serverUrl']`
  - `remoteTypes` / `localTypes` — explicit `type` field overrides; defaults cover the full MCP transport vocabulary (`http`, `sse`, `remote`, `streamable-http`, `ws`, `local`, `stdio`)

Internal helpers: `stripBom`, `isRecord`, `asString`, `asStringArray`, `normalizeCommand` (string + args OR array), `inferTransport` (type override → URL presence → local), `normalizeServerEntry`. Returns `null` for malformed entries; skips them.

### Per-agent handlers — 12 of them, each a 3-line wrapper

| Agent                          | Helper + top-level key                        | Notes                                |
| ------------------------------ | --------------------------------------------- | ------------------------------------ |
| claude-code                    | `parseJsoncMcpServerMap(_, 'mcpServers')`     |                                      |
| claude-desktop                 | `parseJsoncMcpServerMap(_, 'mcpServers')`     |                                      |
| cline                          | `parseJsoncMcpServerMap(_, 'mcpServers')`     | ignores `disabled` field              |
| continue                       | YAML or JSON by extension                     | YAML standalone + JSON import paths   |
| cursor                         | `parseJsoncMcpServerMap(_, 'mcpServers')`     |                                      |
| github-copilot-cli             | `parseJsoncMcpServerMap(_, 'mcpServers')`     |                                      |
| github-copilot-vscode          | `parseJsoncMcpServerMap(_, 'servers')`        | uses `servers` not `mcpServers`        |
| openai-codex                   | `parseTomlMcpServerMap(_, 'mcp_servers')`     | TOML tables                          |
| opencode ✅ (already done)      | inline impl (unchanged)                        | the original template                |
| roo-code                       | `parseJsoncMcpServerMap(_, 'mcpServers')`     | ignores policy extras                |
| windsurf                       | `parseJsoncMcpServerMap(_, 'mcpServers', { urlFields: ['url','serverUrl'] })` | serverUrl is the Windsurf-specific alias |
| zed                            | `parseJsoncMcpServerMap(_, 'context_servers')` | no `type` field — remote inferred from `url` |

The 11 new handlers + the 1 existing opencode handler all sit on each agent's `mcp: { ..., parseServers: parse<X>McpServers }` slot. The CLI's `parseServersForAgent(id, path)` looks up the agent by id and calls `agent.mcp.parseServers?.(path)`.

## Why a single PR

- The shared helpers, the per-agent handlers, and the index exports are one cohesive feature.
- The CLI dispatch is already generic; no CLI changes are needed.
- Splitting by wave would create dependency PRs with limited standalone value (e.g. the helpers commit is useless without per-agent handlers).

## Atomic commit history (5 commits)

1. `chore(deps): add yaml runtime dependency for continue mcp parser` — `yaml@^2.9.0` (eemeli/yaml, ISC, zero-dep)
2. `feat(agents): add shared MCP server parser helpers` — `parse-mcp-servers.ts` + 24-test spec
3. `feat(agents): add parseServers handlers for JSON mcpServers agents` — claude-code, claude-desktop, cline, cursor, copilot-cli, roo-code, windsurf
4. `feat(agents): add parseServers for non-standard, TOML, and YAML agents` — copilot-vscode, zed, openai-codex, continue
5. `chore(agents): export new parseServers handlers and shared helpers` — public surface re-exports

## Gates (all green)

| Gate                                                    | Result                                  |
| ------------------------------------------------------- | --------------------------------------- |
| `yarn tsc -b packages/agents/tsconfig.json --force`     | PASS                                    |
| `yarn tsc -b apps/cli/tsconfig.json --force`            | PASS                                    |
| `yarn nx test @overture/agents --skip-nx-cache`         | **148/148** PASS (was 70; +78 new tests)  |
| `yarn nx test @jander99/overture --skip-nx-cache`       | **96/96** PASS                            |
| `yarn nx lint @jander99/overture --skip-nx-cache`       | 0 issues                                 |
| `yarn nx build @jander99/overture --skip-nx-cache`      | PASS                                    |
| `yarn prettier --check .`                               | PASS                                    |
| `node apps/cli/scripts/verify-package.mjs`              | PASS (4/4 golden entries, install+smoke) |
| Live `overture detect`                                  | claude-code shows 4 servers; opencode 5 (regression); copilot-cli 5 |
| Live `overture detect --json`                           | 14 platforms, 5 detected, 3 mcp-configured |

## Test coverage

Each per-agent spec covers:
- local-only
- remote-only (or type-explicit)
- missing file returns `[]`
- malformed content returns `[]`
- top-level key absent returns `[]`

Plus agent-specific cases:
- windsurf: `serverUrl` is treated as remote URL
- copilot-vscode: `mcpServers` top-level is correctly NOT picked up (uses `servers`)
- zed: `mcpServers` top-level is correctly NOT picked up (uses `context_servers`)
- continue: YAML list (with `name` field on each item) and JSON fallback both work
- openai-codex: TOML tables with both local (`command`+`args`) and remote (`url`) shapes

## Out of scope (potential followups)

- The CLI shows only `matchedMcpLocations[0]` per platform. Users with a project `.mcp.json` AND a user `~/.claude.json` only see the user-global list. Looping over all matched mcp locations and rendering each is a small CLI change.
- The parsers don't yet handle platform-specific extensions like claude-code's `imports` (the local-imports map), or continue's `env: ${{ secrets.X }}` syntax. Those are display-only concerns; the parser shows the transport + command/url, which is what's needed for inventory.

Awaiting your merge per AGENTS.md.