### PR TITLE
fix(agents): align github-copilot-vscode to official user-profile MCP config paths

### DIFF
--- a/apps/cli/src/platforms/detect.spec.ts
+++ b/apps/cli/src/platforms/detect.spec.ts
@@ -82,6 +82,41 @@ describe('detectPlatforms', () => {
     expect(cursorResult!.reason).toBe('User-global Cursor MCP configuration');
   });
 
+  it('happy path: detects github-copilot-vscode when user XDG mcp.json is present', async () => {
+    // VS Code's actual user-level MCP config path on linux is
+    // ${XDG_CONFIG_HOME:-~/.config}/Code/User/mcp.json
+    // (per https://code.visualstudio.com/docs/copilot/reference/mcp-configuration).
+    // The wrong path ~/.vscode/mcp.json does not exist on a real VS Code install.
+    const vscodeUserDir = join(tempConfigDir, 'Code', 'User');
+    await mkdir(vscodeUserDir, { recursive: true });
+    await writeFile(
+      join(vscodeUserDir, 'mcp.json'),
+      JSON.stringify({
+        servers: { filesystem: { type: 'stdio', command: 'npx' } },
+      }),
+    );
+
+    const ctx = makeCtx({
+      homeDir: tempHomeDir,
+      configDir: tempConfigDir,
+      workspaceDir: tempWorkspaceDir,
+    });
+
+    const result = await detectPlatforms(ctx);
+    const vscodeResult = result.platforms.find(
+      (p) => p.id === 'github-copilot-vscode',
+    );
+
+    expect(vscodeResult).toBeDefined();
+    expect(vscodeResult!.installed).toBe(true);
+    expect(vscodeResult!.matchedMcpLocations.length).toBeGreaterThan(0);
+    expect(
+      vscodeResult!.matchedMcpLocations.some((m) =>
+        m.resolvedPath.endsWith('Code/User/mcp.json'),
+      ),
+    ).toBe(true);
+  });
+
   it('no markers: every platform reports installed false', async () => {
     const ctx = makeCtx({
       homeDir: tempHomeDir,

--- a/apps/cli/src/platforms/registry.spec.ts
+++ b/apps/cli/src/platforms/registry.spec.ts
@@ -100,6 +100,89 @@ describe('agentRegistry', () => {
     ).toBe(true);
   });
 
+  it('github-copilot-vscode installMarkers + mcpLocations model the correct user-profile paths per OS', () => {
+    const entry = agentRegistry.find((e) => e.id === 'github-copilot-vscode');
+    expect(entry).toBeDefined();
+
+    // Linux (XDG): Code/User/mcp.json under configDir.
+    expect(
+      entry!.installMarkers.some(
+        (m) =>
+          m.base === 'config' &&
+          m.relativePath === 'Code/User/mcp.json' &&
+          m.platforms?.includes('linux'),
+      ),
+      'linux XDG user marker must be present',
+    ).toBe(true);
+    // Linux Insiders.
+    expect(
+      entry!.installMarkers.some(
+        (m) =>
+          m.base === 'config' &&
+          m.relativePath === 'Code - Insiders/User/mcp.json' &&
+          m.platforms?.includes('linux'),
+      ),
+      'linux XDG Insiders user marker must be present',
+    ).toBe(true);
+    // macOS: Library/Application Support/Code/User/mcp.json under homeDir.
+    expect(
+      entry!.installMarkers.some(
+        (m) =>
+          m.base === 'home' &&
+          m.relativePath === 'Library/Application Support/Code/User/mcp.json' &&
+          m.platforms?.includes('darwin'),
+      ),
+      'macOS user marker must be present',
+    ).toBe(true);
+    // macOS Insiders.
+    expect(
+      entry!.installMarkers.some(
+        (m) =>
+          m.base === 'home' &&
+          m.relativePath ===
+            'Library/Application Support/Code - Insiders/User/mcp.json' &&
+          m.platforms?.includes('darwin'),
+      ),
+      'macOS Insiders user marker must be present',
+    ).toBe(true);
+
+    // The old, wrong user marker at ~/.vscode/mcp.json must be GONE from BOTH
+    // installMarkers and mcpLocations.
+    expect(
+      entry!.installMarkers.some(
+        (m) => m.base === 'home' && m.relativePath === '.vscode/mcp.json',
+      ),
+      'old base=home .vscode/mcp.json marker must not be present',
+    ).toBe(false);
+    expect(
+      entry!.mcpLocations.some(
+        (m) => m.base === 'home' && m.relativePath === '.vscode/mcp.json',
+      ),
+      'old base=home .vscode/mcp.json mcpLocation must not be present',
+    ).toBe(false);
+
+    // mcpLocations must mirror the installMarkers: every user-profile path
+    // appears as a mcpLocation too.
+    expect(
+      entry!.mcpLocations.some(
+        (m) =>
+          m.base === 'config' &&
+          m.relativePath === 'Code/User/mcp.json' &&
+          m.platforms?.includes('linux'),
+      ),
+      'mcpLocations must include the linux XDG user profile',
+    ).toBe(true);
+    expect(
+      entry!.mcpLocations.some(
+        (m) =>
+          m.base === 'home' &&
+          m.relativePath === 'Library/Application Support/Code/User/mcp.json' &&
+          m.platforms?.includes('darwin'),
+      ),
+      'mcpLocations must include the macOS user profile',
+    ).toBe(true);
+  });
+
   it('gives openai-codex at least one high-confidence install marker', () => {
     const entry = agentRegistry.find((e) => e.id === 'openai-codex');
     expect(entry).toBeDefined();

--- a/docs/coding-platform-mcp-configurations.md
+++ b/docs/coding-platform-mcp-configurations.md
@@ -306,12 +306,21 @@ Detection:
 - VS Code extension checks may include GitHub Copilot and GitHub Copilot Chat.
 - Workspace config: `.vscode/mcp.json`.
 
-Configuration locations:
+Configuration locations (per [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration)):
 
-| Scope        | Location                                                                                                |
-| ------------ | ------------------------------------------------------------------------------------------------------- |
-| Workspace    | `<workspace>/.vscode/mcp.json`                                                                          |
-| User/profile | Open with VS Code command `MCP: Open User Configuration`; stored in the active profile/user config area |
+| Scope           | Linux                                                         | macOS                                                         | Windows                                   |
+| --------------- | ------------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------- |
+| Workspace       | `<workspace>/.vscode/mcp.json`                                | `<workspace>/.vscode/mcp.json`                                | `<workspace>/.vscode/mcp.json`            |
+| User (stable)   | `${XDG_CONFIG_HOME:-~/.config}/Code/User/mcp.json`            | `~/Library/Application Support/Code/User/mcp.json`            | `%APPDATA%\Code\User\mcp.json`            |
+| User (Insiders) | `${XDG_CONFIG_HOME:-~/.config}/Code - Insiders/User/mcp.json` | `~/Library/Application Support/Code - Insiders/User/mcp.json` | `%APPDATA%\Code - Insiders\User\mcp.json` |
+
+> **Note**: `overture` currently models user-level markers for **linux** (XDG
+> under `configDir`) and **macOS** (`base: 'home'` + `Library/Application Support/...`).
+> Windows user-level detection (`%APPDATA%\Code\User\mcp.json`) requires a
+> per-OS `configDir` resolver in `defaultPathResolutionContext()`
+> (`apps/cli/src/platforms/detect.ts:31-44`) and is tracked as a follow-up.
+> The universal workspace marker `<workspace>/.vscode/mcp.json` works on
+> every OS.
 
 Format uses top-level `servers`, not `mcpServers`:
 
@@ -807,7 +816,8 @@ metadata, but they are not used as runtime detection probes in v1.
 A platform is reported as installed when any applicable `InstallMarker` resolves to an existing path of the marker's `kind`; `matchedMarkers` carries the absolute resolved paths and the detector uses the highest-confidence matched marker reason (high > medium > low > unsupported).
 
 Detection should report confidence separately from installation. For example,
-finding `.vscode/mcp.json` means VS Code: has a known MCP config surface, but
+finding `<workspace>/.vscode/mcp.json` (or the user-profile
+`Code/User/mcp.json` under XDG_CONFIG_HOME) means VS Code: has a known MCP config surface, but
 MCP support should remain unconfirmed until the file is actually read and
 validated.
 

--- a/packages/agents/src/github-copilot-vscode.ts
+++ b/packages/agents/src/github-copilot-vscode.ts
@@ -1,4 +1,10 @@
 // GitHub Copilot in VS Code agent definition.
+//
+// TODO(agents-vscode-win32): add user-level mcpLocation for Windows
+// (`%APPDATA%\Code\User\mcp.json` and `Code - Insiders` variant). Requires
+// a per-OS `configDir` resolver in `defaultPathResolutionContext()`
+// (apps/cli/src/platforms/detect.ts:31-44). Tracked in
+// https://github.com/jander99/overture/issues/84.
 import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import { defineAgent } from './define-agent.js';
@@ -32,12 +38,44 @@ export const githubCopilotVscode: AgentDefinition = defineAgent({
       reason: 'Workspace-level VS Code MCP configuration',
     },
     {
-      id: 'github-copilot-vscode-2-user-mcp',
+      id: 'github-copilot-vscode-2-user-xdg-linux',
+      kind: 'file',
+      base: 'config',
+      relativePath: 'Code/User/mcp.json',
+      platforms: ['linux'],
+      confidence: 'high',
+      reason:
+        'VS Code user-level MCP config (XDG on linux): https://code.visualstudio.com/docs/copilot/reference/mcp-configuration',
+    },
+    {
+      id: 'github-copilot-vscode-3-user-xdg-linux-insiders',
+      kind: 'file',
+      base: 'config',
+      relativePath: 'Code - Insiders/User/mcp.json',
+      platforms: ['linux'],
+      confidence: 'high',
+      reason:
+        'VS Code Insiders user-level MCP config (XDG on linux): https://code.visualstudio.com/docs/copilot/reference/mcp-configuration',
+    },
+    {
+      id: 'github-copilot-vscode-4-user-appx-darwin',
       kind: 'file',
       base: 'home',
-      relativePath: '.vscode/mcp.json',
-      confidence: 'medium',
-      reason: 'User-global VS Code MCP configuration',
+      relativePath: 'Library/Application Support/Code/User/mcp.json',
+      platforms: ['darwin'],
+      confidence: 'high',
+      reason:
+        'VS Code user-level MCP config (macOS): https://code.visualstudio.com/docs/copilot/reference/mcp-configuration',
+    },
+    {
+      id: 'github-copilot-vscode-5-user-appx-darwin-insiders',
+      kind: 'file',
+      base: 'home',
+      relativePath: 'Library/Application Support/Code - Insiders/User/mcp.json',
+      platforms: ['darwin'],
+      confidence: 'high',
+      reason:
+        'VS Code Insiders user-level MCP config (macOS): https://code.visualstudio.com/docs/copilot/reference/mcp-configuration',
     },
   ],
   mcpLocations: [
@@ -51,11 +89,43 @@ export const githubCopilotVscode: AgentDefinition = defineAgent({
     },
     {
       scope: 'user',
-      base: 'home',
-      relativePath: '.vscode/mcp.json',
+      base: 'config',
+      relativePath: 'Code/User/mcp.json',
+      platforms: ['linux'],
       format: 'json',
       topLevelKey: 'servers',
-      notes: 'User-global MCP servers under servers key',
+      notes:
+        'VS Code user MCP servers under servers key (XDG on linux): https://code.visualstudio.com/docs/copilot/reference/mcp-configuration',
+    },
+    {
+      scope: 'user',
+      base: 'config',
+      relativePath: 'Code - Insiders/User/mcp.json',
+      platforms: ['linux'],
+      format: 'json',
+      topLevelKey: 'servers',
+      notes:
+        'VS Code Insiders user MCP servers under servers key (XDG on linux): https://code.visualstudio.com/docs/copilot/reference/mcp-configuration',
+    },
+    {
+      scope: 'user',
+      base: 'home',
+      relativePath: 'Library/Application Support/Code/User/mcp.json',
+      platforms: ['darwin'],
+      format: 'json',
+      topLevelKey: 'servers',
+      notes:
+        'VS Code user MCP servers under servers key (macOS): https://code.visualstudio.com/docs/copilot/reference/mcp-configuration',
+    },
+    {
+      scope: 'user',
+      base: 'home',
+      relativePath: 'Library/Application Support/Code - Insiders/User/mcp.json',
+      platforms: ['darwin'],
+      format: 'json',
+      topLevelKey: 'servers',
+      notes:
+        'VS Code Insiders user MCP servers under servers key (macOS): https://code.visualstudio.com/docs/copilot/reference/mcp-configuration',
     },
   ],
   defaultConfidence: 'medium',
@@ -127,7 +197,7 @@ export type GitHubCopilotVSCodeServer =
   | GitHubCopilotVSCodeRemoteServer;
 
 /**
- * Native shape of `.vscode/mcp.json` (workspace and user-global
+ * Native shape of VS Code's `mcp.json` (workspace and user-profile
  * variants). The top-level key is `servers` (NOT `mcpServers`); an
  * optional `inputs` array declares prompt/input variables that may be
  * referenced from server entries.

--- a/packages/agents/src/mcp-config-readers.spec.ts
+++ b/packages/agents/src/mcp-config-readers.spec.ts
@@ -136,11 +136,16 @@ describe('per-agent mcp.read returns typed *McpConfig shape', () => {
     }
   });
 
-  it('github-copilot-vscode reads servers map from .vscode/mcp.json', async () => {
+  it('github-copilot-vscode reads servers map from Code/User/mcp.json (XDG) on linux', async () => {
+    // VS Code's actual user-level MCP config path on linux is
+    // ${XDG_CONFIG_HOME:-~/.config}/Code/User/mcp.json
+    // (per https://code.visualstudio.com/docs/copilot/reference/mcp-configuration).
+    // The old ~/.vscode/mcp.json path was incorrect; VS Code stores the
+    // user-level MCP config in `Code/User/mcp.json` under XDG_CONFIG_HOME.
     const ctx = readerCtx();
     await seed(
-      'home',
-      '.vscode/mcp.json',
+      'config',
+      'Code/User/mcp.json',
       JSON.stringify({ servers: { s: { type: 'stdio', command: 'c' } } }),
       ctx,
     );


### PR DESCRIPTION
## Summary

`overture detect` was missing real VS Code installs because the registry used `~/.vscode/mcp.json` as the user-level install marker, which does not exist on a real VS Code install. The correct user-level path is `${XDG_CONFIG_HOME:-~/.config}/Code/User/mcp.json` (linux), `~/Library/Application Support/Code/User/mcp.json` (macOS), and `%APPDATA%\Code\User\mcp.json` (Windows).

This PR adds the correct linux XDG marker and the macOS `Library/Application Support` marker, leaves the workspace `.vscode/mcp.json` marker unchanged, and tracks Windows support in a follow-up issue (it's blocked on a per-OS `configDir` resolver in `defaultPathResolutionContext()`).

## What's in the diff

| File | Change |
| --- | --- |
| `packages/agents/src/github-copilot-vscode.ts` | Replace wrong `~/.vscode/mcp.json` user marker with the correct per-OS markers (linux XDG + macOS). Workspace marker unchanged. |
| `packages/agents/src/mcp-config-readers.spec.ts` | Update the wrong-path test to seed `Code/User/mcp.json` (XDG) and assert the reader resolves it. |
| `apps/cli/src/platforms/detect.spec.ts` | Add happy-path test: seed `tempConfigDir/Code/User/mcp.json`, assert `github-copilot-vscode.installed === true` and the new `matchedMcpLocations[].resolvedPath`. |
| `apps/cli/src/platforms/registry.spec.ts` | Add per-OS invariant test: linux XDG + macOS `Library/Application Support` markers are present in BOTH `installMarkers` AND `mcpLocations`; the old `~/.vscode/mcp.json` user marker is GONE from both. |
| `docs/coding-platform-mcp-configurations.md` | Update the "GitHub Copilot in VS Code" section to a 3-OS matrix (linux/macOS/Windows) and add a follow-up note for Windows. |

## Surfaced verification

On this host (linux, VS Code user config at `~/.config/Code/User/mcp.json`):

**Before the fix:**

```
Detected MCP-capable platforms:
  - Claude Code (high) [mcp-configured]    ...
  - OpenCode (high) [mcp-configured]        ...
  - GitHub Copilot CLI (high) [mcp-configured] ...
  - OpenAI Codex (high) [mcp-not-configured]  ...
```

(VS Code was not reported despite having a real MCP config.)

**After the fix:**

```
  - GitHub Copilot in VS Code (high) [mcp-configured]
    agent: /home/jeff/.config/Code/User/mcp.json
    mcp:   /home/jeff/.config/Code/User/mcp.json
      - filesystem  (local)   npx -y @modelcontextprotocol/server-filesystem
      - memory  (local)   npx -y @modelcontextprotocol/server-memory
```

## Test plan

- [x] `@overture/agents` tests: 169/169 passing (was 168/169 + 1 RED).
- [x] `@jander99/overture` tests: 97/97 passing (was 95/97 + 2 RED).
- [x] `yarn prettier --check .` clean.
- [x] `yarn nx run-many -t test --all --skip-nx-cache` green.
- [x] Manual QA: `overture detect` on this host shows VS Code as `installed: true`, `mcpConfigured: true`, with the 2 configured server names.

## Follow-up

[#84](https://github.com/jander99/overture/issues/84) — Windows support requires a per-OS `configDir` resolver in `defaultPathResolutionContext()`. Out of scope for this PR.

## Authoritative source

- <https://code.visualstudio.com/docs/copilot/reference/mcp-configuration>
- Confirmed empirically on this host.