### PR TITLE
feat(scan-matrix): B1 - scan matrix model for 4 CLI agents

### DIFF
--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -69,6 +69,8 @@ These slices create the product object that later commands use.
 
 ### B1. Define the scan matrix model
 
+**Status: completed.**
+
 Create an internal model for comparing agents, canonical intent, and server
 entries.
 
@@ -96,6 +98,19 @@ Candidate status values:
 Approval gate: status vocabulary and meanings.
 
 Expected result: a pure model with tests and no CLI output changes.
+
+Delivered: the `@overture/scan-matrix` package in `packages/scan-matrix/`
+exports `BuildScanMatrixInput`, `CompareAgentEntriesInput`, `AgentScanInput`,
+`AgentSnapshot`, `NormalizedAgentServer`, `ScanMatrix`, `ServerStatusRow`,
+`ServerStatus`, `AgentReadState`, `serverSettingsEqual`, `compareAgentEntries`,
+`buildScanMatrix`, and `DEFAULT_REGISTRY_ORDER`. The status vocabulary
+approved here is now enforced by the package's type and runtime tests
+(`packages/scan-matrix/src/scan-matrix.spec.ts` plus the colocated
+`scope-guards.spec.ts` anti-scope guards). The implementation source has no
+I/O, no MCP config readers/parsers, and no output formatters; canonical vs
+agent equality is a post-normalization field-exact byte compare
+(`serverSettingsEqual`). B2 can consume the `NormalizedAgentServer` contract
+to supply post-normalized `OvertureMcpServer` values without changing B1.
 
 ### B2. Normalize agent MCP configs into canonical server entries
 

--- a/packages/scan-matrix/package.json
+++ b/packages/scan-matrix/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@overture/scan-matrix",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/scan-matrix/project.json
+++ b/packages/scan-matrix/project.json
@@ -1,0 +1,30 @@
+{
+  "name": "@overture/scan-matrix",
+  "root": "packages/scan-matrix",
+  "sourceRoot": "packages/scan-matrix/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/scan-matrix",
+        "main": "packages/scan-matrix/src/index.ts",
+        "tsConfig": "packages/scan-matrix/tsconfig.lib.json",
+        "platform": "node",
+        "format": ["esm"],
+        "bundle": true,
+        "thirdParty": true,
+        "generatePackageJson": false
+      }
+    },
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "coverage/packages/scan-matrix"
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/scan-matrix/src/index.ts
+++ b/packages/scan-matrix/src/index.ts
@@ -1,1 +1,150 @@
-// Types will land in Task 2.
+/**
+ * Public `@overture/scan-matrix` surface.
+ *
+ * B1 is a pure TypeScript model; it does not import I/O, parsers, or renderers.
+ * Equality happens after B2-style normalization: B1 consumes `OvertureMcpServer`
+ * only via `NormalizedAgentServer.server`. Native-agent fields, display-shaped
+ * entries produced by per-agent renderers, and config-file reads are
+ * explicitly out of scope here.
+ *
+ * Behavior (`serverSettingsEqual`, `compareAgentEntries`, `buildScanMatrix`)
+ * lands in later tasks; this module is type-only.
+ */
+import type { OvertureConfig, OvertureMcpServer } from '@overture/config';
+import type { McpSupport } from '@overture/agents';
+
+/**
+ * Per-row classification of a single canonical/agent server pair.
+ *
+ * - `aligned` — canonical and post-normalized agent settings are byte-equal.
+ * - `missing-from-agent` — canonical intent names a server the agent lacks.
+ * - `extra-in-agent` — the agent declares a server the canonical intent lacks.
+ * - `different-settings` — same `type` but the field values differ.
+ * - `shape-conflict` — the agent entry could not be normalized to
+ *   `OvertureMcpServer`, or the canonical/agent `type` discriminators differ.
+ */
+export type ServerStatus =
+  | 'aligned'
+  | 'missing-from-agent'
+  | 'extra-in-agent'
+  | 'different-settings'
+  | 'shape-conflict';
+
+/**
+ * Read-side outcome of an upstream detection/read pass for a single agent.
+ *
+ * The matrix builder maps each of these to a snapshot and decides whether the
+ * agent's server map should participate in row generation. `read-ok` is the
+ * only state that yields `servers`; all other states produce no rows for the
+ * agent.
+ */
+export type AgentReadState =
+  | 'not-installed'
+  | 'unsupported-agent'
+  | 'not-read'
+  | 'read-ok'
+  | 'read-empty'
+  | 'read-no-config'
+  | 'parse-error';
+
+/**
+ * Post-normalization view of a single agent-side MCP server entry.
+ *
+ * B1 never sees agent-native field shapes; B2 is responsible for converting
+ * each agent's native schema into one of these branches before this package
+ * compares values. The `shape-conflict` branch carries the human-readable
+ * reason that surfaces on the row.
+ */
+export type NormalizedAgentServer =
+  | { readonly state: 'normalized'; readonly server: OvertureMcpServer }
+  | { readonly state: 'shape-conflict'; readonly reason: string };
+
+/**
+ * Input shape for a single agent as the matrix builder receives it.
+ *
+ * Upstream detection/read code (Tasks 3-5 of other slices) produces this from
+ * per-agent `readMcpConfig`/parsers; the scan matrix consumes it as data. The
+ * `servers` map is only populated when `readState === 'read-ok'`.
+ */
+export interface AgentScanInput {
+  readonly id: string;
+  readonly displayName: string;
+  readonly installed: boolean;
+  readonly mcpSupport: McpSupport;
+  readonly readState: AgentReadState;
+  readonly resolvedPath?: string;
+  readonly reason?: string;
+  readonly servers?: Readonly<Record<string, NormalizedAgentServer>>;
+}
+
+/**
+ * Public, server-free view of a single agent in the matrix.
+ *
+ * Mirrors `AgentScanInput` minus the per-server map. The matrix emits this
+ * shape for every target agent (synthesized not-installed or unsupported-agent
+ * snapshots are produced when the input is missing).
+ */
+export interface AgentSnapshot {
+  readonly id: string;
+  readonly displayName: string;
+  readonly installed: boolean;
+  readonly mcpSupport: McpSupport;
+  readonly readState: AgentReadState;
+  readonly resolvedPath?: string;
+  readonly reason?: string;
+}
+
+/**
+ * A single canonical/agent comparison row.
+ *
+ * `canonicalName` and `agentServerName` are nullable on purpose: the
+ * `presence` field and `__extra__` magic sentinel are explicitly forbidden.
+ * Exactly one of the two name fields is non-null per row.
+ */
+export interface ServerStatusRow {
+  readonly agentId: string;
+  readonly canonicalName: string | null;
+  readonly agentServerName: string | null;
+  readonly status: ServerStatus;
+  readonly canonicalServer: OvertureMcpServer | null;
+  readonly agentServer: OvertureMcpServer | null;
+  readonly reason?: string;
+}
+
+/**
+ * Full scan-matrix output: canonical intent, per-agent snapshots, and the
+ * deterministic row list. `canonicalState` distinguishes
+ * `absent` (no config), `ready` (config + profile resolved), and
+ * `invalid-profile` (config present but default profile missing).
+ */
+export interface ScanMatrix {
+  readonly canonicalState: 'absent' | 'ready' | 'invalid-profile';
+  readonly canonicalProfileName: string | null;
+  readonly canonicalIntent: Readonly<Record<string, OvertureMcpServer>>;
+  readonly agents: readonly AgentSnapshot[];
+  readonly rows: readonly ServerStatusRow[];
+  readonly reason?: string;
+}
+
+/**
+ * Input for `buildScanMatrix`. `config: null` is valid (the CLI is allowed to
+ * scan before a user has written `overture.jsonc`); `registryOrder` lets
+ * callers pin the agent order for deterministic output, defaulting to the
+ * canonical four-agent registry order.
+ */
+export interface BuildScanMatrixInput {
+  readonly config: OvertureConfig | null;
+  readonly agents: readonly AgentScanInput[];
+  readonly registryOrder?: readonly string[];
+}
+
+/**
+ * Input for `compareAgentEntries`. Holds the canonical intent for a single
+ * profile and the agent's post-normalized server map. `agentId` flows through
+ * to every row so downstream renderers can group by agent.
+ */
+export interface CompareAgentEntriesInput {
+  readonly canonical: Readonly<Record<string, OvertureMcpServer>>;
+  readonly agent: Readonly<Record<string, NormalizedAgentServer>>;
+  readonly agentId: string;
+}

--- a/packages/scan-matrix/src/index.ts
+++ b/packages/scan-matrix/src/index.ts
@@ -1,0 +1,1 @@
+// Types will land in Task 2.

--- a/packages/scan-matrix/src/index.ts
+++ b/packages/scan-matrix/src/index.ts
@@ -386,3 +386,302 @@ export function compareAgentEntries(
 
   return rows;
 }
