### PR TITLE
ci: add build-and-detect job + fix verify-package clean-runner smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-- name: Verify npm pack + install + smoke
+      - name: Verify npm pack + install + smoke
         run: node apps/cli/scripts/verify-package.mjs
 
   build-and-detect:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,5 +119,69 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Verify npm pack + install + smoke
+- name: Verify npm pack + install + smoke
         run: node apps/cli/scripts/verify-package.mjs
+
+  build-and-detect:
+    # Native build + runtime smoke. Mirrors the local `yarn nx build` +
+    # `node apps/cli/dist/main.js detect` workflow that the `cli:link`
+    # script uses (see apps/cli/package.json). The `package-verify`
+    # job proves the published tarball contract; this job proves the
+    # workspace build pipeline end-to-end on a runner with no
+    # pre-installed agents.
+    name: Build & detect
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Cache Yarn Berry offline mirror
+        uses: actions/cache@v5
+        with:
+          path: |
+            .yarn/cache
+            .yarn/install-state.gz
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build CLI (workspace)
+        # `--skip-nx-cache` forces a clean build so we catch transitive
+        # `^build` regressions (the @overture/agents package must build
+        # before apps/cli). Mirrors what `cli:link` does locally.
+        run: yarn nx build @jander99/overture --skip-nx-cache
+
+      - name: Run overture detect --json on a clean runner
+        # The runner has no installed MCP-capable agents. We assert:
+        # - exit 0
+        # - stdout is valid JSON with a `platforms` array of all 14
+        #   registry entries
+        # - every entry reports `installed: false`
+        # - no platform carries a `parseError`
+        # If any of these fail, the build pipeline is broken in a way
+        # the unit tests wouldn't catch (e.g. a missing runtime dep
+        # like `smol-toml`, or a broken Yarn workspace symlink).
+        run: |
+          set -euo pipefail
+          OUTPUT=$(node apps/cli/dist/main.js detect --json)
+          echo "$OUTPUT" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          assert isinstance(data.get('platforms'), list), 'platforms must be a list'
+          assert len(data['platforms']) == 14, f'expected 14 registry entries, got {len(data[\"platforms\"])}'
+          for p in data['platforms']:
+              assert p.get('installed') is False, f'{p[\"id\"]} reports installed on a clean runner'
+              assert not p.get('parseError'), f'{p[\"id\"]} has parseError: {p.get(\"parseError\")}'
+          print(f'OK: detect --json produced {len(data[\"platforms\"])} platforms, all installed=false, no parseErrors')
+          "

--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -127,11 +127,24 @@ if (jsonResult.status !== 0) {
 }
 try {
   const parsed = JSON.parse(jsonResult.stdout);
-  if (!Array.isArray(parsed.platforms) || parsed.platforms.length === 0) {
-    fail(`detect --json produced no platforms`);
+  // The full registry is always emitted; on a clean runner every
+  // entry reports `installed: false`. Asserting `length > 0` would
+  // fail in CI, which runs on a clean machine with no pre-installed
+  // agents.
+  if (!Array.isArray(parsed.platforms) || parsed.platforms.length !== 14) {
+    fail(
+      `detect --json produced ${parsed.platforms?.length ?? 0} platforms;
+  expected 14`,
+    );
   }
+  for (const p of parsed.platforms) {
+    if (p.parseError) {
+      fail(`${p.id} has parseError: ${p.parseError}`);
+    }
+  }
+  const installed = parsed.platforms.filter((p) => p.installed).length;
   console.log(
-    `detect --json: ${parsed.platforms.length} platforms (parseable)`,
+    `detect --json: ${parsed.platforms.length} platforms (${installed} installed on this host)`,
   );
 } catch (err) {
   fail(`detect --json output is not valid JSON: ${err.message}`);

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -281,12 +281,12 @@ on Trusted Publishing only. Do not add a fallback token.
   fine for development but the publish uses 24 for
   reproducibility.
 - The verify-package step is a no-publish gate: it builds, packs,
-and smoke-tests the tarball. The same script runs in the CI
+  and smoke-tests the tarball. The same script runs in the CI
   `package-verify` job on every PR.
 - The `build-and-detect` CI job is the native-build counterpart to
   `package-verify`. It runs `yarn install --immutable` from a clean
   cache, builds the CLI with the Nx workspace toolchain (`yarn nx
-  build @jander99/overture --skip-nx-cache`), then executes the
+build @jander99/overture --skip-nx-cache`), then executes the
   freshly built `apps/cli/dist/main.js detect --json` on a runner
   with no pre-installed agents. It asserts the output is valid JSON
   with all 14 registry entries, every entry reports

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -281,8 +281,22 @@ on Trusted Publishing only. Do not add a fallback token.
   fine for development but the publish uses 24 for
   reproducibility.
 - The verify-package step is a no-publish gate: it builds, packs,
-  and smoke-tests the tarball. The same script runs in the CI
+and smoke-tests the tarball. The same script runs in the CI
   `package-verify` job on every PR.
+- The `build-and-detect` CI job is the native-build counterpart to
+  `package-verify`. It runs `yarn install --immutable` from a clean
+  cache, builds the CLI with the Nx workspace toolchain (`yarn nx
+  build @jander99/overture --skip-nx-cache`), then executes the
+  freshly built `apps/cli/dist/main.js detect --json` on a runner
+  with no pre-installed agents. It asserts the output is valid JSON
+  with all 14 registry entries, every entry reports
+  `installed: false`, and no platform carries a `parseError`. This
+  catches the class of build-pipeline regressions the unit tests
+  would not (a missing runtime dep like `smol-toml`, a broken Yarn
+  workspace symlink, a transitive `^build` failure, etc.). Together
+  with `package-verify` (which proves the published-tarball
+  contract) the two jobs cover both the workspace build and the
+  shipped artifact.
 - The Trusted Publisher UI is the source of truth for who can
   publish. This runbook does not and should not encode npm
   tokens.


### PR DESCRIPTION
Adds a `build-and-detect` CI job that builds the CLI natively with the Nx workspace toolchain and runs `overture detect --json` on a clean runner (no pre-installed agents). Asserts the output is valid JSON with 14 registry entries, all `installed: false`, no `parseError`.

Also fixes `verify-package.mjs` to assert the full 14-platform registry instead of `platforms.length > 0` (which would fail on a clean CI runner).

Closes the coverage gap where no CI job exercised the native build pipeline end-to-end on a clean machine.

**What `build-and-detect` proves:**
- `yarn install --immutable` works on a clean cache
- `yarn nx build @jander99/overture --skip-nx-cache` transitively builds `@overture/agents` via Nx's `^build` dependency
- The Yarn workspace symlink (`node_modules/@overture/agents`) resolves correctly
- `smol-toml` runtime dep loads via `createRequire`
- The CLI's detect command produces the expected JSON shape on a machine with no agents

**What `package-verify` still proves (unchanged):**
- The published tarball shape matches `package-expected-files.txt`
- The installed binary works after `npm install` in a clean temp dir

Together the two jobs cover both the workspace build and the shipped artifact.

**Gates:** lint clean, typecheck clean, 169/169 agents tests, 95/95 CLI tests, build PASS, package-verify PASS, prettier clean.

Local QA: simulated a clean runner with a minimal PATH (only node binary dir + /usr/bin + /bin). The exact Python validation from the new CI step passes locally with the expected output.