### PR TITLE
feat(config): add @overture/config library, user-level overture.jsonc, and Windows platform gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .nx/self-healing
 .nx/polygraph
 .claude/worktrees
+.worktrees/
+
 .claude/settings.local.json
 vitest.config.*.timestamp*
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ overture detect
 # Machine-readable: full 14-platform inventory with all additive fields
 overture detect --json
 
+# Print the resolved user-level overture config (XDG-aware)
+overture config show
+
 # Print usage and exit 0
+
 overture detect --help
 overture --help
 overture help
@@ -116,6 +120,9 @@ overture/
 ├── apps/
 │   └── cli/              # The `@jander99/overture` CLI (entry point: src/main.ts)
 ├── docs/
+│   ├── overture-config.md  # User-level config schema (overture.jsonc)
+│   └── coding-platform-mcp-configurations.md
+
 │   └── coding-platform-mcp-configurations.md
 ├── nx.json               # NX workspace configuration
 └── package.json          # Yarn 4 workspaces root

--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -677,7 +677,10 @@ describe('run (platform gate)', () => {
     __setPlatformForTests('linux');
     const code = await run(['detect', '--help']);
     expect(code).toBe(0);
-    const allWrites = stdoutSpy.mock.calls.map((c) => c[0] as string).join('');
+    const allWrites = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+
     expect(allWrites).not.toContain('Windows is not supported');
   });
 });
@@ -722,7 +725,10 @@ describe('run (config show)', () => {
   it('prints "not found" message when no config file exists', async () => {
     const code = await run(['config', 'show']);
     expect(code).toBe(0);
-    const out = stdoutSpy.mock.calls.map((c) => c[0] as string).join('');
+    const out = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+
     expect(out).toContain('No overture config found');
     expect(out).toContain(tempDir);
   });
@@ -749,7 +755,10 @@ describe('run (config show)', () => {
     );
     const code = await run(['config', 'show']);
     expect(code).toBe(0);
-    const out = stdoutSpy.mock.calls.map((c) => c[0] as string).join('');
+    const out = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+
     expect(out).toContain(join(configDir, 'overture.jsonc'));
     expect(out).toContain('"version": 1');
     expect(out).toContain('claude-code');
@@ -758,7 +767,10 @@ describe('run (config show)', () => {
   it('returns 2 with a helpful message for unknown config subcommands', async () => {
     const code = await run(['config', 'frobnicate']);
     expect(code).toBe(2);
-    const err = stderrSpy.mock.calls.map((c) => c[0] as string).join('');
+    const err = stderrSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+
     expect(err).toContain('config');
   });
 });

--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { __setPlatformForTests } from './cli.js';
+
 import { run, formatHumanOutput, formatJsonOutput } from './cli.js';
 import type {
   DetectJsonOutput,
@@ -27,7 +33,7 @@ describe('run', () => {
     const code = await run([]);
     expect(code).toBe(0);
     expect(stdoutSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Usage: overture detect [--json]'),
+      expect.stringContaining('detect [--json]'),
     );
   });
 
@@ -35,7 +41,7 @@ describe('run', () => {
     const code = await run(['help']);
     expect(code).toBe(0);
     expect(stdoutSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Usage: overture detect [--json]'),
+      expect.stringContaining('detect [--json]'),
     );
   });
 
@@ -43,7 +49,7 @@ describe('run', () => {
     const code = await run(['--help']);
     expect(code).toBe(0);
     expect(stdoutSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Usage: overture detect [--json]'),
+      expect.stringContaining('detect [--json]'),
     );
   });
 
@@ -624,5 +630,135 @@ describe('opencode server list in human output', () => {
     expect(result).toContain('  - OpenCode (high) [mcp-configured]');
     expect(result).toContain('    mcp:   /nonexistent/path/opencode.jsonc');
     expect(result).not.toContain('      - ');
+  });
+});
+
+describe('run (platform gate)', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    __setPlatformForTests(null);
+  });
+
+  it('prints a Windows unsupported message and exits 0 when platform is win32', async () => {
+    __setPlatformForTests('win32');
+    const code = await run(['detect']);
+    expect(code).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Windows is not supported'),
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining('detected platform: win32'),
+    );
+  });
+
+  it('the Windows gate fires even for `overture --help`', async () => {
+    __setPlatformForTests('win32');
+    const code = await run([]);
+    expect(code).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Windows is not supported'),
+    );
+  });
+
+  it('does not write the Windows message on linux', async () => {
+    __setPlatformForTests('linux');
+    const code = await run(['detect', '--help']);
+    expect(code).toBe(0);
+    const allWrites = stdoutSpy.mock.calls.map((c) => c[0] as string).join('');
+    expect(allWrites).not.toContain('Windows is not supported');
+  });
+});
+
+describe('run (config show)', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let tempDir: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    tempDir = mkdtempSync(join(tmpdir(), 'overture-cli-'));
+    prevHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    process.env.XDG_CONFIG_HOME = tempDir;
+    process.env.XDG_STATE_HOME = tempDir;
+    process.env.XDG_CACHE_HOME = tempDir;
+    __setPlatformForTests('linux');
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    __setPlatformForTests(null);
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.XDG_STATE_HOME;
+    delete process.env.XDG_CACHE_HOME;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('prints "not found" message when no config file exists', async () => {
+    const code = await run(['config', 'show']);
+    expect(code).toBe(0);
+    const out = stdoutSpy.mock.calls.map((c) => c[0] as string).join('');
+    expect(out).toContain('No overture config found');
+    expect(out).toContain(tempDir);
+  });
+
+  it('prints the resolved config file path and JSON contents when present', async () => {
+    const configDir = join(tempDir, 'overture');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'overture.jsonc'),
+      JSON.stringify({
+        $schema: 'https://example/x.json',
+        version: 1,
+        profiles: {
+          default: {
+            mcpServers: {
+              fs: { type: 'stdio', command: 'npx' },
+            },
+            sync: { targets: ['claude-code'] },
+            skills: [],
+          },
+        },
+      }),
+      'utf8',
+    );
+    const code = await run(['config', 'show']);
+    expect(code).toBe(0);
+    const out = stdoutSpy.mock.calls.map((c) => c[0] as string).join('');
+    expect(out).toContain(join(configDir, 'overture.jsonc'));
+    expect(out).toContain('"version": 1');
+    expect(out).toContain('claude-code');
+  });
+
+  it('returns 2 with a helpful message for unknown config subcommands', async () => {
+    const code = await run(['config', 'frobnicate']);
+    expect(code).toBe(2);
+    const err = stderrSpy.mock.calls.map((c) => c[0] as string).join('');
+    expect(err).toContain('config');
   });
 });

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,9 +1,28 @@
+import { platform as nodePlatform } from 'node:os';
 import {
-  detectPlatforms,
-  defaultPathResolutionContext,
-} from './platforms/detect.js';
+  defaultOverturePaths,
+  isSupportedPlatform,
+  loadOvertureConfig,
+  type HostPlatform,
+  type OvertureConfig,
+  type OverturePaths,
+} from '@overture/config';
+import { detectPlatforms } from './platforms/detect.js';
 import { agentRegistry, type McpServerEntry } from '@overture/agents';
 import type { DetectJsonOutput } from './platforms/types.js';
