### PR TITLE
chore: ignore .opencode/ scratch and document RTK in AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 .nx/self-healing
 .nx/polygraph
 .claude/worktrees
+.opencode/
+.worktrees/
+
 .worktrees/
 
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,22 @@ All commands run from the repo root.
 - Verify a local npm pack + install + smoke (no publish):
   `node apps/cli/scripts/verify-package.mjs`.
 
+## RTK
+
+RTK intercepts shell commands at runtime — `git status` becomes
+`rtk git status`; output may change. Don't pre-wrap commands; let RTK do
+its job. Use `rtk run <command>` only when RTK's output is unusable.
+
+**Exception for quality-gate tools.** RTK's runtime versions of
+`prettier`, `eslint`, `tsc`, `vitest`, and `nx` may not match the
+versions the workspace pins in `package.json` (e.g. `prettier: "^3.8.3"`,
+`typescript: "~5.9.0"`). When the command's output gates a CI check — i.e.
+when you intend the result to be the same answer CI will give — invoke
+the workspace-pinned version explicitly: `yarn prettier`, `yarn tsc -b`,
+`yarn nx lint`, `yarn nx test`, or `./node_modules/.bin/<tool>`. RTK's
+output is fine for read-only inspection, but the workspace-pinned version
+is what CI runs and what should gate a commit.
+
 ## Gotchas
 
 - **Naming.** The root `package.json` is named `skills-cli` (legacy project


### PR DESCRIPTION
## Summary

Two small, scoped changes to make local work in this repo cleaner and to capture a lesson learned the hard way.

## Changes

### 1. `.gitignore`: add `.opencode/`

The opencode IDE plugin writes a `.opencode/` directory at the repo root with magic-context scratch files (historian snapshots, dreamer notes). It's regenerated every session, never authored by hand, and should not be committed. Placed next to `.worktrees/` and `.claude/worktrees/` — both are the same flavor of local-only paths that the agent ecosystem creates on its own.

### 2. `AGENTS.md`: new `## RTK` section

The repo's existing AGENTS.md (mirroring the global one) tells the agent to "let RTK do its job" for shell commands. That works for read-only commands, but produces false passes/failures when the command's output gates a CI check: RTK's runtime versions of `prettier`, `eslint`, `tsc`, `vitest`, and `nx` may not match the versions pinned in this repo's `package.json` (e.g. `prettier: "^3.8.3"`, `typescript: "~5.9.0"`).

**Concrete failure that motivated this**: PR #99 (the renovate pin from earlier) had a whitespace issue that `rtk prettier --check` reported as a pass locally, but the workspace's pinned 3.8.3 reported as a fail — and the latter is what CI runs. Same file, different verdict, lost ~10 minutes.

The new section codifies the rule: for read-only inspection RTK is fine; for any tool that gates a CI check, use the workspace-pinned version explicitly (`yarn prettier`, `yarn tsc -b`, `yarn nx lint`, `yarn nx test`, or `./node_modules/.bin/<tool>`).

This is a **repo-local** addition on purpose — the global opencode-level `AGENTS.md` has the shorter 1-line version, and the longer form here can be promoted there once it has soaked in this repo for a while.

## Diff stats

```
 .gitignore |  3 +++
 AGENTS.md  | 16 ++++++++++++++++
 2 files changed, 19 insertions(+)
```

## Why a separate PR

Both changes are tiny but they're independent concerns — `.gitignore` is environment, `AGENTS.md` is meta-documentation about how to work in this repo. A small, scoped PR keeps the history clean and easy to revert either half independently. It also makes it easy to compare "before/after" if anything regresses.

## What this PR does NOT do

- Does not modify the global `~/.config/opencode/AGENTS.md`. The longer form here is a local-soak before the global directive gets the same treatment.
- Does not add any other opencode/agent scratch paths (`.claude/worktrees` was already in `.gitignore`; that's pre-existing and not touched).
- Does not change any source code, dependencies, or CI config.
