### PR TITLE
docs: align READMEs with shipped state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # overture
 
-`overture` is a CLI utility that keeps your MCP (Model Context Protocol) server
-configurations in sync across every installed LLM coding platform on your
-machine. Define your MCP servers once, and `overture` propagates them to the
-configuration files of every detected client — Claude Code, OpenCode, VS Code /
-GitHub Copilot, Cursor, Windsurf, Cline, Roo Code, Continue, Codex, Zed, Aider,
-and friends.
+`overture` is a CLI utility that scans your machine for MCP-capable LLM coding
+platforms and reports the state of each platform's MCP server configuration.
 
-It is the MCP analog of the "npx skills" workflow: just as `skills` syncs Agent
-Skills across coding agents, `overture` syncs MCP servers.
+The currently-shipped commands are `overture detect` (read-only inventory)
+and `overture config show` (print the resolved user-level `overture.jsonc`).
+No command writes, syncs, or modifies any configuration file.
 
 ## Install
 
@@ -17,10 +14,6 @@ Skills across coding agents, `overture` syncs MCP servers.
 ```bash
 # Run without installing (uses the latest published version):
 npx @jander99/overture@latest --help
-
-# Install globally:
-npm install -g @jander99/overture
-overture detect
 ```
 
 Requires **Node.js >= 24** (the CLI's first published version targets the
@@ -32,24 +25,26 @@ Node 24 LTS baseline; local Node 25 also works).
 
 ## What it does
 
-- **Detects** which MCP-capable LLM platforms are installed on the host by
-  probing executables, IDE extensions, and configuration files.
-- **Reads** your canonical MCP server definitions from a single source of
-  truth.
-- **Writes** equivalent entries into each platform's native configuration
-  location, respecting that platform's schema and transport conventions
-  (`mcpServers`, `servers`, `mcp`, `context_servers`, YAML lists, TOML
-  tables, etc.).
-- **Reports** drift, conflicts, and unsupported fields so you can resolve
-  them explicitly instead of silently losing configuration.
+`overture detect` scans the host and reports which MCP-capable LLM platforms
+are installed. For each platform it reports three orthogonal signals:
+
+- `installed` — the platform app or CLI is on this machine.
+- `mcpConfigured` — the user has populated the platform's expected MCP
+  section in its config file (parser-backed for JSON, JSONC, and TOML
+  formats).
+- `mcpSupport` — whether the platform has a known MCP client surface
+  (`supported`, `unsupported`, or `unknown`).
+
+`overture config show` prints the resolved user-level `overture.jsonc` config
+if present.
 
 See [`docs/coding-platform-mcp-configurations.md`](docs/coding-platform-mcp-configurations.md)
-for the per-platform catalog that drives detection and writing logic.
+for the per-platform catalog that drives detection.
 
 ## The `detect` command
 
-The currently-shipped command is `overture detect`. It is a **read-only**
-inventory: it never reads, writes, syncs, or modifies any configuration file.
+`overture detect` is a **read-only** inventory: it never writes, syncs, or
+modifies any configuration file.
 
 It scans the host and reports which MCP-capable LLM platforms are installed,
 using two complementary strategies:
@@ -119,17 +114,21 @@ those not installed, with flat additive fields (`detectionStrategy`,
 overture/
 ├── apps/
 │   └── cli/              # The `@jander99/overture` CLI (entry point: src/main.ts)
+├── packages/
+│   ├── os/               # `@overture/os`: cross-platform OS detection
+│   ├── agents/           # `@overture/agents`: per-agent MCP registry and parsers
+│   └── config/           # `@overture/config`: user-level config loading and schema
 ├── docs/
-│   ├── overture-config.md  # User-level config schema (overture.jsonc)
-│   └── coding-platform-mcp-configurations.md
-
-│   └── coding-platform-mcp-configurations.md
+│   ├── coding-platform-mcp-configurations.md
+│   ├── overture-config.md
+│   ├── overture-vision.md
+│   ├── overture-implementation-slices.md
+│   └── publishing.md
 ├── nx.json               # NX workspace configuration
 └── package.json          # Yarn 4 workspaces root
 ```
 
-The workspace is a Yarn 4 monorepo orchestrated by NX 22. Today only `apps/cli`
-exists; additional apps and shared packages will land under `packages/`.
+The workspace is a Yarn 4 monorepo orchestrated by NX 22.
 
 ## Build & execute
 
@@ -209,7 +208,3 @@ command.
   `@types/node` after CI is bumped off Node 20)
 - Yarn 4 (this repo uses Corepack via `.yarnrc.yml`)
 - A POSIX shell for the `npm link` workflow
-
-## License
-
-MIT — see [`LICENSE`](LICENSE).

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,10 +1,10 @@
 # @jander99/overture
 
-`overture` is a CLI utility that keeps your MCP (Model Context Protocol) server
-configurations in sync across every installed LLM coding platform on your
-machine. This README is the package-local copy shipped inside the published
-tarball so `npm view @jander99/overture` and `npx @jander99/overture --help`
-users can find the essentials.
+`overture` is a CLI utility that scans your machine for MCP-capable LLM coding
+platforms and reports the state of each platform's MCP server configuration.
+This README is the package-local copy shipped inside the published tarball so
+`npm view @jander99/overture` and `npx @jander99/overture --help` users can
+find the essentials.
 
 For full documentation, see the repository README at
 <https://github.com/jander99/overture#readme>.
@@ -12,19 +12,14 @@ For full documentation, see the repository README at
 ## Install & run
 
 ```bash
-# Run without installing:
+# Run without installing (uses the latest published version):
 npx @jander99/overture@latest --help
-
-# Install globally:
-npm install -g @jander99/overture
-overture detect
 ```
 
 ## Requirements
 
 - Node.js >= 24 (the CLI's first published version targets the Node 24 LTS
   baseline)
-- npm >= 11.5.1 (npm Trusted Publishing floor)
 
 ## Commands
 
@@ -32,10 +27,7 @@ overture detect
   state.
 - `overture detect --json` — full 14-platform inventory with all additive
   fields.
+- `overture config show` — print the resolved user-level `overture.jsonc`.
 - `overture detect --help` / `overture --help` — print usage and exit 0.
 
 `detect` is read-only: it makes no writes and spawns no subprocesses.
-
-## License
-
-MIT — see [`LICENSE`](LICENSE).

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -46,6 +46,8 @@ These slices are independent and safe to do at any time.
 
 ### A1. Align README with shipped state
 
+**Status: completed in PR #106.**
+
 Update public docs so they do not claim sync/apply behavior that has not shipped.
 The current shipped surface is `detect` and `config show`.
 


### PR DESCRIPTION
## Summary
- Rewrite README.md and apps/cli/README.md to shipped-only content
- Remove the npx skills analog that implied unimplemented sync behavior
- Fix the repository layout tree to list packages/ and all docs files
- Add overture config show to the cli README commands list
- Drop the LICENSE section (no LICENSE file at repo root; per-package MIT lives at apps/cli/LICENSE)

## Plan tracking
This PR completes slice **A1** ("Align README with shipped state") from
[`docs/overture-implementation-slices.md`](../blob/main/docs/overture-implementation-slices.md#a1-align-readme-with-shipped-state).
The next slice in the same plan is **A2** ("Quiet skills in config docs").

## Verification
- `../../node_modules/.bin/prettier --check README.md apps/cli/README.md`