+
+/**
+ * Indirection over `process.platform` so tests can force a specific host
+ * (e.g. `win32`) without having to mutate Node's global state. Production
+ * callers always see the real value.
+ */
+let platformOverride: HostPlatform | null = null;
+export function __setPlatformForTests(p: HostPlatform | null): void {
+  platformOverride = p;
+}
+function currentPlatform(): HostPlatform {
+  return platformOverride ?? (nodePlatform() as HostPlatform);
+}
 
 export function formatJsonOutput(output: DetectJsonOutput): string {
   return JSON.stringify(output, null, 2) + '\n';
@@ -126,40 +145,119 @@ export function formatHumanOutput(output: DetectJsonOutput): string {
   return sections.join('\n\n') + '\n';
 }
 
-export async function run(args: readonly string[]): Promise<number> {
-  if (args.length === 0 || args[0] === 'help' || args[0] === '--help') {
+const USAGE =
+  'Usage: overture <command> [flags]\n\nCommands:\n' +
+  '  detect [--json]   Detect installed MCP-capable platforms.\n' +
+  '  config show       Print the resolved user-level overture config.\n';
+
+async function runDetect(flags: readonly string[]): Promise<number> {
+  if (flags.includes('--help') || flags.includes('-h')) {
     process.stdout.write('Usage: overture detect [--json]\n');
+    return 0;
+  }
+  const unknownFlags = flags.filter((f) => f !== '--json');
+  if (unknownFlags.length > 0) {
+    process.stderr.write(
+      `Unknown flag: ${unknownFlags[0]}\nUsage: overture detect [--json]\n`,
+    );
+    return 2;
+  }
+  const output = await detectPlatforms(
+    defaultOverturePaths({ workspaceDir: process.cwd() }),
+  );
+  if (flags.includes('--json')) {
+    process.stdout.write(formatJsonOutput(output));
+    return 0;
+  }
+  process.stdout.write(formatHumanOutput(output));
+  return 0;
+}
+
+function renderConfigNotFound(paths: OverturePaths): string {
+  return (
+    `No overture config found at ${paths.configFile}\n` +
+    `Resolved config dir: ${paths.configDir}\n` +
+    `Platform: ${paths.platform}\n` +
+    `(create the file to enable declarative sync — see docs/overture-config.md)\n`
+  );
+}
+
+function renderConfigFound(paths: OverturePaths, cfg: OvertureConfig): string {
+  return (
+    `Config file: ${paths.configFile}\n` +
+    `Platform:    ${paths.platform}\n` +
+    `---\n` +
+    JSON.stringify(cfg, null, 2) +
+    '\n'
+  );
+}
+
+async function runConfigShow(paths: OverturePaths): Promise<number> {
+  let cfg: OvertureConfig | null;
+  try {
+    cfg = await loadOvertureConfig(paths);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${message}\n`);
+    return 2;
+  }
+  if (cfg === null) {
+    process.stdout.write(renderConfigNotFound(paths));
+    return 0;
+  }
+  process.stdout.write(renderConfigFound(paths, cfg));
+  return 0;
+}
+
+async function runConfig(subArgs: readonly string[]): Promise<number> {
+  if (subArgs.length === 0) {
+    process.stderr.write(
+      'Usage: overture config <subcommand>\n  show     Print the resolved user-level overture config.\n',
+    );
+    return 2;
+  }
+  if (subArgs[0] === '--help' || subArgs[0] === '-h') {
+    process.stdout.write(
+      'Usage: overture config <subcommand>\n  show     Print the resolved user-level overture config.\n',
+    );
+    return 0;
+  }
+  if (subArgs[0] === 'show') {
+    return runConfigShow(defaultOverturePaths());
+  }
+  process.stderr.write(
+    `Unknown config subcommand: ${subArgs[0]}\nUsage: overture config <subcommand>\n`,
+  );
+  return 2;
+}
+
+export async function run(args: readonly string[]): Promise<number> {
+  // Platform gate: only linux (incl. WSL1/WSL2) and darwin are supported
+  // in v1. We surface this as a clean stdout message + exit 0 so users
+  // running on Windows see an explanation, not a stack trace.
+  const platform = currentPlatform();
+  if (!isSupportedPlatform(platform)) {
+    const message =
+      `Note: Windows is not supported in this version of overture. ` +
+      `Support is planned for a future release.\n` +
+      `(detected platform: ${platform})\n`;
+    process.stdout.write(message);
+    return 0;
+  }
+
+  if (args.length === 0 || args[0] === 'help' || args[0] === '--help') {
+    process.stdout.write(USAGE);
     return 0;
   }
 
   if (args[0] === 'detect') {
-    const flags = args.slice(1);
-    // Help is recognized and exits 0.
-    if (flags.includes('--help') || flags.includes('-h')) {
-      process.stdout.write('Usage: overture detect [--json]\n');
-      return 0;
-    }
-    const unknownFlags = flags.filter((f) => f !== '--json');
-    if (unknownFlags.length > 0) {
-      process.stderr.write(
-        `Unknown flag: ${unknownFlags[0]}\nUsage: overture detect [--json]\n`,
-      );
-      return 2;
-    }
-
-    const output = await detectPlatforms(defaultPathResolutionContext());
-
-    if (flags.includes('--json')) {
-      process.stdout.write(formatJsonOutput(output));
-      return 0;
-    }
-
-    process.stdout.write(formatHumanOutput(output));
-    return 0;
+    return runDetect(args.slice(1));
   }
 
-  process.stderr.write(
-    `Unknown command: ${args[0]}\nUsage: overture detect [--json]\n`,
-  );
+  if (args[0] === 'config') {
+    return runConfig(args.slice(1));
+  }
+
+  process.stderr.write(`Unknown command: ${args[0]}\n${USAGE}`);
   return 2;
 }

--- a/docs/overture-config.md
+++ b/docs/overture-config.md
@@ -1,0 +1,273 @@
+# Overture config (`overture.jsonc`)
+
+> The user-level, declarative source of truth for `overture`. Authored
+> as JSONC (tolerates comments and trailing commas), validated by Zod
+> at load time, and rendered to humans via `overture config show`.
+
+## Support matrix
+
+| Platform | Status    | Path layout                                    |
+| -------- | --------- | ---------------------------------------------- |
+| Linux    | Supported | XDG (same as below)                            |
+| WSL1     | Supported | XDG (treats as Linux)                          |
+| WSL2     | Supported | XDG (treats as Linux)                          |
+| macOS    | Supported | XDG (same as Linux; **not** `~/Library/...`)   |
+| Windows  | Not in v1 | — (the CLI prints a clean message and exits 0) |
+
+WSL1/WSL2 are indistinguishable from native Linux at the XDG resolver
+level. Cross-filesystem sync (WSL Linux paths ↔ Windows-side agents)
+is out of scope for v1.
+
+## File locations
+
+All paths are XDG-style, identical on Linux (incl. WSL) and macOS.
+There is no platform-specific branch.
+
+| Purpose | Variable             | Default                             |
+| ------- | -------------------- | ----------------------------------- |
+| Config  | `${XDG_CONFIG_HOME}` | `~/.config/overture/overture.jsonc` |
+| State   | `${XDG_STATE_HOME}`  | `~/.local/state/overture/`          |
+| Cache   | `${XDG_CACHE_HOME}`  | `~/.cache/overture/`                |
+
+`overture` reads **only the user-level config** in v1. Project-level
+configs (`./.overture.jsonc`) are explicitly out of scope. The schema
+file is the only artifact the user is expected to author; the state
+and cache files are machine-managed.
+
+Verify the resolved locations on your host:
+
+```bash
+overture config show
+```
+
+When the config does not exist, the command prints the resolved
+`configFile` and `configDir` paths it would have used.
+
+## Schema (v1)
+
+The full Zod schema lives at
+[`packages/config/src/schema.ts`](../packages/config/src/schema.ts).
+The `version` field is a literal `1` — future schema versions will
+live in a sibling `OvertureConfigV2Schema` and dispatch on the same
+field.
+
+```jsonc
+{
+  "$schema": "https://raw.githubusercontent.com/jander99/overture/main/schemas/overture.config.schema.json",
+  "version": 1,
+
+  "settings": {
+    "defaultProfile": "default", // optional, default "default"
+    "dryRunByDefault": true, // optional, default true
+    "backupBeforeWrite": true, // optional, default true
+    "conflictPolicy": "refuse", // optional: "refuse" | "prompt" | "overwrite"
+  },
+
+  "profiles": {
+    "default": {
+      "mcpServers": {
+        // mcpServers key is canonical (matches Claude Code / OpenCode / etc.)
+      },
+
+      "sync": {
+        "targets": ["claude-code", "opencode", "github-copilot-cli"],
+
+        "disabledServers": [
+          // global exclusions: server names that are never synced anywhere
+        ],
+      },
+
+      "skills": [
+        {
+          "source": "vercel-labs/agent-skills",
+          "include": ["frontend-design", "skill-creator"],
+        },
+        {
+          "source": "mattpocock/skills",
+          "include": ["grill-me", "tdd"],
+        },
+      ],
+    },
+  },
+}
+```
+
+### MCP server entries
+
+Two transport kinds, modeled as a discriminated union on `type`:
+
+```jsonc
+// Local server (spawns a child process)
+"filesystem": {
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home"],
+  "env": { "MY_VAR": "${MY_VAR}" }   // optional; ${VAR} is preserved literally
+}
+
+// Remote server (HTTP/SSE)
+"context7-remote": {
+  "type": "remote",
+  "url": "https://mcp.context7.com/mcp",
+  "headers": { "Authorization": "Bearer ${CONTEXT7_API_KEY}" }
+}
+```
+
+`command` and `args` are required for `stdio`; `url` is required for
+`remote`. The schema rejects entries that violate this.
+
+### Skills
+
+A skill install entry is a `npx skills add` invocation pre-baked:
+
+```jsonc
+{
+  "source": "vercel-labs/agent-skills",
+  "include": ["frontend-design", "skill-creator"],
+}
+```
+
+This expands to:
+
+```bash
+npx skills add vercel-labs/agent-skills --skill frontend-design --skill skill-creator -g -y
+```
+
+`source` must be in `owner/repo` form. Full URLs and local paths are
+intentionally disallowed because the first-class install flow is the
+`npx skills add` shim. `include` is required and must contain at
+least one skill name — installing "the whole repo" is too broad to
+be a stable config target.
+
+### Settings
+
+All settings are optional and have defaults. `settings` itself is
+optional.
+
+| Key                 | Type                                    | Default     |
+| ------------------- | --------------------------------------- | ----------- |
+| `defaultProfile`    | string (must be a key under `profiles`) | `"default"` |
+| `dryRunByDefault`   | boolean                                 | `true`      |
+| `backupBeforeWrite` | boolean                                 | `true`      |
+| `conflictPolicy`    | `"refuse" \| "prompt" \| "overwrite"`   | `"refuse"`  |
+
+## Environment variables
+
+| Variable          | Effect                                                 |
+| ----------------- | ------------------------------------------------------ |
+| `XDG_CONFIG_HOME` | Overrides the base for the user config file.           |
+| `XDG_STATE_HOME`  | Overrides the base for state files.                    |
+| `XDG_CACHE_HOME`  | Overrides the base for cache files.                    |
+| `HOME`            | Used as the fallback for the XDG bases (linux/darwin). |
+
+## What is NOT in the global config (v1)
+
+By deliberate design, the following items live in **state** or
+**cache** files (machine-managed, do not edit), or are absent from
+v1 entirely:
+
+- Per-agent overrides (we dropped the per-target override section
+  during design; differences stay in the per-agent writer layer).
+- Detected agent paths and parsed server lists (read on demand from
+  the agents' own config files).
+- Last sync timestamps, hashes of target files, backups, conflict
+  records.
+- Convergence / bidirectional sync (out of scope; `overture merge`
+  is a future addition).
+- Project-level / per-repo config (explicitly out of scope for v1).
+
+## Design principles
+
+1. **Declarative, not procedural.** The config describes _what the
+   user wants_; the implementation decides _how to get there_ per
+   target agent.
+2. **No agent-specific quirks at the top level.** The schema uses the
+   dominant `mcpServers` shape; per-agent translation lives in the
+   writer layer (`packages/agents/src/<id>.ts`).
+3. **Skills are installer coordinates, not local skill names.** The
+   schema records where to _install from_, not what's already on
+   disk. Local skill enumeration is `npx skills list`'s job.
+4. **State lives elsewhere.** Anything that changes at runtime
+   belongs in `${XDG_STATE_HOME}/overture/`, not in the config.
+5. **JSONC, not JSON.** The file name advertises that comments and
+   trailing commas are tolerated; the loader uses `jsonc-parser`.
+
+## Examples
+
+### Minimal
+
+```jsonc
+{
+  "$schema": "https://raw.githubusercontent.com/jander99/overture/main/schemas/overture.config.schema.json",
+  "version": 1,
+  "profiles": {
+    "default": {
+      "mcpServers": {},
+      "sync": { "targets": [] },
+      "skills": [],
+    },
+  },
+}
+```
+
+### With MCP servers, sync, and skills
+
+```jsonc
+{
+  "$schema": "https://raw.githubusercontent.com/jander99/overture/main/schemas/overture.config.schema.json",
+  "version": 1,
+  "settings": {
+    "conflictPolicy": "prompt",
+    "dryRunByDefault": true,
+  },
+  "profiles": {
+    "default": {
+      "mcpServers": {
+        "filesystem": {
+          "type": "stdio",
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home"],
+        },
+        "context7": {
+          "type": "stdio",
+          "command": "npx",
+          "args": ["-y", "@upstash/context7-mcp@latest"],
+          "env": { "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}" },
+        },
+      },
+      "sync": {
+        "targets": ["claude-code", "opencode", "github-copilot-cli"],
+      },
+      "skills": [
+        {
+          "source": "vercel-labs/agent-skills",
+          "include": ["frontend-design", "skill-creator"],
+        },
+      ],
+    },
+  },
+}
+```
+
+## Verifying
+
+```bash
+# Show the resolved config location and contents
+overture config show
+
+# (When the file does not exist, the command prints the path it would
+#  have used, so you can `mkdir -p` and create one.)
+```
+
+The loader accepts JSONC: line comments (`// ...`) and trailing commas
+are tolerated. Unknown top-level keys are rejected — the file must
+match the schema exactly.
+
+## See also
+
+- [`coding-platform-mcp-configurations.md`](./coding-platform-mcp-configurations.md)
+  — the per-platform catalog that drives detection.
+- [`packages/config/src/schema.ts`](../packages/config/src/schema.ts)
+  — the canonical Zod schema.
+- [`packages/config/src/paths.ts`](../packages/config/src/paths.ts)
+  — the XDG path resolver.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "vite": "^6.0.0",
     "vitest": "^4.0.0"
   },
+  "resolutions": {
+    "esbuild": "^0.28.1"
+  },
   "scripts": {
     "nx": "nx"
   }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@overture/config",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "jsonc-parser": "^3.3.1",
+    "zod": "^3.23.8"
+  }
+}

--- a/packages/config/project.json
+++ b/packages/config/project.json
@@ -1,0 +1,30 @@
+{
+  "name": "@overture/config",
+  "root": "packages/config",
+  "sourceRoot": "packages/config/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/config",
+        "main": "packages/config/src/index.ts",
+        "tsConfig": "packages/config/tsconfig.lib.json",
+        "platform": "node",
+        "format": ["esm"],
+        "bundle": true,
+        "thirdParty": true,
+        "generatePackageJson": false
+      }
+    },
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "coverage/packages/config"
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Public @overture/config surface.
+ *
+ * Exports the Zod schema for `overture.jsonc`, the XDG path resolver for
+ * the user-level config, and a small loader that reads + parses + validates
+ * the config file at the resolved path.
+ *
+ * Supported platforms: Linux (native + WSL1 + WSL2) and macOS. Both use
+ * the same XDG layout — `${XDG_CONFIG_HOME:-~/.config}/overture/...`.
+ * Windows is explicitly out of scope for v1.
+ */
+export * from './schema.js';
+export * from './paths.js';
+export * from './loader.js';

--- a/packages/config/src/loader.spec.ts
+++ b/packages/config/src/loader.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadOvertureConfig } from './loader.js';
+import { defaultOverturePaths } from './paths.js';
+
+function writeConfigAt(paths: { configFile: string }, contents: string): void {
+  mkdirSync(join(paths.configFile, '..'), { recursive: true });
+  writeFileSync(paths.configFile, contents, 'utf8');
+}
+
+function withTempDir<T>(fn: (dir: string) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), 'overture-cfg-'));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('loadOvertureConfig', () => {
+  it('returns null when the config file does not exist', async () => {
+    await withTempDir(async (dir) => {
+      const paths = defaultOverturePaths(
+        { platform: 'linux', workspaceDir: dir },
+        { HOME: dir } as NodeJS.ProcessEnv,
+      );
+      const result = await loadOvertureConfig(paths);
+      expect(result).toBeNull();
+    });
+  });
+
+  it('parses a valid config and returns the typed object', async () => {
+    await withTempDir(async (dir) => {
+      const paths = defaultOverturePaths(
+        { platform: 'linux', workspaceDir: dir },
+        { HOME: dir } as NodeJS.ProcessEnv,
+      );
+      writeConfigAt(
+        paths,
+        JSON.stringify({
+          $schema: 'https://example/x.json',
+          version: 1,
+          profiles: {
+            default: {
+              mcpServers: {
+                fs: { type: 'stdio', command: 'npx', args: ['-y', 'mcp-fs'] },
+              },
+              sync: { targets: ['claude-code'] },
+              skills: [{ source: 'foo/bar', include: ['baz'] }],
+            },
+          },
+        }),
+      );
+      const result = await loadOvertureConfig(paths);
+      expect(result).not.toBeNull();
+      expect(result?.version).toBe(1);
+      expect(result?.profiles.default.mcpServers.fs.type).toBe('stdio');
+    });
+  });
+
+  it('tolerates JSONC (trailing commas + line comments)', async () => {
+    await withTempDir(async (dir) => {
+      const paths = defaultOverturePaths(
+        { platform: 'linux', workspaceDir: dir },
+        { HOME: dir } as NodeJS.ProcessEnv,
+      );
+      const jsonc = `{
+        // a leading comment
+        "$schema": "https://example/x.json",
+        "version": 1,
+        "profiles": {
+          "default": {
+            "mcpServers": {
+              "fs": { "type": "stdio", "command": "npx" },
+            },
+            "sync": { "targets": ["claude-code"], },
+            "skills": [],
+          },
+        },
+      }`;
+      writeConfigAt(paths, jsonc);
+      const result = await loadOvertureConfig(paths);
+      expect(result).not.toBeNull();
+      expect(result?.profiles.default.sync.targets).toEqual(['claude-code']);
+    });
+  });
+
+  it('throws a clear error when the file exists but is invalid', async () => {
+    await withTempDir(async (dir) => {
+      const paths = defaultOverturePaths(
+        { platform: 'linux', workspaceDir: dir },
+        { HOME: dir } as NodeJS.ProcessEnv,
+      );
+      writeConfigAt(
+        paths,
+        JSON.stringify({ version: 1 /* missing profiles */ }),
+      );
+      await expect(loadOvertureConfig(paths)).rejects.toThrow(/config/i);
+    });
+  });
+
+  it('propagates filesystem errors other than ENOENT', async () => {
+    await withTempDir(async (dir) => {
+      const paths = defaultOverturePaths(
+        { platform: 'linux', workspaceDir: dir },
+        { HOME: dir } as NodeJS.ProcessEnv,
+      );
+      // Replace the (non-existent) configFile with a directory so readFile
+      // throws EISDIR instead of ENOENT — loader must not swallow this.
+      mkdirSync(paths.configFile, { recursive: true });
+      await expect(loadOvertureConfig(paths)).rejects.toThrow();
+    });
+  });
+});

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -1,0 +1,66 @@
+import { readFile } from 'node:fs/promises';
+// Deep import from the ESM subpath. The package root re-exports
+// through a UMD wrapper that uses relative `require()` calls, which
+// break once esbuild inlines the package into the CJS bundle that
+// lives outside `node_modules/jsonc-parser/`. Mirrors the pattern in
+// `apps/cli/src/platforms/mcp-config.ts` and the repo's AGENTS.md.
+import { parse as parseJsonc } from 'jsonc-parser/lib/esm/main.js';
+
+import { OvertureConfigSchema, type OvertureConfig } from './schema.js';
+import type { OverturePaths } from './paths.js';
+
+/**
+ * Read and validate the user-level overture config at the resolved path.
+ *
+ * Returns `null` when the file does not exist (ENOENT) — this is the
+ * "no config yet" state, not an error. All other filesystem and parse
+ * errors are propagated.
+ *
+ * JSONC (comments + trailing commas) is tolerated because the canonical
+ * `overture.jsonc` file name advertises that the file may contain them.
+ */
+export async function loadOvertureConfig(
+  paths: OverturePaths,
+): Promise<OvertureConfig | null> {
+  let raw: string;
+  try {
+    raw = await readFile(paths.configFile, 'utf8');
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      typeof err.code === 'string' &&
+      err.code === 'ENOENT'
+    ) {
+      return null;
+    }
+    throw err;
+  }
+
+  // jsonc-parser returns the same value as JSON.parse for valid JSON, but
+  // it also accepts comments and trailing commas. We pass the `disallowComments`
+  // option as `false` (the default) to allow them.
+  const errors: import('jsonc-parser/lib/esm/main.js').ParseError[] = [];
+
+  const parsed: unknown = parseJsonc(raw, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  if (errors.length > 0) {
+    const first = errors[0];
+    throw new Error(
+      `Failed to parse overture config at ${paths.configFile}: jsonc-parser error #${String(first)}`,
+    );
+  }
+
+  const result = OvertureConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('\n');
+    throw new Error(
+      `Invalid overture config at ${paths.configFile}:\n${issues}`,
+    );
+  }
+  return result.data;
+}

