### PR TITLE
chore(renovate): hold typescript at <6 until Nx 23+ is adopted

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,12 @@
       "description": "Require 7-day minimum release age for npm/yarn updates to guard against supply chain attacks",
       "matchManagers": ["npm"],
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Hold typescript at <6 until Nx 23+ is adopted (Nx 22.7.5 only supports TS 5.x)",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<6.0.0"
     }
+
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,5 @@
       "matchPackageNames": ["typescript"],
       "allowedVersions": "<6.0.0"
     }
-
   ]
 }


### PR DESCRIPTION
## Summary

Pins the `typescript` dependency in the renovate config to `<6.0.0` so the v6 bump doesn't keep getting re-proposed every cycle until the repo is actually ready to adopt it.

## Why

PR #92 (`chore(deps): update dependency typescript to v6`) was opened by Renovate. It's been closed with a comment, but without a renovate-side constraint the same PR will reappear on the next dependency-detection cycle. Two independent blockers make a v6 bump unsafe right now:

1. **Nx 22.7.5 is the last release in the Nx 22 line and was developed against TypeScript 5.x.** Nx 23+ is the release that tracks TypeScript 6. Bumping `typescript` alone, while leaving Nx on 22, puts us on an unsupported combination — `@nx/js`, `@nx/esbuild`, `@nx/vitest`, and `@nx/eslint` 22.7.5 all peer-depend on TypeScript 5.x. The right migration is a **coordinated Nx 23 + TypeScript 6** as a single PR.

2. **The project's package tsconfigs aren't yet ready for TS 6's stricter node-types resolution.** Today `packages/agents/tsconfig.lib.json`, `packages/os/tsconfig.lib.json`, and `packages/config/tsconfig.lib.json` rely on the transitive `types` array inherited from `tsconfig.base.json`. TypeScript 6 requires every tsconfig that uses `node:*` imports to declare `"types": ["node"]` (or include a triple-slash reference) explicitly. That's a real, repo-wide config change that belongs in the Nx-23 migration PR, not a silent fix on a Renovate branch.

## What this PR does

Adds a single `packageRule` to `renovate.json`:

```json
{
  "description": "Hold typescript at <6 until Nx 23+ is adopted (Nx 22.7.5 only supports TS 5.x)",
  "matchPackageNames": ["typescript"],
  "allowedVersions": "<6.0.0"
}
```

The hold can be lifted (or expanded to track Nx 23) in the same PR that does the actual migration.

## How to unblock the migration when ready

The Nx-23 + TS-6 PR will need to:
1. Bump `nx` and all `@nx/*` packages to 23.x in `package.json` (and the corresponding `@nx/*: ^22.7.5` entries in `apps/cli/project.json` if any are pinned there).
2. Bump `typescript` to ~6.x in `package.json` and remove the `allowedVersions: "<6.0.0"` rule from `renovate.json` (in the same PR, or in a follow-up).
3. Add `"types": ["node"]` to every `packages/*/tsconfig.lib.json` and `apps/*/tsconfig*.json` that uses `node:*` imports. Right now those are at least: `packages/agents/`, `packages/os/`, `packages/config/`, and `apps/cli/`.
4. Re-run the full QA sweep (lint + tsc -b + test + build + verify-package.mjs) and fix any incidental breakage from the Nx 23 plugin shape changes.

## CI

This PR only touches `renovate.json` (no code, no `package.json`, no `yarn.lock`). The CI config-gate job runs `prettier --check`, `nx lint`, `tsc -b`, and `npm audit` — none of which are affected. Workflow changes are also not exercised by the existing CI job. Manually validated: `jq -e . renovate.json` parses cleanly; the new rule matches the schema documented at https://docs.renovatebot.com/key-concepts/versioning/.