+
+/**
+ * Default agent-id order for `buildScanMatrix`.
+ *
+ * Mirrors the canonical four-agent registry (`claude-code`, `opencode`,
+ * `github-copilot-cli`, `openai-codex`) but is intentionally a plain
+ * string list rather than a re-export of `@overture/agents`'s
+ * `AGENT_REGISTRY_ORDER` so the scan-matrix model stays decoupled from
+ * per-agent `AgentDefinition` data. Callers that want to override the
+ * order pass `BuildScanMatrixInput.registryOrder`; this constant is the
+ * fallback when no order is supplied.
+ */
+export const DEFAULT_REGISTRY_ORDER: readonly string[] = [
+  'claude-code',
+  'opencode',
+  'github-copilot-cli',
+  'openai-codex',
+];
+
+interface ResolveCanonicalResult {
+  readonly state: 'absent' | 'ready' | 'invalid-profile';
+  readonly profileName: string | null;
+  readonly intent: Readonly<Record<string, OvertureMcpServer>>;
+  readonly targetIds: readonly string[];
+  readonly reason?: string;
+}
+
+/**
+ * Resolve canonical state, intent, and target ids from the input. Pulled
+ * out of `buildScanMatrix` so the three-state switch stays readable.
+ *
+ * - `config === null` => absent state, empty intent, targets = `registryOrder`.
+ * - Default profile missing => invalid-profile state, empty intent, targets
+ *   follow `sync.targets` (so the snapshot list still populates correctly),
+ *   reason pinned to the approved string.
+ * - Default profile present => ready state, intent is the profile's
+ *   `mcpServers` minus `sync.disabledServers` entries, targets follow
+ *   `sync.targets`.
+ */
+function resolveCanonical(
+  config: OvertureConfig | null,
+  registryOrder: readonly string[],
+): ResolveCanonicalResult {
+  if (config === null) {
+    return {
+      state: 'absent',
+      profileName: null,
+      intent: {},
+      targetIds: registryOrder,
+    };
+  }
+  // The Zod schema's `default('default')` is shadowed by the outer
+  // `.partial().default({})` on the settings object, so the inferred type
+  // surfaces as `string | undefined`. Post-parse, the value is always
+  // defined (the schema applies its default before output), so the
+  // `?? 'default'` is a TypeScript-only fallback that matches the
+  // schema's resolved default.
+  const profileName = config.settings.defaultProfile ?? 'default';
+  const profile = config.profiles[profileName];
+  if (profile === undefined) {
+    // Named profile is missing. Fall back to the 'default' profile's
+    // sync.targets so the agent snapshot list still has meaningful
+    // content (the test plan requires "populated target agents" even
+    // for invalid-profile state). If the default profile is itself
+    // missing or its targets are empty, fall back to registryOrder.
+    const fallback = config.profiles.default;
+    const fallbackTargets =
+      fallback !== undefined && fallback.sync.targets.length > 0
+        ? fallback.sync.targets
+        : registryOrder;
+    return {
+      state: 'invalid-profile',
+      profileName,
+      intent: {},
+      targetIds: fallbackTargets,
+      reason: `Default profile "${profileName}" does not exist`,
+    };
+  }
+  const targetIds =
+    profile.sync.targets.length === 0 ? registryOrder : profile.sync.targets;
+  const disabled = new Set(profile.sync.disabledServers);
+  const mcpServers = profile.mcpServers;
+  const intent: Record<string, OvertureMcpServer> = {};
+  for (const name of Object.keys(mcpServers)) {
+    if (disabled.has(name)) {
+      continue;
+    }
+    const server = mcpServers[name];
+    if (server === undefined) {
+      continue;
+    }
+    intent[name] = server;
+  }
+  return {
+    state: 'ready',
+    profileName,
+    intent,
+    targetIds,
+  };
+}
+
+/**
+ * Derive the per-target id order used for both the snapshot list and the
+ * global row sort. Known ids emit first in their `registryOrder` position;
+ * unknown ids follow in ascending lexical order. Duplicates collapse.
+ */
+function orderTargetIds(
+  targetIds: readonly string[],
+  registryOrder: readonly string[],
+): readonly string[] {
+  const known = new Set(registryOrder);
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const id of registryOrder) {
+    if (targetIds.includes(id) && !seen.has(id)) {
+      ordered.push(id);
+      seen.add(id);
+    }
+  }
+  for (const id of [...targetIds].filter((id) => !known.has(id)).sort()) {
+    if (!seen.has(id)) {
+      ordered.push(id);
+      seen.add(id);
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Build the public `AgentSnapshot` for a target id. When an input is
+ * present, the `servers` field is dropped (the snapshot is intentionally
+ * server-free). When absent, a synthetic not-installed snapshot is built
+ * with the approved reason.
+ */
+function snapshotForTarget(
+  id: string,
+  input: AgentScanInput | undefined,
+): AgentSnapshot {
+  if (input !== undefined) {
+    const { servers: _ignored, ...snapshot } = input;
+    return snapshot;
+  }
+  return {
+    id,
+    displayName: id,
+    installed: false,
+    mcpSupport: 'unknown',
+    readState: 'not-installed',
+    reason: `No scan input for target "${id}"`,
+  };
+}
+
+/**
+ * Build the synthetic unsupported-agent snapshot for a target id that is
+ * not part of the four-agent registry. `installed: false` because
+ * unsupported agents are not part of the host.
+ */
+function unsupportedSnapshotFor(id: string): AgentSnapshot {
+  return {
+    id,
+    displayName: id,
+    installed: false,
+    mcpSupport: 'unsupported',
+    readState: 'unsupported-agent',
+    reason: `Target "${id}" is not supported by this Overture build`,
+  };
+}
+
+/**
+ * Build the full scan matrix from canonical config and per-agent scan
+ * inputs. Pure, synchronous, and side-effect free: it never reads files,
+ * inspects agent-native fields, or mutates any of its inputs.
+ *
+ * Output shape:
+ *
+ * - `canonicalState`, `canonicalProfileName`, `canonicalIntent`, and
+ *   optional `reason` are derived from the config (absent / ready /
+ *   invalid-profile).
+ * - `agents` lists one `AgentSnapshot` per target id, ordered by
+ *   `registryOrder` for known ids and lexicographically for unknown ids.
+ *   Synthesized not-installed / unsupported-agent snapshots fill the
+ *   gaps left by missing or unrecognized inputs.
+ * - `rows` is the global concatenation of `compareAgentEntries` results
+ *   for every read-ok target. The list is empty for the invalid-profile
+ *   state (the plan pins that as the row count when the named profile
+ *   is missing). Rows whose `canonicalName` is non-null emit first,
+ *   sorted by canonical name ascending then by agent position; rows
+ *   with a null `canonicalName` (agent-only entries) emit after, sorted
+ *   by agent position then by agent server name.
+ * Read states other than `read-ok` produce no rows for that agent but
+ * still appear in the snapshot list (the input's snapshot view is used
+ * verbatim, minus the `servers` field). `read-ok` without a `servers`
+ * map behaves as an empty server map.
+ */
+export function buildScanMatrix(input: BuildScanMatrixInput): ScanMatrix {
+  const { config, agents } = input;
+  const registryOrder = input.registryOrder ?? DEFAULT_REGISTRY_ORDER;
+
+  const inputById = new Map<string, AgentScanInput>();
+  for (const agent of agents) {
+    inputById.set(agent.id, agent);
+  }
+  const knownIds = new Set(registryOrder);
+
+  const resolution = resolveCanonical(config, registryOrder);
+  const orderedIds = orderTargetIds(resolution.targetIds, registryOrder);
+
+  const matrixAgents: AgentSnapshot[] = [];
+  for (const id of orderedIds) {
+    if (!knownIds.has(id)) {
+      matrixAgents.push(unsupportedSnapshotFor(id));
+    } else {
+      matrixAgents.push(snapshotForTarget(id, inputById.get(id)));
+    }
+  }
+
+  const agentPosition = new Map<string, number>();
+  orderedIds.forEach((id, index) => {
+    agentPosition.set(id, index);
+  });
+
+  const rawRows: ServerStatusRow[] = [];
+  // The plan pins `rows: []` for the invalid-profile state: the canonical
+  // intent is empty (the named profile is missing), so even read-ok agents
+  // cannot meaningfully compare against nothing. Skip row generation in
+  // that state so the row list stays empty as the plan requires.
+  if (resolution.state !== 'invalid-profile') {
+    for (const id of orderedIds) {
+      const agentInput = inputById.get(id);
+      if (agentInput === undefined) {
+        continue;
+      }
+      if (agentInput.readState !== 'read-ok') {
+        continue;
+      }
+      for (const row of compareAgentEntries({
+        canonical: resolution.intent,
+        agent: agentInput.servers ?? {},
+        agentId: id,
+      })) {
+        rawRows.push(row);
+      }
+    }
+  }
+
+  const canonicalRows: ServerStatusRow[] = [];
+  const extraRows: ServerStatusRow[] = [];
+  for (const row of rawRows) {
+    if (row.canonicalName === null) {
+      extraRows.push(row);
+    } else {
+      canonicalRows.push(row);
+    }
+  }
+
+  canonicalRows.sort((left, right) => {
+    const leftName = left.canonicalName ?? '';
+    const rightName = right.canonicalName ?? '';
+    if (leftName < rightName) {
+      return -1;
+    }
+    if (leftName > rightName) {
+      return 1;
+    }
+    return (
+      (agentPosition.get(left.agentId) ?? 0) -
+      (agentPosition.get(right.agentId) ?? 0)
+    );
+  });
+
+  extraRows.sort((left, right) => {
+    const leftPos = agentPosition.get(left.agentId) ?? 0;
+    const rightPos = agentPosition.get(right.agentId) ?? 0;
+    if (leftPos !== rightPos) {
+      return leftPos - rightPos;
+    }
+    const leftName = left.agentServerName ?? '';
+    const rightName = right.agentServerName ?? '';
+    if (leftName < rightName) {
+      return -1;
+    }
+    if (leftName > rightName) {
+      return 1;
+    }
+    return 0;
+  });
+
+  const result: ScanMatrix = {
+    canonicalState: resolution.state,
+    canonicalProfileName: resolution.profileName,
+    canonicalIntent: resolution.intent,
+    agents: matrixAgents,
+    rows: [...canonicalRows, ...extraRows],
+  };
+  if (resolution.reason !== undefined) {
+    return { ...result, reason: resolution.reason };
+  }
+  return result;
+}

--- a/packages/scan-matrix/src/index.ts
+++ b/packages/scan-matrix/src/index.ts
@@ -251,3 +251,138 @@ export interface CompareAgentEntriesInput {
   readonly agent: Readonly<Record<string, NormalizedAgentServer>>;
   readonly agentId: string;
 }
+
+/**
+ * Classify a single canonical intent against a single agent's
+ * post-normalized server map.
+ *
+ * The function is a pure, synchronous row emitter. It does not read files,
+ * inspect agent-native fields, or branch on agent ids: every decision is
+ * made from the canonical entry, the `NormalizedAgentServer` produced by
+ * upstream B2 normalization, and the comparison helpers in this module.
+ *
+ * Row order is deterministic:
+ *
+ * 1. One row per canonical server name, iterated in ascending lexical
+ *    order. The row's `canonicalName` is the name; `agentServerName` is
+ *    `null` when the agent lacks that name.
+ * 2. One row per agent-only server name, appended after the canonical
+ *    block and iterated in ascending lexical order. `canonicalName` is
+ *    `null`; `agentServerName` is the agent's name.
+ *
+ * `canonicalServer` / `agentServer` use `null` for absent sides; the
+ * `presence` field and `__extra__` magic sentinel are explicitly forbidden.
+ * Reasons are human-readable strings that downstream renderers can surface
+ * verbatim.
+ */
+export function compareAgentEntries(
+  input: CompareAgentEntriesInput,
+): readonly ServerStatusRow[] {
+  const { canonical, agent, agentId } = input;
+  const rows: ServerStatusRow[] = [];
+
+  const canonicalNames = Object.keys(canonical).sort();
+  const agentNames = Object.keys(agent).sort();
+
+  for (const name of canonicalNames) {
+    const canonicalServer = canonical[name];
+    if (canonicalServer === undefined) {
+      // Defensive: `Object.keys` only returns own enumerable keys, so this
+      // branch is unreachable in practice. Kept to satisfy `noUncheckedIndexedAccess`.
+      continue;
+    }
+    const entry = agent[name];
+    if (entry === undefined) {
+      rows.push({
+        agentId,
+        canonicalName: name,
+        agentServerName: null,
+        status: 'missing-from-agent',
+        canonicalServer,
+        agentServer: null,
+        reason: `Agent has no server named "${name}"`,
+      });
+      continue;
+    }
+    if (entry.state === 'shape-conflict') {
+      rows.push({
+        agentId,
+        canonicalName: name,
+        agentServerName: name,
+        status: 'shape-conflict',
+        canonicalServer,
+        agentServer: null,
+        reason: entry.reason,
+      });
+      continue;
+    }
+    const agentServer = entry.server;
+    if (canonicalServer.type !== agentServer.type) {
+      rows.push({
+        agentId,
+        canonicalName: name,
+        agentServerName: name,
+        status: 'shape-conflict',
+        canonicalServer,
+        agentServer: null,
+        reason: `Canonical type "${canonicalServer.type}" differs from agent type "${agentServer.type}"`,
+      });
+      continue;
+    }
+    if (serverSettingsEqual(canonicalServer, agentServer)) {
+      rows.push({
+        agentId,
+        canonicalName: name,
+        agentServerName: name,
+        status: 'aligned',
+        canonicalServer,
+        agentServer,
+      });
+      continue;
+    }
+    rows.push({
+      agentId,
+      canonicalName: name,
+      agentServerName: name,
+      status: 'different-settings',
+      canonicalServer,
+      agentServer,
+      reason: 'Canonical and agent settings differ',
+    });
+  }
+
+  for (const name of agentNames) {
+    if (canonical[name] !== undefined) {
+      continue;
+    }
+    const entry = agent[name];
+    if (entry === undefined) {
+      // Mirror the canonical loop's defensive guard: `Object.keys` only yields
+      // own keys, so this branch is unreachable in practice.
+      continue;
+    }
+    if (entry.state === 'shape-conflict') {
+      rows.push({
+        agentId,
+        canonicalName: null,
+        agentServerName: name,
+        status: 'shape-conflict',
+        canonicalServer: null,
+        agentServer: null,
+        reason: entry.reason,
+      });
+      continue;
+    }
+    rows.push({
+      agentId,
+      canonicalName: null,
+      agentServerName: name,
+      status: 'extra-in-agent',
+      canonicalServer: null,
+      agentServer: entry.server,
+      reason: `Canonical intent has no server named "${name}"`,
+    });
+  }
+
+  return rows;
+}

--- a/packages/scan-matrix/src/index.ts
+++ b/packages/scan-matrix/src/index.ts
@@ -7,11 +7,114 @@
  * entries produced by per-agent renderers, and config-file reads are
  * explicitly out of scope here.
  *
- * Behavior (`serverSettingsEqual`, `compareAgentEntries`, `buildScanMatrix`)
- * lands in later tasks; this module is type-only.
+ * Behavior (`compareAgentEntries`, `buildScanMatrix`) lands in later
+ * tasks; `serverSettingsEqual` is the canonical equality helper row
+ * classification and matrix construction consume.
  */
 import type { OvertureConfig, OvertureMcpServer } from '@overture/config';
 import type { McpSupport } from '@overture/agents';
+
+/**
+ * Canonical equality for two `OvertureMcpServer` values.
+ *
+ * The comparison is post-normalization: callers are responsible for
+ * producing both sides from their native shapes before invoking. The
+ * helper is a pure, synchronous, field-exact byte comparison:
+ *
+ * - `type` mismatch short-circuits to `false`; cross-type fields are
+ *   never inspected.
+ * - `stdio` compares only `command`, `args`, and `env`.
+ * - `remote` compares only `url` and `headers`.
+ * - Optional arrays/objects: `undefined` and `[]` / `{}` are distinct
+ *   values and never compare equal.
+ * - `args` order is significant; `env` / `headers` key insertion order
+ *   is not.
+ * - No URL normalization, command trimming, case folding, or
+ *   `JSON.stringify`-based diffing.
+ *
+ * This is the equality contract row classification and the matrix
+ * builder rely on.
+ */
+export function serverSettingsEqual(
+  left: OvertureMcpServer,
+  right: OvertureMcpServer,
+): boolean {
+  if (left.type !== right.type) {
+    return false;
+  }
+  if (left.type === 'stdio' && right.type === 'stdio') {
+    return (
+      left.command === right.command &&
+      stringArrayEqual(left.args, right.args) &&
+      stringRecordEqual(left.env, right.env)
+    );
+  }
+  if (left.type === 'remote' && right.type === 'remote') {
+    return (
+      left.url === right.url && stringRecordEqual(left.headers, right.headers)
+    );
+  }
+  return false;
+}
+
+/**
+ * Order-sensitive equality for two optional `string[]` values.
+ *
+ * `undefined` and `[]` are distinct: a missing field is not the same
+ * as an explicitly empty list. Same reference (including both
+ * `undefined`) short-circuits to `true`.
+ */
+function stringArrayEqual(
+  left: readonly string[] | undefined,
+  right: readonly string[] | undefined,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Key-set + per-key string equality for two optional
+ * `Record<string, string>` values. Key insertion order is ignored;
+ * `undefined` and `{}` are distinct. Same reference (including both
+ * `undefined`) short-circuits to `true`.
+ */
+function stringRecordEqual(
+  left: Readonly<Record<string, string>> | undefined,
+  right: Readonly<Record<string, string>> | undefined,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+  const leftKeys = Object.keys(left);
+  if (leftKeys.length !== Object.keys(right).length) {
+    return false;
+  }
+  for (const key of leftKeys) {
+    if (!(key in right)) {
+      return false;
+    }
+    if (left[key] !== right[key]) {
+      return false;
+    }
+  }
+  return true;
+}
 
 /**
  * Per-row classification of a single canonical/agent server pair.

--- a/packages/scan-matrix/src/scan-matrix.spec.ts
+++ b/packages/scan-matrix/src/scan-matrix.spec.ts
@@ -1,0 +1,5 @@
+describe('scan-matrix package', () => {
+  it('smokes', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/packages/scan-matrix/src/scan-matrix.spec.ts
+++ b/packages/scan-matrix/src/scan-matrix.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import type { McpSupport } from '@overture/agents';
 import type { OvertureConfig, OvertureMcpServer } from '@overture/config';
-import { serverSettingsEqual } from './index.js';
+import { compareAgentEntries, serverSettingsEqual } from './index.js';
 import type {
   AgentReadState,
   AgentScanInput,
@@ -351,6 +351,316 @@ describe('serverSettingsEqual', () => {
     };
     expect(serverSettingsEqual(stdioSide, remoteSide)).toBe(false);
     expect(serverSettingsEqual(remoteSide, stdioSide)).toBe(false);
+  });
+});
+
+describe('compareAgentEntries', () => {
+  const stdioA: OvertureMcpServer = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'mcp-server'],
+  };
+  const stdioB: OvertureMcpServer = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'mcp-server', '--debug'],
+  };
+  const remoteA: OvertureMcpServer = {
+    type: 'remote',
+    url: 'https://api.example.com/mcp',
+  };
+
+  it('emits one aligned row for an identical stdio pair', () => {
+    const rows = compareAgentEntries({
+      agentId: 'claude-code',
+      canonical: { memory: stdioA },
+      agent: { memory: { state: 'normalized', server: stdioA } },
+    });
+    expect(rows).toEqual([
+      {
+        agentId: 'claude-code',
+        canonicalName: 'memory',
+        agentServerName: 'memory',
+        status: 'aligned',
+        canonicalServer: stdioA,
+        agentServer: stdioA,
+      },
+    ]);
+  });
+
+  it('emits one aligned row for an identical remote pair', () => {
+    const rows = compareAgentEntries({
+      agentId: 'opencode',
+      canonical: { r: remoteA },
+      agent: { r: { state: 'normalized', server: remoteA } },
+    });
+    expect(rows).toEqual([
+      {
+        agentId: 'opencode',
+        canonicalName: 'r',
+        agentServerName: 'r',
+        status: 'aligned',
+        canonicalServer: remoteA,
+        agentServer: remoteA,
+      },
+    ]);
+  });
+
+  it('emits different-settings when same type but field values differ', () => {
+    const rows = compareAgentEntries({
+      agentId: 'claude-code',
+      canonical: { memory: stdioA },
+      agent: { memory: { state: 'normalized', server: stdioB } },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      agentId: 'claude-code',
+      canonicalName: 'memory',
+      agentServerName: 'memory',
+      status: 'different-settings',
+      canonicalServer: stdioA,
+      agentServer: stdioB,
+      reason: 'Canonical and agent settings differ',
+    });
+  });
+
+  it('emits shape-conflict when canonical stdio and agent remote disagree on type', () => {
+    const rows = compareAgentEntries({
+      agentId: 'claude-code',
+      canonical: { mixed: stdioA },
+      agent: { mixed: { state: 'normalized', server: remoteA } },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      agentId: 'claude-code',
+      canonicalName: 'mixed',
+      agentServerName: 'mixed',
+      status: 'shape-conflict',
+      canonicalServer: stdioA,
+      agentServer: null,
+      reason: 'Canonical type "stdio" differs from agent type "remote"',
+    });
+  });
+
+  it('emits shape-conflict when agent normalization returned a shape-conflict marker', () => {
+    const conflictReason = 'agent entry is missing required "command" field';
+    const rows = compareAgentEntries({
+      agentId: 'opencode',
+      canonical: { memory: stdioA },
+      agent: {
+        memory: { state: 'shape-conflict', reason: conflictReason },
+      },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      agentId: 'opencode',
+      canonicalName: 'memory',
+      agentServerName: 'memory',
+      status: 'shape-conflict',
+      canonicalServer: stdioA,
+      agentServer: null,
+      reason: conflictReason,
+    });
+  });
+
+  it('emits missing-from-agent when agent has no entry for the canonical name', () => {
+    const rows = compareAgentEntries({
+      agentId: 'claude-code',
+      canonical: { memory: stdioA },
+      agent: {},
+    });
+    expect(rows).toEqual([
+      {
+        agentId: 'claude-code',
+        canonicalName: 'memory',
+        agentServerName: null,
+        status: 'missing-from-agent',
+        canonicalServer: stdioA,
+        agentServer: null,
+        reason: 'Agent has no server named "memory"',
+      },
+    ]);
+  });
+
+  it('emits extra-in-agent when canonical has no entry for the agent name', () => {
+    const rows = compareAgentEntries({
+      agentId: 'opencode',
+      canonical: {},
+      agent: { bonus: { state: 'normalized', server: stdioA } },
+    });
+    expect(rows).toEqual([
+      {
+        agentId: 'opencode',
+        canonicalName: null,
+        agentServerName: 'bonus',
+        status: 'extra-in-agent',
+        canonicalServer: null,
+        agentServer: stdioA,
+        reason: 'Canonical intent has no server named "bonus"',
+      },
+    ]);
+  });
+
+  it('emits all extras when canonical is empty and agent is populated', () => {
+    const rows = compareAgentEntries({
+      agentId: 'opencode',
+      canonical: {},
+      agent: {
+        a: { state: 'normalized', server: stdioA },
+        b: { state: 'normalized', server: remoteA },
+      },
+    });
+    expect(rows).toEqual([
+      {
+        agentId: 'opencode',
+        canonicalName: null,
+        agentServerName: 'a',
+        status: 'extra-in-agent',
+        canonicalServer: null,
+        agentServer: stdioA,
+        reason: 'Canonical intent has no server named "a"',
+      },
+      {
+        agentId: 'opencode',
+        canonicalName: null,
+        agentServerName: 'b',
+        status: 'extra-in-agent',
+        canonicalServer: null,
+        agentServer: remoteA,
+        reason: 'Canonical intent has no server named "b"',
+      },
+    ]);
+  });
+
+  it('emits all missing when canonical is populated and agent is empty', () => {
+    const rows = compareAgentEntries({
+      agentId: 'claude-code',
+      canonical: { x: stdioA, y: remoteA },
+      agent: {},
+    });
+    expect(rows).toEqual([
+      {
+        agentId: 'claude-code',
+        canonicalName: 'x',
+        agentServerName: null,
+        status: 'missing-from-agent',
+        canonicalServer: stdioA,
+        agentServer: null,
+        reason: 'Agent has no server named "x"',
+      },
+      {
+        agentId: 'claude-code',
+        canonicalName: 'y',
+        agentServerName: null,
+        status: 'missing-from-agent',
+        canonicalServer: remoteA,
+        agentServer: null,
+        reason: 'Agent has no server named "y"',
+      },
+    ]);
+  });
+
+  it('emits zero rows when both sides are empty', () => {
+    const rows = compareAgentEntries({
+      agentId: 'claude-code',
+      canonical: {},
+      agent: {},
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('sorts multiple canonical names ascending then appends agent-only rows ascending', () => {
+    const rows = compareAgentEntries({
+      agentId: 'claude-code',
+      canonical: {
+        charlie: stdioA,
+        alpha: remoteA,
+        bravo: stdioA,
+      },
+      agent: {
+        bravo: { state: 'normalized', server: stdioA },
+        delta: { state: 'normalized', server: stdioA },
+        charlie: { state: 'shape-conflict', reason: 'agent shape conflict' },
+        alpha: { state: 'normalized', server: remoteA },
+      },
+    });
+    expect(rows.map((r) => r.canonicalName ?? r.agentServerName)).toEqual([
+      'alpha',
+      'bravo',
+      'charlie',
+      'delta',
+    ]);
+    expect(rows.map((r) => r.status)).toEqual([
+      'aligned',
+      'aligned',
+      'shape-conflict',
+      'extra-in-agent',
+    ]);
+    expect(rows.map((r) => r.agentId)).toEqual([
+      'claude-code',
+      'claude-code',
+      'claude-code',
+      'claude-code',
+    ]);
+  });
+
+  it('extra rows use canonicalName: null and the agent server name', () => {
+    const rows = compareAgentEntries({
+      agentId: 'opencode',
+      canonical: { shared: stdioA },
+      agent: {
+        shared: { state: 'normalized', server: stdioA },
+        orphan: { state: 'normalized', server: stdioA },
+      },
+    });
+    const extras = rows.filter((r) => r.status === 'extra-in-agent');
+    expect(extras).toHaveLength(1);
+    expect(extras[0]?.canonicalName).toBeNull();
+    expect(extras[0]?.canonicalServer).toBeNull();
+    expect(extras[0]?.agentServerName).toBe('orphan');
+    expect(extras[0]?.agentServer).toBe(stdioA);
+  });
+
+  it('row name fields are null on the absent side, never sentinel strings', () => {
+    const rows = compareAgentEntries({
+      agentId: 'claude-code',
+      canonical: { present: stdioA, missing: stdioA },
+      agent: {
+        present: { state: 'normalized', server: stdioA },
+        absent: { state: 'normalized', server: stdioA },
+      },
+    });
+    const missing = rows.find((r) => r.status === 'missing-from-agent');
+    const extra = rows.find((r) => r.status === 'extra-in-agent');
+    const aligned = rows.find((r) => r.status === 'aligned');
+    expect(missing?.agentServerName).toBeNull();
+    expect(missing?.agentServer).toBeNull();
+    expect(extra?.canonicalName).toBeNull();
+    expect(extra?.canonicalServer).toBeNull();
+    expect(aligned?.canonicalName).toBe('present');
+    expect(aligned?.agentServerName).toBe('present');
+  });
+
+  it('emits shape-conflict rows after canonical rows for agent-only conflicts', () => {
+    const rows = compareAgentEntries({
+      agentId: 'opencode',
+      canonical: { a: stdioA },
+      agent: {
+        a: { state: 'normalized', server: stdioA },
+        broken: { state: 'shape-conflict', reason: 'agent side is broken' },
+      },
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.status).toBe('aligned');
+    expect(rows[1]).toMatchObject({
+      agentId: 'opencode',
+      canonicalName: null,
+      agentServerName: 'broken',
+      status: 'shape-conflict',
+      canonicalServer: null,
+      agentServer: null,
+      reason: 'agent side is broken',
+    });
   });
 });
 

--- a/packages/scan-matrix/src/scan-matrix.spec.ts
+++ b/packages/scan-matrix/src/scan-matrix.spec.ts
@@ -1,3 +1,196 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import type { McpSupport } from '@overture/agents';
+import type { OvertureConfig, OvertureMcpServer } from '@overture/config';
+import type {
+  AgentReadState,
+  AgentScanInput,
+  AgentSnapshot,
+  BuildScanMatrixInput,
+  CompareAgentEntriesInput,
+  NormalizedAgentServer,
+  ScanMatrix,
+  ServerStatus,
+  ServerStatusRow,
+} from './index.js';
+
+// Type-only compile-time assertions for the B1 model. Each `expectTypeOf`
+// call exercises a fixture of the target type; the runtime matcher fails
+// only when the fixture drifts from the declared type. Tests for actual
+// function behavior land in Tasks 3-5.
+
+describe('B1 public type contracts', () => {
+  it('ServerStatus is the approved five-row vocabulary', () => {
+    expectTypeOf<ServerStatus>().toEqualTypeOf<
+      | 'aligned'
+      | 'missing-from-agent'
+      | 'extra-in-agent'
+      | 'different-settings'
+      | 'shape-conflict'
+    >();
+  });
+
+  it('AgentReadState is the approved seven-state vocabulary', () => {
+    expectTypeOf<AgentReadState>().toEqualTypeOf<
+      | 'not-installed'
+      | 'unsupported-agent'
+      | 'not-read'
+      | 'read-ok'
+      | 'read-empty'
+      | 'read-no-config'
+      | 'parse-error'
+    >();
+  });
+
+  it('McpSupport narrows to the approved three-state vocabulary', () => {
+    expectTypeOf<McpSupport>().toEqualTypeOf<
+      'supported' | 'unsupported' | 'unknown'
+    >();
+  });
+
+  it('OvertureMcpServer and OvertureConfig resolve to upstream types', () => {
+    const server: OvertureMcpServer = { type: 'stdio', command: 'echo' };
+    const config: OvertureConfig = {
+      version: 1,
+      settings: { defaultProfile: 'default' },
+      profiles: {
+        default: {
+          mcpServers: {},
+          sync: { targets: [], disabledServers: [] },
+          skills: [],
+        },
+      },
+    };
+    expectTypeOf(server).toMatchTypeOf<OvertureMcpServer>();
+    expectTypeOf(config).toMatchTypeOf<OvertureConfig>();
+  });
+
+  it('NormalizedAgentServer discriminates on state and narrows correctly', () => {
+    expectTypeOf<NormalizedAgentServer>().toEqualTypeOf<
+      | { readonly state: 'normalized'; readonly server: OvertureMcpServer }
+      | { readonly state: 'shape-conflict'; readonly reason: string }
+    >();
+  });
+
+  it('AgentScanInput accepts all optional slots', () => {
+    const input: AgentScanInput = {
+      id: 'claude-code',
+      displayName: 'Claude Code',
+      installed: true,
+      mcpSupport: 'supported',
+      readState: 'read-ok',
+      resolvedPath: '/home/user/.claude.json',
+      servers: {
+        stdio: { state: 'normalized', server: { type: 'stdio', command: 'x' } },
+      },
+    };
+    expectTypeOf(input).toMatchTypeOf<AgentScanInput>();
+  });
+
+  it('AgentSnapshot is the public server-free view', () => {
+    const snapshot: AgentSnapshot = {
+      id: 'opencode',
+      displayName: 'OpenCode',
+      installed: true,
+      mcpSupport: 'supported',
+      readState: 'read-empty',
+    };
+    expectTypeOf(snapshot).toMatchTypeOf<AgentSnapshot>();
+  });
+
+  it('ServerStatusRow uses nullable names instead of magic sentinels', () => {
+    const aligned: ServerStatusRow = {
+      agentId: 'claude-code',
+      canonicalName: 'memory',
+      agentServerName: 'memory',
+      status: 'aligned',
+      canonicalServer: { type: 'stdio', command: 'x' },
+      agentServer: { type: 'stdio', command: 'x' },
+    };
+    const extra: ServerStatusRow = {
+      agentId: 'opencode',
+      canonicalName: null,
+      agentServerName: 'extra-server',
+      status: 'extra-in-agent',
+      canonicalServer: null,
+      agentServer: { type: 'stdio', command: 'x' },
+      reason: 'Canonical intent has no server named "extra-server"',
+    };
+    const missing: ServerStatusRow = {
+      agentId: 'openai-codex',
+      canonicalName: 'memory',
+      agentServerName: null,
+      status: 'missing-from-agent',
+      canonicalServer: { type: 'stdio', command: 'x' },
+      agentServer: null,
+      reason: 'Agent has no server named "memory"',
+    };
+    expectTypeOf(aligned).toMatchTypeOf<ServerStatusRow>();
+    expectTypeOf(extra).toMatchTypeOf<ServerStatusRow>();
+    expectTypeOf(missing).toMatchTypeOf<ServerStatusRow>();
+  });
+
+  it('ScanMatrix enumerates the three canonical states', () => {
+    const ready: ScanMatrix = {
+      canonicalState: 'ready',
+      canonicalProfileName: 'default',
+      canonicalIntent: {},
+      agents: [],
+      rows: [],
+    };
+    const absent: ScanMatrix = {
+      canonicalState: 'absent',
+      canonicalProfileName: null,
+      canonicalIntent: {},
+      agents: [],
+      rows: [],
+    };
+    const invalid: ScanMatrix = {
+      canonicalState: 'invalid-profile',
+      canonicalProfileName: 'default',
+      canonicalIntent: {},
+      agents: [],
+      rows: [],
+      reason: 'Default profile "default" does not exist',
+    };
+    expectTypeOf(ready).toMatchTypeOf<ScanMatrix>();
+    expectTypeOf(absent).toMatchTypeOf<ScanMatrix>();
+    expectTypeOf(invalid).toMatchTypeOf<ScanMatrix>();
+  });
+
+  it('BuildScanMatrixInput allows null config and an optional registryOrder', () => {
+    const withConfig: BuildScanMatrixInput = {
+      config: {
+        version: 1,
+        settings: { defaultProfile: 'default' },
+        profiles: {
+          default: {
+            mcpServers: {},
+            sync: { targets: [], disabledServers: [] },
+            skills: [],
+          },
+        },
+      },
+      agents: [],
+    };
+    const withoutConfig: BuildScanMatrixInput = {
+      config: null,
+      agents: [],
+      registryOrder: ['claude-code', 'opencode'],
+    };
+    expectTypeOf(withConfig).toMatchTypeOf<BuildScanMatrixInput>();
+    expectTypeOf(withoutConfig).toMatchTypeOf<BuildScanMatrixInput>();
+  });
+
+  it('CompareAgentEntriesInput carries canonical, agent, and agentId', () => {
+    const input: CompareAgentEntriesInput = {
+      canonical: {},
+      agent: {},
+      agentId: 'claude-code',
+    };
+    expectTypeOf(input).toMatchTypeOf<CompareAgentEntriesInput>();
+  });
+});
+
 describe('scan-matrix package', () => {
   it('smokes', () => {
     expect(1).toBe(1);

--- a/packages/scan-matrix/src/scan-matrix.spec.ts
+++ b/packages/scan-matrix/src/scan-matrix.spec.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import type { McpSupport } from '@overture/agents';
 import type { OvertureConfig, OvertureMcpServer } from '@overture/config';
-import { compareAgentEntries, serverSettingsEqual } from './index.js';
+import {
+  DEFAULT_REGISTRY_ORDER,
+  buildScanMatrix,
+  compareAgentEntries,
+  serverSettingsEqual,
+} from './index.js';
 import type {
   AgentReadState,
   AgentScanInput,
@@ -661,6 +666,492 @@ describe('compareAgentEntries', () => {
       agentServer: null,
       reason: 'agent side is broken',
     });
+  });
+});
+
+describe('buildScanMatrix', () => {
+  // Minimal fixtures shared by the buildScanMatrix tests. Each helper
+  // produces a strict-mode-compliant `OvertureConfig` or `AgentScanInput`
+  // so individual tests can focus on the field under test rather than
+  // Zod noise.
+  const stdioA: OvertureMcpServer = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'mcp-a'],
+  };
+  const stdioB: OvertureMcpServer = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'mcp-b'],
+  };
+  const remoteA: OvertureMcpServer = {
+    type: 'remote',
+    url: 'https://api.example.com/mcp',
+  };
+
+  const makeConfig = (
+    profileName: string,
+    profileOverrides: {
+      mcpServers?: Record<string, OvertureMcpServer>;
+      targets?: readonly string[];
+      disabledServers?: readonly string[];
+    } = {},
+  ): OvertureConfig => {
+    const profile = {
+      mcpServers: profileOverrides.mcpServers ?? {},
+      sync: {
+        targets: [...(profileOverrides.targets ?? [])],
+        disabledServers: [...(profileOverrides.disabledServers ?? [])],
+      },
+      skills: [],
+    };
+    const profiles: OvertureConfig['profiles'] = { default: profile };
+    if (profileName !== 'default') {
+      profiles[profileName] = profile;
+    }
+    return {
+      version: 1,
+      settings: { defaultProfile: profileName },
+      profiles,
+    };
+  };
+
+  const makeAgent = (
+    id: string,
+    overrides: Partial<AgentScanInput> = {},
+  ): AgentScanInput => ({
+    id,
+    displayName: id,
+    installed: true,
+    mcpSupport: 'supported',
+    readState: 'read-ok',
+    servers: {},
+    ...overrides,
+  });
+
+  it('config: null uses registryOrder as targets and ignores unknown input agent ids', () => {
+    const matrix = buildScanMatrix({
+      config: null,
+      registryOrder: ['claude-code'],
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'read-ok',
+          servers: { x: { state: 'normalized', server: stdioA } },
+        }),
+        makeAgent('unknown-future', {
+          readState: 'read-ok',
+          servers: { y: { state: 'normalized', server: stdioA } },
+        }),
+      ],
+    });
+    expect(matrix.canonicalState).toBe('absent');
+    expect(matrix.canonicalProfileName).toBeNull();
+    expect(matrix.canonicalIntent).toEqual({});
+    expect(matrix.agents.map((a) => a.id)).toEqual(['claude-code']);
+    // The unknown input agent is dropped, so no extras for it.
+    expect(matrix.rows.map((r) => r.agentServerName)).toEqual(['x']);
+  });
+
+  it('config: null with empty agent entries synthesizes not-installed snapshots for every registry id', () => {
+    const matrix = buildScanMatrix({ config: null, agents: [] });
+    expect(matrix.canonicalState).toBe('absent');
+    expect(matrix.agents.map((a) => a.id)).toEqual([
+      'claude-code',
+      'opencode',
+      'github-copilot-cli',
+      'openai-codex',
+    ]);
+    for (const snapshot of matrix.agents) {
+      expect(snapshot.readState).toBe('not-installed');
+      expect(snapshot.installed).toBe(false);
+      expect(snapshot.mcpSupport).toBe('unknown');
+      expect(snapshot.reason).toBe(`No scan input for target "${snapshot.id}"`);
+    }
+    expect(matrix.rows).toEqual([]);
+  });
+
+  it('config: null with populated read-ok agents emits extra-in-agent rows only', () => {
+    const matrix = buildScanMatrix({
+      config: null,
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'read-ok',
+          servers: { orphan: { state: 'normalized', server: stdioA } },
+        }),
+      ],
+    });
+    expect(matrix.canonicalIntent).toEqual({});
+    expect(matrix.rows).toHaveLength(1);
+    expect(matrix.rows[0]).toMatchObject({
+      agentId: 'claude-code',
+      canonicalName: null,
+      agentServerName: 'orphan',
+      status: 'extra-in-agent',
+      canonicalServer: null,
+      agentServer: stdioA,
+      reason: 'Canonical intent has no server named "orphan"',
+    });
+  });
+
+  it('uses the default profile when the named profile exists', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('staging', {
+        mcpServers: { x: stdioA },
+        targets: ['claude-code'],
+      }),
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'read-ok',
+          servers: { x: { state: 'normalized', server: stdioA } },
+        }),
+      ],
+    });
+    expect(matrix.canonicalState).toBe('ready');
+    expect(matrix.canonicalProfileName).toBe('staging');
+    expect(matrix.canonicalIntent).toEqual({ x: stdioA });
+    expect(matrix.rows).toEqual([
+      {
+        agentId: 'claude-code',
+        canonicalName: 'x',
+        agentServerName: 'x',
+        status: 'aligned',
+        canonicalServer: stdioA,
+        agentServer: stdioA,
+      },
+    ]);
+  });
+
+  it('returns invalid-profile with populated agents and zero rows when the default profile is missing', () => {
+    // Inlined so the config intentionally lacks the named 'missing'
+    // profile: only 'default' is present, but the defaultProfile setting
+    // points elsewhere. `makeConfig` auto-creates the named profile, so
+    // it cannot express this case.
+    const matrix = buildScanMatrix({
+      config: {
+        version: 1,
+        settings: { defaultProfile: 'missing' },
+        profiles: {
+          default: {
+            mcpServers: {},
+            sync: { targets: ['claude-code'], disabledServers: [] },
+            skills: [],
+          },
+        },
+      },
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'read-ok',
+          servers: { x: { state: 'normalized', server: stdioA } },
+        }),
+      ],
+    });
+    expect(matrix.canonicalState).toBe('invalid-profile');
+    expect(matrix.canonicalProfileName).toBe('missing');
+    expect(matrix.canonicalIntent).toEqual({});
+    expect(matrix.reason).toBe('Default profile "missing" does not exist');
+    expect(matrix.agents.map((a) => a.id)).toEqual(['claude-code']);
+    expect(matrix.rows).toEqual([]);
+  });
+
+  it('sync.targets empty includes every registry id present in the input', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', { targets: [] }),
+      agents: [
+        makeAgent('claude-code'),
+        makeAgent('opencode'),
+        makeAgent('github-copilot-cli'),
+        makeAgent('openai-codex'),
+      ],
+    });
+    expect(matrix.agents.map((a) => a.id)).toEqual(DEFAULT_REGISTRY_ORDER);
+  });
+
+  it('sync.targets non-empty filters agents to only the listed ids', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', { targets: ['opencode'] }),
+      agents: [
+        makeAgent('claude-code'),
+        makeAgent('opencode'),
+        makeAgent('github-copilot-cli'),
+        makeAgent('openai-codex'),
+      ],
+    });
+    expect(matrix.agents.map((a) => a.id)).toEqual(['opencode']);
+  });
+
+  it('unknown target id produces an unsupported-agent snapshot with the approved reason', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', {
+        targets: ['claude-code', 'unknown-future'],
+      }),
+      agents: [makeAgent('claude-code')],
+    });
+    expect(matrix.agents.map((a) => a.id)).toEqual([
+      'claude-code',
+      'unknown-future',
+    ]);
+    const unsupported = matrix.agents[1];
+    expect(unsupported).toMatchObject({
+      id: 'unknown-future',
+      displayName: 'unknown-future',
+      installed: false,
+      mcpSupport: 'unsupported',
+      readState: 'unsupported-agent',
+      reason: 'Target "unknown-future" is not supported by this Overture build',
+    });
+  });
+
+  it('known target id without a matching input produces a not-installed snapshot', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', { targets: ['claude-code'] }),
+      agents: [],
+    });
+    expect(matrix.agents).toHaveLength(1);
+    expect(matrix.agents[0]).toMatchObject({
+      id: 'claude-code',
+      displayName: 'claude-code',
+      installed: false,
+      mcpSupport: 'unknown',
+      readState: 'not-installed',
+      reason: 'No scan input for target "claude-code"',
+    });
+    expect(matrix.rows).toEqual([]);
+  });
+
+  it('sync.disabledServers removes the named servers from canonicalIntent and makes matching agent entries extra', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', {
+        mcpServers: { keep: stdioA, drop: stdioB },
+        targets: ['claude-code'],
+        disabledServers: ['drop'],
+      }),
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'read-ok',
+          servers: {
+            keep: { state: 'normalized', server: stdioA },
+            drop: { state: 'normalized', server: stdioB },
+          },
+        }),
+      ],
+    });
+    expect(matrix.canonicalIntent).toEqual({ keep: stdioA });
+    expect(
+      matrix.rows.map((r) => ({
+        canonical: r.canonicalName,
+        agent: r.agentServerName,
+        status: r.status,
+      })),
+    ).toEqual([
+      { canonical: 'keep', agent: 'keep', status: 'aligned' },
+      { canonical: null, agent: 'drop', status: 'extra-in-agent' },
+    ]);
+  });
+
+  it('parse-error agent snapshots preserve the parse reason and produce no rows', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', {
+        mcpServers: { x: stdioA },
+        targets: ['claude-code'],
+      }),
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'parse-error',
+          reason: 'unexpected token at position 42',
+          // No `servers` on a parse-error agent.
+        }),
+      ],
+    });
+    expect(matrix.agents[0]).toMatchObject({
+      id: 'claude-code',
+      readState: 'parse-error',
+      reason: 'unexpected token at position 42',
+    });
+    expect(matrix.rows).toEqual([]);
+  });
+
+  it('read-empty and read-no-config snapshots are preserved verbatim and produce no rows', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', {
+        mcpServers: { x: stdioA },
+        targets: ['claude-code', 'opencode'],
+      }),
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'read-empty',
+        }),
+        makeAgent('opencode', {
+          readState: 'read-no-config',
+        }),
+      ],
+    });
+    expect(matrix.agents[0]?.readState).toBe('read-empty');
+    expect(matrix.agents[1]?.readState).toBe('read-no-config');
+    expect(matrix.rows).toEqual([]);
+  });
+
+  it('multiple agents sharing a server name produce independent rows keyed by agentId', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', {
+        mcpServers: { shared: stdioA },
+        targets: ['claude-code', 'opencode'],
+      }),
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'read-ok',
+          servers: { shared: { state: 'normalized', server: stdioA } },
+        }),
+        makeAgent('opencode', {
+          readState: 'read-ok',
+          servers: { shared: { state: 'normalized', server: stdioA } },
+        }),
+      ],
+    });
+    const aligned = matrix.rows.filter((r) => r.status === 'aligned');
+    expect(aligned).toHaveLength(2);
+    const ids = aligned.map((r) => r.agentId).sort();
+    expect(ids).toEqual(['claude-code', 'opencode']);
+    for (const row of aligned) {
+      expect(row.canonicalName).toBe('shared');
+      expect(row.agentServerName).toBe('shared');
+    }
+  });
+
+  it('JSON.stringify is identical for repeated buildScanMatrix calls with the same input', () => {
+    const input: BuildScanMatrixInput = {
+      config: makeConfig('default', {
+        mcpServers: { a: stdioA, b: stdioB },
+        targets: ['claude-code', 'opencode'],
+      }),
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'read-ok',
+          servers: {
+            a: { state: 'normalized', server: stdioA },
+            c: { state: 'normalized', server: remoteA },
+          },
+        }),
+        makeAgent('opencode', {
+          readState: 'parse-error',
+          reason: 'bad token',
+        }),
+      ],
+    };
+    const first = JSON.stringify(buildScanMatrix(input));
+    const second = JSON.stringify(buildScanMatrix(input));
+    expect(first).toBe(second);
+  });
+
+  it('applies the global row order: canonical rows by name then agent, extras by agent then name', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', {
+        mcpServers: { a: stdioA, b: stdioB },
+        targets: ['claude-code', 'opencode'],
+      }),
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'read-ok',
+          servers: {
+            a: { state: 'normalized', server: stdioA },
+            b: { state: 'normalized', server: stdioB },
+            c: { state: 'normalized', server: remoteA },
+          },
+        }),
+        makeAgent('opencode', {
+          readState: 'read-ok',
+          servers: {
+            a: { state: 'normalized', server: stdioA },
+            b: { state: 'normalized', server: stdioB },
+            d: { state: 'normalized', server: remoteA },
+          },
+        }),
+      ],
+    });
+    const summary = matrix.rows.map((r) => ({
+      canonical: r.canonicalName,
+      agent: r.agentId,
+      server: r.agentServerName,
+      status: r.status,
+    }));
+    expect(summary).toEqual([
+      { canonical: 'a', agent: 'claude-code', server: 'a', status: 'aligned' },
+      { canonical: 'a', agent: 'opencode', server: 'a', status: 'aligned' },
+      { canonical: 'b', agent: 'claude-code', server: 'b', status: 'aligned' },
+      { canonical: 'b', agent: 'opencode', server: 'b', status: 'aligned' },
+      {
+        canonical: null,
+        agent: 'claude-code',
+        server: 'c',
+        status: 'extra-in-agent',
+      },
+      {
+        canonical: null,
+        agent: 'opencode',
+        server: 'd',
+        status: 'extra-in-agent',
+      },
+    ]);
+  });
+
+  it('does not mutate the input config, agents, or server entries', () => {
+    const config = makeConfig('default', {
+      mcpServers: { a: stdioA },
+      targets: ['claude-code'],
+    });
+    const agentInput = makeAgent('claude-code', {
+      readState: 'read-ok',
+      servers: {
+        a: { state: 'normalized', server: stdioA },
+        extra: { state: 'normalized', server: stdioB },
+      },
+    });
+    const configSnapshot = JSON.parse(JSON.stringify(config));
+    const agentSnapshot = JSON.parse(JSON.stringify(agentInput));
+    const originalStdioA = JSON.parse(JSON.stringify(stdioA));
+
+    buildScanMatrix({ config, agents: [agentInput] });
+
+    expect(JSON.parse(JSON.stringify(config))).toEqual(configSnapshot);
+    expect(JSON.parse(JSON.stringify(agentInput))).toEqual(agentSnapshot);
+    expect(JSON.parse(JSON.stringify(stdioA))).toEqual(originalStdioA);
+  });
+
+  it('readState not in read-ok is the only state gate for row emission (not-installed, not-read, unsupported-agent)', () => {
+    const matrix = buildScanMatrix({
+      config: makeConfig('default', {
+        mcpServers: { x: stdioA },
+        targets: ['claude-code', 'opencode', 'github-copilot-cli'],
+      }),
+      agents: [
+        makeAgent('claude-code', {
+          readState: 'not-installed',
+          installed: false,
+        }),
+        makeAgent('opencode', {
+          readState: 'not-read',
+        }),
+        makeAgent('github-copilot-cli', {
+          readState: 'unsupported-agent',
+          mcpSupport: 'unsupported',
+          installed: false,
+        }),
+      ],
+    });
+    expect(matrix.agents.map((a) => a.readState)).toEqual([
+      'not-installed',
+      'not-read',
+      'unsupported-agent',
+    ]);
+    expect(matrix.rows).toEqual([]);
+  });
+
+  it('DEFAULT_REGISTRY_ORDER lists the four canonical agent ids in the documented order', () => {
+    expect(DEFAULT_REGISTRY_ORDER).toEqual([
+      'claude-code',
+      'opencode',
+      'github-copilot-cli',
+      'openai-codex',
+    ]);
   });
 });
 

--- a/packages/scan-matrix/src/scan-matrix.spec.ts
+++ b/packages/scan-matrix/src/scan-matrix.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import type { McpSupport } from '@overture/agents';
 import type { OvertureConfig, OvertureMcpServer } from '@overture/config';
+import { serverSettingsEqual } from './index.js';
 import type {
   AgentReadState,
   AgentScanInput,
@@ -188,6 +189,168 @@ describe('B1 public type contracts', () => {
       agentId: 'claude-code',
     };
     expectTypeOf(input).toMatchTypeOf<CompareAgentEntriesInput>();
+  });
+});
+
+describe('serverSettingsEqual', () => {
+  // Fixtures: keep the equality tests focused on the fields the helper
+  // is contract-bound to compare. Each case is a single behavioral
+  // assertion that pins the post-normalization contract.
+  const stdioBase: OvertureMcpServer = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'mcp-server'],
+    env: { API_KEY: 'secret', REGION: 'us-east-1' },
+  };
+  const remoteBase: OvertureMcpServer = {
+    type: 'remote',
+    url: 'https://api.example.com/mcp',
+    headers: { Authorization: 'Bearer token', Accept: 'application/json' },
+  };
+
+  it('identical stdio entries are equal', () => {
+    expect(serverSettingsEqual(stdioBase, { ...stdioBase })).toBe(true);
+  });
+
+  it('identical remote entries are equal', () => {
+    expect(serverSettingsEqual(remoteBase, { ...remoteBase })).toBe(true);
+  });
+
+  it('stdio command differs', () => {
+    const right: OvertureMcpServer = { ...stdioBase, command: 'node' };
+    expect(serverSettingsEqual(stdioBase, right)).toBe(false);
+  });
+
+  it('stdio command differs by case (npx vs Npx)', () => {
+    const right: OvertureMcpServer = { ...stdioBase, command: 'Npx' };
+    expect(serverSettingsEqual(stdioBase, right)).toBe(false);
+  });
+
+  it('stdio command differs by whitespace (npx vs " npx ")', () => {
+    const right: OvertureMcpServer = { ...stdioBase, command: ' npx ' };
+    expect(serverSettingsEqual(stdioBase, right)).toBe(false);
+  });
+
+  it('stdio args missing vs [] are unequal', () => {
+    const left: OvertureMcpServer = {
+      type: 'stdio',
+      command: 'npx',
+      env: { API_KEY: 'secret' },
+    };
+    const right: OvertureMcpServer = {
+      type: 'stdio',
+      command: 'npx',
+      args: [],
+      env: { API_KEY: 'secret' },
+    };
+    expect(serverSettingsEqual(left, right)).toBe(false);
+  });
+
+  it('stdio args order differs', () => {
+    const right: OvertureMcpServer = {
+      ...stdioBase,
+      args: ['mcp-server', '-y'],
+    };
+    expect(serverSettingsEqual(stdioBase, right)).toBe(false);
+  });
+
+  it('stdio env subset differs', () => {
+    const right: OvertureMcpServer = {
+      ...stdioBase,
+      env: { API_KEY: 'secret' },
+    };
+    expect(serverSettingsEqual(stdioBase, right)).toBe(false);
+  });
+
+  it('stdio env key insertion order does not differ', () => {
+    const right: OvertureMcpServer = {
+      ...stdioBase,
+      env: { REGION: 'us-east-1', API_KEY: 'secret' },
+    };
+    expect(serverSettingsEqual(stdioBase, right)).toBe(true);
+  });
+
+  it('remote url differs', () => {
+    const right: OvertureMcpServer = {
+      ...remoteBase,
+      url: 'https://api.example.com/v2/mcp',
+    };
+    expect(serverSettingsEqual(remoteBase, right)).toBe(false);
+  });
+
+  it('remote url trailing slash differs', () => {
+    const right: OvertureMcpServer = {
+      ...remoteBase,
+      url: 'https://api.example.com/mcp/',
+    };
+    expect(serverSettingsEqual(remoteBase, right)).toBe(false);
+  });
+
+  it('remote scheme differs', () => {
+    const right: OvertureMcpServer = {
+      ...remoteBase,
+      url: 'http://api.example.com/mcp',
+    };
+    expect(serverSettingsEqual(remoteBase, right)).toBe(false);
+  });
+
+  it('remote host case differs', () => {
+    const right: OvertureMcpServer = {
+      ...remoteBase,
+      url: 'https://API.EXAMPLE.COM/mcp',
+    };
+    expect(serverSettingsEqual(remoteBase, right)).toBe(false);
+  });
+
+  it('remote headers subset differs', () => {
+    const right: OvertureMcpServer = {
+      ...remoteBase,
+      headers: { Authorization: 'Bearer token' },
+    };
+    expect(serverSettingsEqual(remoteBase, right)).toBe(false);
+  });
+
+  it('remote headers missing vs {} differs', () => {
+    const left: OvertureMcpServer = {
+      type: 'remote',
+      url: 'https://api.example.com/mcp',
+    };
+    const right: OvertureMcpServer = {
+      type: 'remote',
+      url: 'https://api.example.com/mcp',
+      headers: {},
+    };
+    expect(serverSettingsEqual(left, right)).toBe(false);
+  });
+
+  it('remote headers key insertion order does not differ', () => {
+    const right: OvertureMcpServer = {
+      ...remoteBase,
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer token',
+      },
+    };
+    expect(serverSettingsEqual(remoteBase, right)).toBe(true);
+  });
+
+  it('type mismatch returns false and does not inspect cross-type fields', () => {
+    // Even when every cross-type field matches, the type mismatch must
+    // short-circuit to false. The fixture intentionally sets stdio.command
+    // to the remote url and remote.url to the stdio command to prove no
+    // field value is consulted once `type` differs.
+    const stdioSide: OvertureMcpServer = {
+      type: 'stdio',
+      command: 'https://api.example.com/mcp',
+      args: [],
+    };
+    const remoteSide: OvertureMcpServer = {
+      type: 'remote',
+      url: 'npx',
+      headers: { '0': 'npx', '1': 'mcp-server' },
+    };
+    expect(serverSettingsEqual(stdioSide, remoteSide)).toBe(false);
+    expect(serverSettingsEqual(remoteSide, stdioSide)).toBe(false);
   });
 });
 

--- a/packages/scan-matrix/src/scope-guards.spec.ts
+++ b/packages/scan-matrix/src/scope-guards.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * B1 anti-scope guard tests.
+ *
+ * These tests read only the implementation source
+ * (`packages/scan-matrix/src/index.ts`) and assert that the B1 model
+ * stays pure: no file I/O, no MCP config readers/parsers, no output
+ * formatters, no `JSON.stringify`-based behavior, and no per-agent
+ * branches beyond the four-CLI allow-list in `DEFAULT_REGISTRY_ORDER`.
+ *
+ * The "removed agent" deny-list check lives in the Task 6 shell QA
+ * scenario (`.omo/evidence/task-6-no-removed-agents.log`) and is
+ * intentionally not embedded here — committing a deny-list of removed
+ * platform ids to the package would re-introduce the very scope the
+ * guards are trying to prevent.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Vitest runs the spec through Vite, so `__dirname` is the directory
+// of the compiled test module. The package is CommonJS (`module:
+// "nodenext"` + no `"type": "module"` in package.json), so
+// `import.meta.url` would fail the strict TS build. Resolve the
+// implementation path relative to `__dirname` instead.
+const IMPL_PATH = resolve(__dirname, 'index.ts');
+const IMPL_SOURCE = readFileSync(IMPL_PATH, 'utf8');
+
+describe('B1 anti-scope guards', () => {
+  it('implementation source does not import node:fs, fs, readFile, or any reader/parser', () => {
+    // Each token is a positive signal that an I/O or reader dependency
+    // leaked into B1. The list mirrors the forbidden surface from the
+    // Task 6 plan block.
+    const forbidden = [
+      'node:fs',
+      'node:fs/promises',
+      "from 'fs'",
+      'from "fs"',
+      'readFile',
+      'readAgentMcpConfig',
+      'parseMcpConfig',
+      'parseJsoncMcpServerMap',
+      'parseTomlMcpServerMap',
+    ];
+    for (const token of forbidden) {
+      expect(IMPL_SOURCE, `forbidden token: ${token}`).not.toContain(token);
+    }
+  });
+
+  it('implementation source does not use JSON.stringify for behavior or equality', () => {
+    // Match the function-call form (`JSON.stringify(`) so the JSDoc
+    // mention of the forbidden pattern on `serverSettingsEqual` does
+    // not trip the guard.
+    expect(IMPL_SOURCE).not.toMatch(/JSON\.stringify\s*\(/);
+  });
+
+  it('implementation source does not write to stdout/stderr or invoke a renderer', () => {
+    const forbidden = [
+      'process.stdout',
+      'process.stderr',
+      'console.log',
+      'formatHumanOutput',
+      'formatJsonOutput',
+    ];
+    for (const token of forbidden) {
+      expect(IMPL_SOURCE, `forbidden token: ${token}`).not.toContain(token);
+    }
+  });
+
+  it('implementation source is not async and does not return a Promise', () => {
+    expect(IMPL_SOURCE).not.toMatch(/\basync\b/);
+    expect(IMPL_SOURCE).not.toMatch(/\bPromise\b/);
+  });
+
+  it('the four supported agent ids appear only inside the DEFAULT_REGISTRY_ORDER block', () => {
+    // The plan allows the four supported ids inside the
+    // DEFAULT_REGISTRY_ORDER constant and inside tests. Anywhere else
+    // in the implementation source would be a per-agent branch — a
+    // hard scope violation against the four-CLI mandate.
+    const supportedIds = [
+      'claude-code',
+      'opencode',
+      'github-copilot-cli',
+      'openai-codex',
+    ];
+    const lines = IMPL_SOURCE.split('\n');
+
+    const constLine = lines.findIndex((line) =>
+      line.includes('export const DEFAULT_REGISTRY_ORDER'),
+    );
+    expect(
+      constLine,
+      'DEFAULT_REGISTRY_ORDER must exist',
+    ).toBeGreaterThanOrEqual(0);
+
+    // Walk upward to the start of the JSDoc that documents the constant.
+    // The JSDoc is part of the "constant block" for the purposes of this
+    // guard: it is documentation, not code, and it must be free to name
+    // the agents so future readers know what the list means.
+    let jsDocStart = constLine;
+    while (jsDocStart > 0) {
+      const prev = lines[jsDocStart - 1];
+      if (prev !== undefined && prev.trim().startsWith('/**')) {
+        break;
+      }
+      jsDocStart--;
+    }
+    expect(
+      jsDocStart,
+      'DEFAULT_REGISTRY_ORDER must have a JSDoc block above it',
+    ).toBeLessThan(constLine);
+
+    // Walk downward to the closing `];` of the array literal.
+    let arrayEnd = constLine;
+    while (arrayEnd < lines.length && !lines[arrayEnd]?.includes('];')) {
+      arrayEnd++;
+    }
+    expect(
+      arrayEnd,
+      'DEFAULT_REGISTRY_ORDER array must close with `];`',
+    ).toBeLessThan(lines.length);
+
+    const outsideBlock = lines
+      .filter((_, i) => i < jsDocStart || i > arrayEnd)
+      .join('\n');
+
+    for (const id of supportedIds) {
+      expect(
+        outsideBlock,
+        `agent id "${id}" must only appear inside DEFAULT_REGISTRY_ORDER`,
+      ).not.toContain(id);
+    }
+  });
+
+  it('DEFAULT_REGISTRY_ORDER lists exactly the four canonical agent ids in the documented order', () => {
+    // This is a positive allow-list: the four ids and their order are
+    // load-bearing for downstream consumers. The constant is the single
+    // source of truth; the test pins both the contents and the order so
+    // a future edit that reorders or drops an id has to be intentional.
+    const match = IMPL_SOURCE.match(
+      /export const DEFAULT_REGISTRY_ORDER[^=]*=\s*\[([\s\S]*?)\]/,
+    );
+    expect(
+      match,
+      'DEFAULT_REGISTRY_ORDER must exist as an array literal',
+    ).toBeTruthy();
+    const entries = (match?.[1] ?? '')
+      .split(',')
+      .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+      .filter((s) => s.length > 0);
+    expect(entries).toEqual([
+      'claude-code',
+      'opencode',
+      'github-copilot-cli',
+      'openai-codex',
+    ]);
+  });
+});

--- a/packages/scan-matrix/tsconfig.json
+++ b/packages/scan-matrix/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/scan-matrix/tsconfig.lib.json
+++ b/packages/scan-matrix/tsconfig.lib.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "../../dist/packages/scan-matrix",
+    "rootDir": "src",
+    "tsBuildInfoFile": "../../dist/packages/scan-matrix/tsconfig.lib.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/packages/scan-matrix/tsconfig.spec.json
+++ b/packages/scan-matrix/tsconfig.spec.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/packages/scan-matrix/out-tsc/vitest",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/scan-matrix/vitest.config.mts
+++ b/packages/scan-matrix/vitest.config.mts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/scan-matrix',
+  test: {
+    name: '@overture/scan-matrix',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,9 @@
     },
     {
       "path": "./packages/os"
+    },
+    {
+      "path": "./packages/scan-matrix"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,6 +2512,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@overture/scan-matrix@workspace:packages/scan-matrix":
+  version: 0.0.0-use.local
+  resolution: "@overture/scan-matrix@workspace:packages/scan-matrix"
+  languageName: unknown
+  linkType: soft
+
 "@oxc-project/types@npm:=0.133.0":
   version: 0.133.0
   resolution: "@oxc-project/types@npm:0.133.0"


### PR DESCRIPTION
## Summary

Implements the **B1 scan matrix model** as defined in `docs/overture-implementation-slices.md` — a pure, synchronous, deterministic model that compares canonical MCP server entries across the four supported CLI agents (Claude Code, OpenCode, GitHub Copilot CLI, OpenAI Codex).

This is the data backbone the B2/B3 CLI commands (`status`, `sync`, `diff`) will hang off of.

## What's in the PR

A new workspace package `@overture/scan-matrix` under `packages/scan-matrix/`:

| Export | Purpose |
| --- | --- |
| `OvertureMcpServer`, `NormalizedAgentServer` | Canonical entry shapes after per-agent normalization |
| `ServerStatus` (5 values) | `aligned` / `missing-from-agent` / `extra-in-agent` / `different-settings` / `shape-conflict` |
| `AgentReadState` (7 values) | Agent-level read state including `not-installed`, `unsupported`, `parse-error`, `not-applicable` |
| `serverSettingsEqual(a, b)` | Field-exact equality with deterministic, order-insensitive collection handling |
| `compareAgentEntries(input)` | Classifies canonical names into `ServerStatusRow`s, then agent-only names; deterministic ASC sort |
| `buildScanMatrix(input)` | Pure sync builder; respects `targets`, `disabledServers`, agent read states, invalid profiles |
| `DEFAULT_REGISTRY_ORDER` | Frozen canonical order of the four supported agents |

**Purity contract** (locked by tests and `scope-guards.spec.ts`): no I/O, no async, no `JSON.stringify` in implementation, no readers/parsers. Equality happens **after** each agent's native config is normalized to the canonical shape.

## Quality gates (verified locally on `feat/b1-scan-matrix-model`)

- `yarn nx test @overture/scan-matrix --skip-nx-cache` → **67/67 pass** (`scan-matrix.spec.ts`: 61, `scope-guards.spec.ts`: 6)
- `yarn nx test @overture/config --skip-nx-cache` → 28/28
- `yarn nx test @overture/agents --skip-nx-cache` → 76/76
- `yarn nx test @jander99/overture --skip-nx-cache` → 87/87 (no regression)
- `yarn nx build @overture/scan-matrix --skip-nx-cache` → SUCCESS
- `yarn nx build @jander99/overture --skip-nx-cache` → SUCCESS
- `yarn tsc -b --pretty false` → EXIT 0
- `./node_modules/.bin/prettier --check .` → clean
- Static guards: no `node:fs` / `node:child_process` / parser imports in `packages/scan-matrix/src/index.ts`; no removed platform-id literals; no `JSON.stringify(` in implementation
- `docs/overture-implementation-slices.md` B1 marked **Status: completed.**

## Commits (6)

```
4381c819 chore(scan-matrix): verify B1 scope and docs
9e59b4fd feat(scan-matrix): build scan matrix
be9da80b feat(scan-matrix): classify server rows
7b4ddd4a feat(scan-matrix): implement canonical equality
fcb5406c feat(scan-matrix): define model contracts
c79bb7fc feat(scan-matrix): scaffold package
```

## Scope notes

- **Four-CLI only.** `DEFAULT_REGISTRY_ORDER` and the row model are intentionally limited to `claude-code`, `opencode`, `github-copilot-cli`, `openai-codex`. The 10 removed platform ids (claude-desktop, github-copilot-vscode, github-copilot-cloud-agent, cursor, windsurf, cline, roo-code, continue, zed, aider) do not appear in any committed source or docs in this PR.
- **`yarn.lock`** has a 6-line addition for the new workspace package entry; not a package-level dep change.
- **No CLI surface added.** This PR is the model only; the B2 (`status`/`diff`) and B3 (`sync`) commands will follow in separate PRs.

## Plan & verification

- Plan: `.omo/plans/b1-scan-matrix-model.md`
- Metis pre-planning review: incorporated
- Oracle phase 1 (design): GO
- Oracle phase 2 (execution-readiness): GO
- Oracle phase 3 (final readiness): GO
- Final wave: F1 Plan Compliance **APPROVE** | F2 Code Quality **APPROVE** | F3 Real Manual QA **APPROVE** | F4 Scope Fidelity **APPROVE**

🤖 Generated with [opencode](https://opencode.ai)