--- a/packages/config/src/paths.spec.ts
+++ b/packages/config/src/paths.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultOverturePaths,
+  isSupportedPlatform,
+  UnsupportedPlatformError,
+  type OverturePaths,
+} from './paths.js';
+
+describe('defaultOverturePaths', () => {
+  it('returns XDG paths on linux when XDG_CONFIG_HOME is unset', () => {
+    const paths = defaultOverturePaths({ platform: 'linux' }, {
+      HOME: '/home/test' /* no XDG_* */,
+    } as NodeJS.ProcessEnv);
+    expect(paths.configFile).toBe('/home/test/.config/overture/overture.jsonc');
+    expect(paths.configDir).toBe('/home/test/.config/overture');
+    expect(paths.stateDir).toBe('/home/test/.local/state/overture');
+    expect(paths.cacheDir).toBe('/home/test/.cache/overture');
+    expect(paths.platform).toBe('linux');
+  });
+
+  it('honors XDG_CONFIG_HOME on linux', () => {
+    const paths = defaultOverturePaths({ platform: 'linux' }, {
+      HOME: '/home/test',
+      XDG_CONFIG_HOME: '/srv/config',
+    } as NodeJS.ProcessEnv);
+    expect(paths.configDir).toBe('/srv/config/overture');
+    expect(paths.configFile).toBe('/srv/config/overture/overture.jsonc');
+  });
+
+  it('honors XDG_STATE_HOME and XDG_CACHE_HOME', () => {
+    const paths = defaultOverturePaths({ platform: 'linux' }, {
+      HOME: '/home/test',
+      XDG_STATE_HOME: '/srv/state',
+      XDG_CACHE_HOME: '/srv/cache',
+    } as NodeJS.ProcessEnv);
+    expect(paths.stateDir).toBe('/srv/state/overture');
+    expect(paths.cacheDir).toBe('/srv/cache/overture');
+  });
+
+  it('returns XDG paths on darwin (NOT ~/Library/Application Support)', () => {
+    const paths = defaultOverturePaths({ platform: 'darwin' }, {
+      HOME: '/Users/test',
+    } as NodeJS.ProcessEnv);
+    expect(paths.configDir).toBe('/Users/test/.config/overture');
+    expect(paths.stateDir).toBe('/Users/test/.local/state/overture');
+    expect(paths.cacheDir).toBe('/Users/test/.cache/overture');
+    expect(paths.platform).toBe('darwin');
+    // Sanity: should NOT be macOS-native Application Support
+    expect(paths.configDir).not.toContain('Application Support');
+  });
+
+  it('throws UnsupportedPlatformError for win32', () => {
+    expect(() =>
+      defaultOverturePaths({ platform: 'win32' }, {
+        USERPROFILE: 'C:/Users/test',
+      } as NodeJS.ProcessEnv),
+    ).toThrow(UnsupportedPlatformError);
+  });
+
+  it('UnsupportedPlatformError message names Windows and points to v2', () => {
+    let caught: unknown;
+    try {
+      defaultOverturePaths({ platform: 'win32' }, {
+        USERPROFILE: 'C:/Users/test',
+      } as NodeJS.ProcessEnv);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UnsupportedPlatformError);
+    const msg = (caught as Error).message;
+    expect(msg.toLowerCase()).toContain('windows');
+    expect(msg).toMatch(/v2|future|plan/i);
+  });
+
+  it('exposes the same shape regardless of platform (linux vs darwin)', () => {
+    const linux = defaultOverturePaths({ platform: 'linux' }, {
+      HOME: '/home/x',
+    } as NodeJS.ProcessEnv);
+    const darwin = defaultOverturePaths({ platform: 'darwin' }, {
+      HOME: '/Users/x',
+    } as NodeJS.ProcessEnv);
+    const linuxKeys = Object.keys(linux).sort();
+    const darwinKeys = Object.keys(darwin).sort();
+    expect(linuxKeys).toEqual(darwinKeys);
+  });
+});
+
+describe('isSupportedPlatform', () => {
+  it('returns true for linux', () => {
+    expect(isSupportedPlatform('linux')).toBe(true);
+  });
+  it('returns true for darwin', () => {
+    expect(isSupportedPlatform('darwin')).toBe(true);
+  });
+  it('returns false for win32', () => {
+    expect(isSupportedPlatform('win32')).toBe(false);
+  });
+});
+
+describe('OverturePaths shape', () => {
+  it('exposes configFile, configDir, stateDir, cacheDir, homeDir, platform, workspaceDir', () => {
+    const paths: OverturePaths = defaultOverturePaths({ platform: 'linux' }, {
+      HOME: '/home/x',
+    } as NodeJS.ProcessEnv);
+    expect(typeof paths.configFile).toBe('string');
+    expect(typeof paths.configDir).toBe('string');
+    expect(typeof paths.stateDir).toBe('string');
+    expect(typeof paths.cacheDir).toBe('string');
+    expect(typeof paths.homeDir).toBe('string');
+    expect(typeof paths.workspaceDir).toBe('string');
+    expect(['linux', 'darwin']).toContain(paths.platform);
+  });
+});

--- a/packages/config/src/paths.ts
+++ b/packages/config/src/paths.ts
@@ -1,0 +1,152 @@
+import { join } from 'node:path';
+import { platform as nodePlatform } from 'node:os';
+
+/**
+ * Hosts that `overture` supports in v1. Linux covers native Linux, WSL1, and
+ * WSL2 — the WSL case is indistinguishable from native Linux at the XDG
+ * resolver level (both use the same filesystem layout).
+ */
+export type SupportedHostPlatform = 'linux' | 'darwin';
+
+export const SUPPORTED_HOST_PLATFORMS: readonly SupportedHostPlatform[] = [
+  'linux',
+  'darwin',
+] as const;
+
+/**
+ * Mirrors the `HostPlatform` type from `@overture/os`. Defined locally
+ * (instead of imported) to keep `@overture/config` decoupled from the OS
+ * detection library — the caller is responsible for normalizing the input
+ * to one of these three values.
+ */
+export type HostPlatform = SupportedHostPlatform | 'win32';
+
+/**
+ * All on-disk locations that `@overture/config` and consumers need to find
+ * or write. Resolved by {@link defaultOverturePaths} from the XDG base
+ * directories and the current process environment.
+ */
+export interface OverturePaths {
+  /** Absolute path to the user-level `overture.jsonc` config file. */
+  readonly configFile: string;
+  /** Parent directory of {@link configFile}; also where state/cache siblings live. */
+  readonly configDir: string;
+  /** Directory for machine-managed state files (sync-state, last-apply, etc.). */
+  readonly stateDir: string;
+  /** Directory for regeneratable caches (installed-skills-cache, etc.). */
+  readonly cacheDir: string;
+  /** `$HOME` on linux/darwin (or equivalent). */
+  readonly homeDir: string;
+  /** Current working directory at the time of resolution. */
+  readonly workspaceDir: string;
+  /** Narrowed to supported host platforms only. */
+  readonly platform: SupportedHostPlatform;
+}
+
+export interface ResolvePathsOptions {
+  /** Override the host platform; defaults to `process.platform`. */
+  readonly platform?: HostPlatform;
+  /** Override the working directory; defaults to `process.cwd()`. */
+  readonly workspaceDir?: string;
+}
+
+/**
+ * Thrown when a caller asks for paths on a host that `overture` does not
+ * support in v1 (currently only Windows). The CLI catches this and prints
+ * a human-readable message.
+ */
+export class UnsupportedPlatformError extends Error {
+  public readonly platform: HostPlatform;
+  public constructor(platform: HostPlatform) {
+    super(
+      `Windows is not supported in this version of overture. ` +
+        `Support is planned for a future release. ` +
+        `(requested platform: ${platform})`,
+    );
+    this.name = 'UnsupportedPlatformError';
+    this.platform = platform;
+  }
+}
+
+/**
+ * Returns true iff `platform` is one of {@link SUPPORTED_HOST_PLATFORMS}.
+ */
+export function isSupportedPlatform(
+  platform: HostPlatform,
+): platform is SupportedHostPlatform {
+  return (SUPPORTED_HOST_PLATFORMS as readonly string[]).includes(platform);
+}
+
+/**
+ * Resolve the XDG base directory for `key`, falling back to `home + fallback`
+ * when the env var is unset. Mirrors the behavior of the XDG Base Directory
+ * Specification, with macOS following the same convention (we do not
+ * translate to `~/Library/Application Support`).
+ */
+function xdgBase(
+  env: NodeJS.ProcessEnv,
+  key:
+    | 'XDG_CONFIG_HOME'
+    | 'XDG_DATA_HOME'
+    | 'XDG_STATE_HOME'
+    | 'XDG_CACHE_HOME',
+  home: string,
+  fallback: string,
+): string {
+  const value = env[key];
+  if (typeof value === 'string' && value.length > 0) return value;
+  return join(home, fallback);
+}
+
+/**
+ * Compute the on-disk paths used by `overture` for the requested platform.
+ * Linux (including WSL1/WSL2) and macOS use the same XDG layout. Windows is
+ * rejected with {@link UnsupportedPlatformError}.
+ *
+ * Pure function — no filesystem access, safe to call from tests.
+ */
+export function defaultOverturePaths(
+  options: ResolvePathsOptions = {},
+  env: NodeJS.ProcessEnv = process.env,
+): OverturePaths {
+  // `nodePlatform()` may return more values than our HostPlatform union
+  // (e.g. 'aix', 'freebsd'); we collapse any non-{linux,darwin,win32}
+  // value to 'win32' so the unsupported-platform gate treats them all
+  // the same way. In practice this only matters if someone runs the CLI
+  // on an exotic host; on linux/darwin/win32 it's a no-op.
+  const rawPlatform = options.platform ?? (nodePlatform() as HostPlatform);
+  const platform: HostPlatform =
+    rawPlatform === 'linux' ||
+    rawPlatform === 'darwin' ||
+    rawPlatform === 'win32'
+      ? rawPlatform
+      : 'win32';
+
+  if (!isSupportedPlatform(platform)) {
+    throw new UnsupportedPlatformError(platform);
+  }
+
+  const homeDir =
+    (typeof env.HOME === 'string' && env.HOME.length > 0 && env.HOME) ||
+    (typeof env.USERPROFILE === 'string' && env.USERPROFILE.length > 0
+      ? env.USERPROFILE
+      : '/');
+
+  const configBase = xdgBase(env, 'XDG_CONFIG_HOME', homeDir, '.config');
+  const stateBase = xdgBase(env, 'XDG_STATE_HOME', homeDir, '.local/state');
+  const cacheBase = xdgBase(env, 'XDG_CACHE_HOME', homeDir, '.cache');
+
+  const configDir = join(configBase, 'overture');
+  const stateDir = join(stateBase, 'overture');
+  const cacheDir = join(cacheBase, 'overture');
+
+  return {
+    configFile: join(configDir, 'overture.jsonc'),
+    configDir,
+    stateDir,
+    cacheDir,
+    homeDir,
+    workspaceDir: options.workspaceDir ?? process.cwd(),
+    platform,
+  };
+}

--- a/packages/config/src/schema.spec.ts
+++ b/packages/config/src/schema.spec.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OvertureConfigSchema,
+  parseOvertureConfig,
+  type OvertureConfig,
+} from './schema.js';
+
+const validMinimal = {
+  $schema: 'https://example/overture.config.schema.json',
+  version: 1 as const,
+  profiles: {
+    default: {
+      mcpServers: {},
+      sync: { targets: [] },
+      skills: [],
+    },
+  },
+};
+
+describe('OvertureConfigSchema', () => {
+  it('accepts a minimal valid config', () => {
+    const r = OvertureConfigSchema.safeParse(validMinimal);
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a config with a profile that has mcpServers, sync, and skills', () => {
+    const input = {
+      $schema: 'https://example/x.json',
+      version: 1,
+      profiles: {
+        default: {
+          mcpServers: {
+            filesystem: {
+              type: 'stdio' as const,
+              command: 'npx',
+              args: ['-y', '@mcp/server-filesystem', '/home'],
+            },
+            context7: {
+              type: 'stdio' as const,
+              command: 'npx',
+              args: ['-y', '@upstash/context7-mcp@latest'],
+              env: { CONTEXT7_API_KEY: '${CONTEXT7_API_KEY}' },
+            },
+          },
+          sync: {
+            targets: ['claude-code', 'opencode'],
+            disabledServers: ['filesystem'],
+          },
+          skills: [
+            {
+              source: 'vercel-labs/agent-skills',
+              include: ['frontend-design', 'skill-creator'],
+            },
+          ],
+        },
+      },
+    };
+    const r = OvertureConfigSchema.safeParse(input);
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects unknown top-level keys', () => {
+    const r = OvertureConfigSchema.safeParse({
+      ...validMinimal,
+      mystery: true,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects version != 1', () => {
+    const r = OvertureConfigSchema.safeParse({
+      ...validMinimal,
+      version: 2,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a profile whose name is not a string', () => {
+    const r = OvertureConfigSchema.safeParse({
+      ...validMinimal,
+      profiles: { default: 42 },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an mcp server with neither command nor url', () => {
+    const r = OvertureConfigSchema.safeParse({
+      ...validMinimal,
+      profiles: {
+        default: {
+          mcpServers: { broken: { type: 'stdio' as const } },
+          sync: { targets: [] },
+          skills: [],
+        },
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a remote mcp server without url', () => {
+    const r = OvertureConfigSchema.safeParse({
+      ...validMinimal,
+      profiles: {
+        default: {
+          mcpServers: {
+            broken: { type: 'remote' as const, command: 'npx' },
+          },
+          sync: { targets: [] },
+          skills: [],
+        },
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a skills entry without include (or with empty include)', () => {
+    const r = OvertureConfigSchema.safeParse({
+      ...validMinimal,
+      profiles: {
+        default: {
+          mcpServers: {},
+          sync: { targets: [] },
+          skills: [{ source: 'foo/bar', include: [] }],
+        },
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a skills entry whose source is not owner/repo', () => {
+    const r = OvertureConfigSchema.safeParse({
+      ...validMinimal,
+      profiles: {
+        default: {
+          mcpServers: {},
+          sync: { targets: [] },
+          skills: [{ source: 'not-a-coord', include: ['x'] }],
+        },
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a sync target that is not a string', () => {
+    const r = OvertureConfigSchema.safeParse({
+      ...validMinimal,
+      profiles: {
+        default: {
+          mcpServers: {},
+          sync: { targets: [42] },
+          skills: [],
+        },
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('parseOvertureConfig', () => {
+  it('returns the parsed config on success', () => {
+    const cfg: OvertureConfig = parseOvertureConfig(validMinimal);
+    expect(cfg.version).toBe(1);
+    expect(cfg.profiles.default.sync.targets).toEqual([]);
+  });
+
+  it('throws with a useful message on failure', () => {
+    expect(() => parseOvertureConfig({ version: 1 })).toThrow(/config/i);
+  });
+});

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -1,0 +1,155 @@
+// Deep import from `zod/v3` (the ESM subpath) instead of the package
+// root. The package root re-exports through a UMD `index.cjs` that
+// uses relative `require()` calls, which break once esbuild inlines
+// the package into the CJS bundle at `apps/cli/dist/main.js`. Mirrors
+// the jsonc-parser deep-import pattern in the repo's AGENTS.md.
+import { z } from 'zod/v3';
+
+/**
+ * Source coordinate for an installed skill, matching the `npx skills add`
+ * CLI grammar: `owner/repo`. We deliberately disallow full URLs and local
+ * paths here because overture's first-class skill install flow is the
+ * `npx skills add` shim; URL/path installs are out of scope for v1.
+ */
+const OwnerRepo = z
+  .string()
+  .regex(
+    /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/,
+    "source must be in 'owner/repo' form (e.g. 'vercel-labs/agent-skills')",
+  );
+
+/**
+ * A single MCP server entry. The discriminator is `type`:
+ * - `stdio` requires `command`
+ * - `remote` requires `url`
+ *
+ * The union narrows correctly so the per-agent write layer can rely on the
+ * type system to enforce which fields are present.
+ */
+const StdioMcpServer = z
+  .object({
+    type: z.literal('stdio'),
+    command: z.string().min(1),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .strict();
+
+const RemoteMcpServer = z
+  .object({
+    type: z.literal('remote'),
+    url: z.string().url(),
+    headers: z.record(z.string(), z.string()).optional(),
+  })
+  .strict();
+
+const McpServer = z.discriminatedUnion('type', [
+  StdioMcpServer,
+  RemoteMcpServer,
+]);
+
+const McpServerMap = z.record(z.string(), McpServer);
+
+const SyncConfig = z
+  .object({
+    /**
+     * Target platform ids to sync the global MCP server set to. Strings
+     * here are intentionally NOT validated against the agent registry — the
+     * registry may grow and we want the config to be forward-compatible.
+     */
+    targets: z.array(z.string().min(1)),
+    /**
+     * Per-profile, per-target exclusions are out of scope for v1 (we
+     * dropped the per-agent override section during design). This field
+     * remains a flat list of server names to skip everywhere.
+     */
+    disabledServers: z.array(z.string().min(1)).default([]),
+  })
+  .strict();
+
+const SkillInstallEntry = z
+  .object({
+    source: OwnerRepo,
+    /**
+     * Explicit list of skills to install from the source. Required and
+     * non-empty: the skills CLI's "install everything" mode is too broad
+     * to be a stable configuration target.
+     */
+    include: z.array(z.string().min(1)).min(1),
+  })
+  .strict();
+
+const Profile = z
+  .object({
+    mcpServers: McpServerMap,
+    sync: SyncConfig,
+    skills: z.array(SkillInstallEntry).default([]),
+  })
+  .strict();
+
+const Settings = z
+  .object({
+    defaultProfile: z.string().min(1).default('default'),
+    dryRunByDefault: z.boolean().default(true),
+    backupBeforeWrite: z.boolean().default(true),
+    conflictPolicy: z.enum(['refuse', 'prompt', 'overwrite']).default('refuse'),
+  })
+  .strict()
+  .partial()
+  .default({});
+
+/**
+ * Top-level Zod schema for the `overture.jsonc` config file. All fields
+ * are validated; unknown keys are rejected. Future schema versions should
+ * live in `OvertureConfigV2Schema` etc. and be dispatched on `version`.
+ */
+export const OvertureConfigSchema = z
+  .object({
+    $schema: z.string().optional(),
+    version: z.literal(1),
+    settings: Settings,
+    profiles: z
+      .object({
+        default: Profile,
+      })
+      .catchall(Profile)
+      .refine(
+        (profiles) => Object.keys(profiles).length > 0,
+        'at least one profile is required',
+      ),
+  })
+  .strict();
+
+/** Static TypeScript type derived from the Zod schema. */
+export type OvertureConfig = z.infer<typeof OvertureConfigSchema>;
+
+/** Single profile shape, derived. */
+export type OvertureProfile = z.infer<typeof Profile>;
+
+/** Settings block shape, derived. */
+export type OvertureSettings = z.infer<typeof Settings>;
+
+/** Sync block shape, derived. */
+export type OvertureSyncConfig = z.infer<typeof SyncConfig>;
+
+/** Single MCP server entry (the union), derived. */
+export type OvertureMcpServer = z.infer<typeof McpServer>;
+
+/** Skills install entry, derived. */
+export type OvertureSkillInstall = z.infer<typeof SkillInstallEntry>;
+
+/**
+ * Parse-and-throw variant. Use only when you know the input shape comes
+ * from a trusted local file. For external/untrusted input, prefer
+ * `OvertureConfigSchema.safeParse`.
+ */
+export function parseOvertureConfig(input: unknown): OvertureConfig {
+  const result = OvertureConfigSchema.safeParse(input);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('\n');
+    throw new Error(`Invalid overture config:\n${issues}`);
+  }
+  return result.data;
+}

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/config/tsconfig.lib.json
+++ b/packages/config/tsconfig.lib.json
@@ -3,27 +3,13 @@
   "compilerOptions": {
     "composite": true,
     "declaration": true,
-    "declarationMap": false,
-    "outDir": "dist",
-    "types": ["node"],
+    "declarationMap": true,
+    "outDir": "../../dist/packages/config",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo"
+    "tsBuildInfoFile": "../../dist/packages/config/tsconfig.lib.tsbuildinfo"
   },
-  "references": [
-    {
-      "path": "../../packages/agents"
-    },
-    {
-      "path": "../../packages/config"
-    },
-    {
-      "path": "../../packages/os"
-    }
-  ],
   "include": ["src/**/*.ts"],
   "exclude": [
-    "vite.config.ts",
-    "vite.config.mts",
     "vitest.config.ts",
     "vitest.config.mts",
     "src/**/*.test.ts",

--- a/packages/config/tsconfig.spec.json
+++ b/packages/config/tsconfig.spec.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "outDir": "./out-tsc/vitest",
+    "outDir": "../../dist/packages/config/out-tsc/vitest",
     "types": [
       "vitest/globals",
       "vitest/importMeta",
@@ -11,21 +10,8 @@
       "vitest"
     ]
   },
-  "references": [
-    {
-      "path": "../../packages/agents"
-    },
-    {
-      "path": "../../packages/config"
-    },
-    {
-      "path": "../../packages/os"
-    }
-  ],
   "include": [
     "src/**/*.ts",
-    "vite.config.ts",
-    "vite.config.mts",
     "vitest.config.ts",
     "vitest.config.mts",
     "src/**/*.test.ts",

--- a/packages/config/vitest.config.mts
+++ b/packages/config/vitest.config.mts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/config',
+  test: {
+    name: '@overture/config',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "./packages/agents"
     },
     {
+      "path": "./packages/config"
+    },
+    {
       "path": "./packages/os"
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,366 +1547,184 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/aix-ppc64@npm:0.25.12"
+"@esbuild/aix-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/aix-ppc64@npm:0.28.1"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/aix-ppc64@npm:0.28.0"
-  conditions: os=aix & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/android-arm64@npm:0.25.12"
+"@esbuild/android-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm64@npm:0.28.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/android-arm64@npm:0.28.0"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/android-arm@npm:0.25.12"
+"@esbuild/android-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm@npm:0.28.1"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/android-arm@npm:0.28.0"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/android-x64@npm:0.25.12"
+"@esbuild/android-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-x64@npm:0.28.1"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/android-x64@npm:0.28.0"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-arm64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/darwin-arm64@npm:0.25.12"
+"@esbuild/darwin-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-arm64@npm:0.28.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/darwin-arm64@npm:0.28.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/darwin-x64@npm:0.25.12"
+"@esbuild/darwin-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-x64@npm:0.28.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/darwin-x64@npm:0.28.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-arm64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/freebsd-arm64@npm:0.25.12"
+"@esbuild/freebsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.28.1"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/freebsd-arm64@npm:0.28.0"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/freebsd-x64@npm:0.25.12"
+"@esbuild/freebsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-x64@npm:0.28.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/freebsd-x64@npm:0.28.0"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/linux-arm64@npm:0.25.12"
+"@esbuild/linux-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm64@npm:0.28.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/linux-arm64@npm:0.28.0"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/linux-arm@npm:0.25.12"
+"@esbuild/linux-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm@npm:0.28.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/linux-arm@npm:0.28.0"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ia32@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/linux-ia32@npm:0.25.12"
+"@esbuild/linux-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ia32@npm:0.28.1"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/linux-ia32@npm:0.28.0"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/linux-loong64@npm:0.25.12"
+"@esbuild/linux-loong64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-loong64@npm:0.28.1"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/linux-loong64@npm:0.28.0"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-mips64el@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/linux-mips64el@npm:0.25.12"
+"@esbuild/linux-mips64el@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-mips64el@npm:0.28.1"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/linux-mips64el@npm:0.28.0"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ppc64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/linux-ppc64@npm:0.25.12"
+"@esbuild/linux-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ppc64@npm:0.28.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/linux-ppc64@npm:0.28.0"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-riscv64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/linux-riscv64@npm:0.25.12"
+"@esbuild/linux-riscv64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-riscv64@npm:0.28.1"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/linux-riscv64@npm:0.28.0"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-s390x@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/linux-s390x@npm:0.25.12"
+"@esbuild/linux-s390x@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-s390x@npm:0.28.1"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/linux-s390x@npm:0.28.0"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-x64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/linux-x64@npm:0.25.12"
+"@esbuild/linux-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-x64@npm:0.28.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/linux-x64@npm:0.28.0"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-arm64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+"@esbuild/netbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-arm64@npm:0.28.1"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-arm64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/netbsd-arm64@npm:0.28.0"
-  conditions: os=netbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-x64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/netbsd-x64@npm:0.25.12"
+"@esbuild/netbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-x64@npm:0.28.1"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/netbsd-x64@npm:0.28.0"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-arm64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+"@esbuild/openbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.28.1"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-arm64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/openbsd-arm64@npm:0.28.0"
-  conditions: os=openbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-x64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/openbsd-x64@npm:0.25.12"
+"@esbuild/openbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-x64@npm:0.28.1"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/openbsd-x64@npm:0.28.0"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openharmony-arm64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+"@esbuild/openharmony-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openharmony-arm64@npm:0.28.1"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/openharmony-arm64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/openharmony-arm64@npm:0.28.0"
-  conditions: os=openharmony & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/sunos-x64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/sunos-x64@npm:0.25.12"
+"@esbuild/sunos-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/sunos-x64@npm:0.28.1"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/sunos-x64@npm:0.28.0"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-arm64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/win32-arm64@npm:0.25.12"
+"@esbuild/win32-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-arm64@npm:0.28.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/win32-arm64@npm:0.28.0"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-ia32@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/win32-ia32@npm:0.25.12"
+"@esbuild/win32-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-ia32@npm:0.28.1"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/win32-ia32@npm:0.28.0"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.25.12":
-  version: 0.25.12
-  resolution: "@esbuild/win32-x64@npm:0.25.12"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.28.0":
-  version: 0.28.0
-  resolution: "@esbuild/win32-x64@npm:0.28.0"
+"@esbuild/win32-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-x64@npm:0.28.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5006,36 +4824,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.25.0":
-  version: 0.25.12
-  resolution: "esbuild@npm:0.25.12"
+"esbuild@npm:^0.28.1":
+  version: 0.28.1
+  resolution: "esbuild@npm:0.28.1"
   dependencies:
-    "@esbuild/aix-ppc64": "npm:0.25.12"
-    "@esbuild/android-arm": "npm:0.25.12"
-    "@esbuild/android-arm64": "npm:0.25.12"
-    "@esbuild/android-x64": "npm:0.25.12"
-    "@esbuild/darwin-arm64": "npm:0.25.12"
-    "@esbuild/darwin-x64": "npm:0.25.12"
-    "@esbuild/freebsd-arm64": "npm:0.25.12"
-    "@esbuild/freebsd-x64": "npm:0.25.12"
-    "@esbuild/linux-arm": "npm:0.25.12"
-    "@esbuild/linux-arm64": "npm:0.25.12"
-    "@esbuild/linux-ia32": "npm:0.25.12"
-    "@esbuild/linux-loong64": "npm:0.25.12"
-    "@esbuild/linux-mips64el": "npm:0.25.12"
-    "@esbuild/linux-ppc64": "npm:0.25.12"
-    "@esbuild/linux-riscv64": "npm:0.25.12"
-    "@esbuild/linux-s390x": "npm:0.25.12"
-    "@esbuild/linux-x64": "npm:0.25.12"
-    "@esbuild/netbsd-arm64": "npm:0.25.12"
-    "@esbuild/netbsd-x64": "npm:0.25.12"
-    "@esbuild/openbsd-arm64": "npm:0.25.12"
-    "@esbuild/openbsd-x64": "npm:0.25.12"
-    "@esbuild/openharmony-arm64": "npm:0.25.12"
-    "@esbuild/sunos-x64": "npm:0.25.12"
-    "@esbuild/win32-arm64": "npm:0.25.12"
-    "@esbuild/win32-ia32": "npm:0.25.12"
-    "@esbuild/win32-x64": "npm:0.25.12"
+    "@esbuild/aix-ppc64": "npm:0.28.1"
+    "@esbuild/android-arm": "npm:0.28.1"
+    "@esbuild/android-arm64": "npm:0.28.1"
+    "@esbuild/android-x64": "npm:0.28.1"
+    "@esbuild/darwin-arm64": "npm:0.28.1"
+    "@esbuild/darwin-x64": "npm:0.28.1"
+    "@esbuild/freebsd-arm64": "npm:0.28.1"
+    "@esbuild/freebsd-x64": "npm:0.28.1"
+    "@esbuild/linux-arm": "npm:0.28.1"
+    "@esbuild/linux-arm64": "npm:0.28.1"
+    "@esbuild/linux-ia32": "npm:0.28.1"
+    "@esbuild/linux-loong64": "npm:0.28.1"
+    "@esbuild/linux-mips64el": "npm:0.28.1"
+    "@esbuild/linux-ppc64": "npm:0.28.1"
+    "@esbuild/linux-riscv64": "npm:0.28.1"
+    "@esbuild/linux-s390x": "npm:0.28.1"
+    "@esbuild/linux-x64": "npm:0.28.1"
+    "@esbuild/netbsd-arm64": "npm:0.28.1"
+    "@esbuild/netbsd-x64": "npm:0.28.1"
+    "@esbuild/openbsd-arm64": "npm:0.28.1"
+    "@esbuild/openbsd-x64": "npm:0.28.1"
+    "@esbuild/openharmony-arm64": "npm:0.28.1"
+    "@esbuild/sunos-x64": "npm:0.28.1"
+    "@esbuild/win32-arm64": "npm:0.28.1"
+    "@esbuild/win32-ia32": "npm:0.28.1"
+    "@esbuild/win32-x64": "npm:0.28.1"
   dependenciesMeta:
     "@esbuild/aix-ppc64":
       optional: true
@@ -5091,96 +4909,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 10c0/c205357531423220a9de8e1e6c6514242bc9b1666e762cd67ccdf8fdfdc3f1d0bd76f8d9383958b97ad4c953efdb7b6e8c1f9ca5951cd2b7c5235e8755b34a6b
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.28.0":
-  version: 0.28.0
-  resolution: "esbuild@npm:0.28.0"
-  dependencies:
-    "@esbuild/aix-ppc64": "npm:0.28.0"
-    "@esbuild/android-arm": "npm:0.28.0"
-    "@esbuild/android-arm64": "npm:0.28.0"
-    "@esbuild/android-x64": "npm:0.28.0"
-    "@esbuild/darwin-arm64": "npm:0.28.0"
-    "@esbuild/darwin-x64": "npm:0.28.0"
-    "@esbuild/freebsd-arm64": "npm:0.28.0"
-    "@esbuild/freebsd-x64": "npm:0.28.0"
-    "@esbuild/linux-arm": "npm:0.28.0"
-    "@esbuild/linux-arm64": "npm:0.28.0"
-    "@esbuild/linux-ia32": "npm:0.28.0"
-    "@esbuild/linux-loong64": "npm:0.28.0"
-    "@esbuild/linux-mips64el": "npm:0.28.0"
-    "@esbuild/linux-ppc64": "npm:0.28.0"
-    "@esbuild/linux-riscv64": "npm:0.28.0"
-    "@esbuild/linux-s390x": "npm:0.28.0"
-    "@esbuild/linux-x64": "npm:0.28.0"
-    "@esbuild/netbsd-arm64": "npm:0.28.0"
-    "@esbuild/netbsd-x64": "npm:0.28.0"
-    "@esbuild/openbsd-arm64": "npm:0.28.0"
-    "@esbuild/openbsd-x64": "npm:0.28.0"
-    "@esbuild/openharmony-arm64": "npm:0.28.0"
-    "@esbuild/sunos-x64": "npm:0.28.0"
-    "@esbuild/win32-arm64": "npm:0.28.0"
-    "@esbuild/win32-ia32": "npm:0.28.0"
-    "@esbuild/win32-x64": "npm:0.28.0"
-  dependenciesMeta:
-    "@esbuild/aix-ppc64":
-      optional: true
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-arm64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-arm64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/openharmony-arm64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10c0/8acd95c238ec6c4a9d16163277faf228a8994b642d187b3fe667ffbb469008e6748cde144fdc3c175bf8e78ee49e15a0ed9b9f183fdb5fcea1772f87fb1372a4
+  checksum: 10c0/29cd456a79ce35ac2c7e05fe871330416b2c395c045d849653f843e51378d6e0d6e774d6dcd01b35f4e83238a29bf8decd04fcd34b3780c589a250b21e5f92bb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,6 +2690,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@overture/config@workspace:packages/config":
+  version: 0.0.0-use.local
+  resolution: "@overture/config@workspace:packages/config"
+  dependencies:
+    jsonc-parser: "npm:^3.3.1"
+    zod: "npm:^3.23.8"
+  languageName: unknown
+  linkType: soft
+
 "@overture/os@workspace:packages/os":
   version: 0.0.0-use.local
   resolution: "@overture/os@workspace:packages/os"
@@ -9007,5 +9016,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.23.8":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary

Adds the `@overture/config` library (a new workspace package), the user-level `overture.jsonc` declarative config file, a Windows platform gate, and a new `overture config show` subcommand. Includes full user docs and a deep test sweep.

## What's in the box

### `@overture/config` (new package at `packages/config/`)
- `OvertureConfigSchema` — the Zod schema for the v1 user-level `overture.jsonc`. Strict: unknown top-level keys are rejected, the `version` literal is pinned to `1`, the MCP `mcpServers` shape uses a discriminated union (`stdio` requires `command`, `remote` requires `url`), and the skills entries require `source` in `owner/repo` form plus a non-empty `include` list.
- `defaultOverturePaths` — XDG-only path resolver. Same layout on Linux (incl. WSL1/WSL2) and macOS. Throws `UnsupportedPlatformError` for `win32` and any other host platform Node reports.
- `loadOvertureConfig` — reads the file at the resolved path, parses with `jsonc-parser` (tolerates comments + trailing commas), validates with the Zod schema, returns `null` for ENOENT, propagates other errors with a clear message.

### CLI changes
- New `overture config show` subcommand. Prints the resolved `overture.jsonc` path and the parsed JSON, or a "not found" message with the path it would have used. Invalid configs go to stderr + exit 2 (no stack trace).
- New Windows platform gate. Every subcommand on `win32` prints a clean stdout message and exits 0 instead of crashing or silently doing the wrong thing.
- Updated top-level usage to list both `detect` and `config show`.

### Docs
- New `docs/overture-config.md`: support matrix, XDG path map, full v1 schema, env vars, MCP server entry shapes (stdio + remote), skills shape, examples, design principles, and what's explicitly out of scope (per-target overrides, project-level config, convergence sync, state files).
- README cross-link + a one-line mention of `overture config show`.

### Repo hygiene
- `.gitignore` gains `.worktrees/` (the in-repo worktree location recommended by the repo's AGENTS.md).

## Why a new library and not a `src/` module in the CLI?

The Zod schema, the path resolver, and the loader are independently consumable: a future `overture sync` (planned follow-up) needs the schema to validate, the resolver to find the source, and the loader to read+parse+validate — all without dragging in the CLI's command-parser or detection pipeline. Keeping it as `@overture/config` also lets future tools (e.g. an editor extension) validate `overture.jsonc` against the same source of truth.

## Why XDG on macOS (not `~/Library/Application Support`)?

`vercel-labs/skills` already uses `~/.config/agents/skills/` on macOS, so XDG-on-macOS is a de-facto convention among agent-adjacent tooling. Picking a single layout for both supported hosts also makes the path resolver a single, testable function with no platform branch.

## Test sweep

| Suite                       | Tests | Status |
| --------------------------- | ----- | ------ |
| `@overture/config` (new)    | 28    | green  |
| `@jander99/overture` (CLI)  | 103   | green  |
| `yarn prettier --check .`   | —     | clean  |
| `yarn nx affected -t test`  | 4 projects | green |
| `yarn nx affected -t build` | 4 projects | green |
| `node apps/cli/scripts/verify-package.mjs` | — | `=== PASS ===` |

The new `@overture/config` suite covers: the XDG resolver (linux + darwin + win32), the Zod schema (happy + every rejection path), the JSONC loader (missing file, happy path, JSONC tolerance, invalid file, EISDIR propagation).

The new CLI specs cover: the Windows platform gate (3 cases — `detect` subcommand, no args, linux control), and `overture config show` (3 cases — not found, happy path, unknown subcommand).

## Out of scope (explicitly)

These were discussed during design and are deliberately **not** in this PR:
- `overture sync` (one-way or N→N) — needs per-agent `mcp.write` implementations first
- Per-target MCP overrides — dropped during design
- Project-level `overture.jsonc` — explicitly user-level only in v1
- Windows support — explicit "not in v1"; issue #84 stays open
- Per-agent write handlers — `mcp.write` slot is reserved but unused; this PR only adds read + parse

## Manual QA evidence

- `overture` prints the new two-command usage
- `overture detect` (linux host) — unchanged, 14 platforms, all green
- `overture config show` with no file — clean "not found" message + path
- `overture config show` with a real JSONC file (comments + trailing commas) — parsed and rendered
- `overture config show` with a bad file — clean stderr message + exit 2, no stack trace
