### PR TITLE
feat(agents): B2 - normalize agent MCP configs into canonical server entries

### DIFF
--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -114,18 +114,32 @@ to supply post-normalized `OvertureMcpServer` values without changing B1.
 
 ### B2. Normalize agent MCP configs into canonical server entries
 
-Convert each supported agent's native MCP shape into canonical `mcpServers`
-entries for comparison.
+Add a new optional handler `mcp.normalize` on `AgentMcpHandlers` that converts
+each supported agent's native MCP shape into canonical `OvertureMcpServer`
+entries. The handler is implemented per agent inside `@overture/agents` (the
+existing `mcp.parseServers` handler stays separate — it renders the display
+path; `mcp.normalize` is the canonical path for comparison).
 
-Start with the highest-value agents:
+Per-agent implementations live in `packages/agents/src/<id>.ts` for
+claude-code, opencode, github-copilot-cli, and openai-codex. The agents
+package depends on `@overture/config` for the `OvertureMcpServer` type
+only — no `@overture/scan-matrix` import (scan-matrix already imports
+`McpSupport` from agents; a reverse import would close a package cycle).
 
-- Claude Code
-- OpenCode
-- GitHub Copilot CLI
-- OpenAI Codex
+Shared normalization helpers and the canonical shape-conflict reason strings
+live in `packages/agents/src/normalize-mcp-config.ts`. Per-agent normalizers are
+wired into the registry through `asRegistryNormalizeHandler<TConfig>(handler)`
+so the heterogeneous `AgentMcpHandlers.normalize` slot stays non-generic
+while per-agent functions preserve their typed input shape.
 
-Expected result: fixture-backed normalization for each included agent, with no
-writes.
+Approval gate: the `mcp.normalize` handler interface and the
+agents-package-as-home decision.
+
+Expected result: fixture-backed `mcp.normalize` per agent, with no CLI
+surface change. `@overture/scan-matrix` continues to receive canonical
+entries unchanged.
+
+**Status: completed.**
 
 ### B3. Classify conflicts
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -10,5 +10,8 @@
       "types": "./src/index.ts",
       "default": "./src/index.ts"
     }
+  },
+  "dependencies": {
+    "@overture/config": "workspace:*"
   }
 }

--- a/packages/agents/src/claude-code.ts
+++ b/packages/agents/src/claude-code.ts
@@ -1,11 +1,22 @@
 // Claude Code agent definition.
+import {
+  asRegistryNormalizeHandler,
+  isRecord,
+  normalized,
+  normalizeOptionalArgs,
+  normalizeOptionalEnv,
+  normalizeOptionalHeaders,
+  shapeConflict,
+} from './normalize-mcp-config.js';
 import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import { defineAgent } from './define-agent.js';
+import type { OvertureMcpServer } from '@overture/config';
 import type {
   AgentDefinition,
   AgentMcpParseServersHandler,
   AgentMcpReadResult,
+  AgentNormalizedMcpServer,
   NoMcpExtension,
   StandardMcpConfig,
   StandardMcpServer,
@@ -16,6 +27,80 @@ import type { PathResolutionContext } from './types.js';
 export const parseClaudeCodeMcpServers: AgentMcpParseServersHandler = (
   resolvedPath,
 ) => parseJsoncMcpServerMap(resolvedPath, 'mcpServers');
+
+export function normalizeClaudeCodeMcpServers(
+  input: AgentMcpReadResult<ClaudeCodeMcpConfig>,
+): Readonly<Record<string, AgentNormalizedMcpServer>> {
+  if (input.parseError !== undefined) {
+    return {};
+  }
+  if (input.config === null) {
+    return {};
+  }
+  const mcpServers = input.config.mcpServers;
+  if (mcpServers === undefined) {
+    return {};
+  }
+  if (!isRecord(mcpServers)) {
+    return {};
+  }
+  const out: Record<string, AgentNormalizedMcpServer> = {};
+  for (const name of Object.keys(mcpServers)) {
+    out[name] = normalizeClaudeServerEntry(mcpServers[name]);
+  }
+  return out;
+}
+
+function normalizeClaudeServerEntry(entry: unknown): AgentNormalizedMcpServer {
+  if (!isRecord(entry)) {
+    return shapeConflict('Expected server entry to be an object.');
+  }
+  const hasCommand = 'command' in entry;
+  const hasUrl = 'url' in entry;
+  if (hasCommand && hasUrl) {
+    return shapeConflict('Server declares both stdio command and remote url.');
+  }
+  if (!hasCommand && !hasUrl) {
+    return shapeConflict(
+      'Server declares neither stdio command nor remote url.',
+    );
+  }
+  if (hasCommand) {
+    const command = entry['command'];
+    if (typeof command !== 'string' || command.length === 0) {
+      return shapeConflict('Stdio command is missing or empty.');
+    }
+    const args = normalizeOptionalArgs(entry['args']);
+    if (typeof args === 'string') {
+      return shapeConflict(args);
+    }
+    const env = normalizeOptionalEnv(entry['env']);
+    if (typeof env === 'string') {
+      return shapeConflict(env);
+    }
+    const server: OvertureMcpServer = {
+      type: 'stdio',
+      command,
+      ...(args !== undefined ? { args } : {}),
+      ...(env !== undefined ? { env } : {}),
+    };
+    return normalized(server);
+  }
+  const url = entry['url'];
+  if (typeof url !== 'string' || url.length === 0) {
+    return shapeConflict('Remote url is missing or empty.');
+  }
+  const headers = normalizeOptionalHeaders(entry['headers']);
+  if (typeof headers === 'string') {
+    return shapeConflict(headers);
+  }
+  const server: OvertureMcpServer = {
+    type: 'remote',
+    url,
+    ...(headers !== undefined ? { headers } : {}),
+  };
+  return normalized(server);
+}
 
 export const claudeCode: AgentDefinition = defineAgent({
   id: 'claude-code',
@@ -62,38 +147,21 @@ export const claudeCode: AgentDefinition = defineAgent({
   executableNames: ['claude'],
   mcp: {
     parseServers: parseClaudeCodeMcpServers,
+    normalize: asRegistryNormalizeHandler(normalizeClaudeCodeMcpServers),
   },
 });
 
-/**
- * Native Claude Code MCP config: `mcpServers` map; the top level may
- * also carry a local `imports` map (Claude Code's local-imports
- * feature). The per-server shape is the standard stdio/remote
- * union — no Claude-specific server fields beyond the imports slot.
- */
 export type ClaudeCodeMcpConfig = StandardMcpConfig<
   NoMcpExtension,
   Readonly<{ readonly imports?: StringMap }>
 >;
 
-/** Per-server type — re-exported under the historical name for downstream imports. */
 export type ClaudeCodeMcpServer = StandardMcpServer<NoMcpExtension>;
 
-/** Stdio transport: local process invocation. */
 export type ClaudeCodeStdioServer = StandardMcpServer<NoMcpExtension>;
 
-/** Remote transport: HTTP / streamable-http / SSE / WebSocket. */
 export type ClaudeCodeRemoteServer = StandardMcpServer<NoMcpExtension>;
 
-/** Remote transport: HTTP / streamable-http / SSE / WebSocket. */
-
-/**
- * Read the agent's MCP config into the typed `ClaudeCodeMcpConfig` shape.
- * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
- * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
- * as `claudeCode.mcp.read`, but with the generic `config` field
- * narrowed to `ClaudeCodeMcpConfig | null`.
- */
 export async function readClaudeCodeMcpConfig(
   ctx: PathResolutionContext,
 ): Promise<AgentMcpReadResult<ClaudeCodeMcpConfig>> {

--- a/packages/agents/src/define-agent.spec.ts
+++ b/packages/agents/src/define-agent.spec.ts
@@ -42,6 +42,19 @@ describe('defineAgent', () => {
     expect(agent.mcp.parseServers).toBe(parseServers);
   });
 
+  it('preserves caller-provided normalize by identity', () => {
+    const normalize = () => ({});
+    const agent = defineAgent({
+      ...base,
+      id: 'opencode',
+      mcp: {
+        read: () => Promise.resolve({ config: null, nonEmpty: false }),
+        normalize,
+      },
+    });
+    expect(agent.mcp.normalize).toBe(normalize);
+  });
+
   it('preserves notImplementedMcpHandlers for unsupported agents', async () => {
     const agent = defineAgent({
       ...base,

--- a/packages/agents/src/define-agent.ts
+++ b/packages/agents/src/define-agent.ts
@@ -54,6 +54,9 @@ export function defineAgent(input: DefineAgentInput): AgentDefinition {
         ...(input.mcp.parseServers
           ? { parseServers: input.mcp.parseServers }
           : {}),
+        ...(input.mcp.normalize
+          ? { normalize: input.mcp.normalize }
+          : {}),
       },
     };
   }
@@ -68,6 +71,9 @@ export function defineAgent(input: DefineAgentInput): AgentDefinition {
       write: input.mcp?.write ?? defaultMcpWriteHandler(input.id),
       ...(input.mcp?.parseServers
         ? { parseServers: input.mcp.parseServers }
+        : {}),
+      ...(input.mcp?.normalize
+        ? { normalize: input.mcp?.normalize }
         : {}),
     },
   };

--- a/packages/agents/src/define-agent.ts
+++ b/packages/agents/src/define-agent.ts
@@ -54,9 +54,7 @@ export function defineAgent(input: DefineAgentInput): AgentDefinition {
         ...(input.mcp.parseServers
           ? { parseServers: input.mcp.parseServers }
           : {}),
-        ...(input.mcp.normalize
-          ? { normalize: input.mcp.normalize }
-          : {}),
+        ...(input.mcp.normalize ? { normalize: input.mcp.normalize } : {}),
       },
     };
   }
@@ -72,9 +70,7 @@ export function defineAgent(input: DefineAgentInput): AgentDefinition {
       ...(input.mcp?.parseServers
         ? { parseServers: input.mcp.parseServers }
         : {}),
-      ...(input.mcp?.normalize
-        ? { normalize: input.mcp?.normalize }
-        : {}),
+      ...(input.mcp?.normalize ? { normalize: input.mcp?.normalize } : {}),
     },
   };
   (agent.mcp as CompleteAgentMcpHandlers).read = (ctx) =>

--- a/packages/agents/src/github-copilot-cli.ts
+++ b/packages/agents/src/github-copilot-cli.ts
@@ -1,11 +1,22 @@
 // GitHub Copilot CLI agent definition.
+import {
+  asRegistryNormalizeHandler,
+  isRecord,
+  normalized,
+  normalizeOptionalArgs,
+  normalizeOptionalEnv,
+  normalizeOptionalHeaders,
+  shapeConflict,
+} from './normalize-mcp-config.js';
 import { parseJsoncMcpServerMap } from './parse-mcp-servers.js';
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import { defineAgent } from './define-agent.js';
+import type { OvertureMcpServer } from '@overture/config';
 import type {
   AgentDefinition,
   AgentMcpParseServersHandler,
   AgentMcpReadResult,
+  AgentNormalizedMcpServer,
   McpServerMap,
   PathResolutionContext,
   StringList,
@@ -16,6 +27,73 @@ import type {
 export const parseGitHubCopilotCliMcpServers: AgentMcpParseServersHandler = (
   resolvedPath,
 ) => parseJsoncMcpServerMap(resolvedPath, 'mcpServers');
+
+export function normalizeGitHubCopilotCliMcpServers(
+  input: AgentMcpReadResult<GitHubCopilotCliMcpConfig>,
+): Readonly<Record<string, AgentNormalizedMcpServer>> {
+  if (input.parseError !== undefined) {
+    return {};
+  }
+  if (input.config === null) {
+    return {};
+  }
+  const mcpServers = input.config.mcpServers;
+  if (mcpServers === undefined) {
+    return {};
+  }
+  if (!isRecord(mcpServers)) {
+    return {};
+  }
+  const out: Record<string, AgentNormalizedMcpServer> = {};
+  for (const name of Object.keys(mcpServers)) {
+    out[name] = normalizeCopilotServerEntry(mcpServers[name]);
+  }
+  return out;
+}
+
+function normalizeCopilotServerEntry(entry: unknown): AgentNormalizedMcpServer {
+  if (!isRecord(entry)) {
+    return shapeConflict('Expected server entry to be an object.');
+  }
+  if (entry['type'] === 'local') {
+    const command = entry['command'];
+    if (typeof command !== 'string' || command.length === 0) {
+      return shapeConflict('Stdio command is missing or empty.');
+    }
+    const args = normalizeOptionalArgs(entry['args']);
+    if (typeof args === 'string') {
+      return shapeConflict(args);
+    }
+    const env = normalizeOptionalEnv(entry['env']);
+    if (typeof env === 'string') {
+      return shapeConflict(env);
+    }
+    const server: OvertureMcpServer = {
+      type: 'stdio',
+      command,
+      ...(args !== undefined ? { args } : {}),
+      ...(env !== undefined ? { env } : {}),
+    };
+    return normalized(server);
+  }
+  if (entry['type'] === 'http') {
+    const url = entry['url'];
+    if (typeof url !== 'string' || url.length === 0) {
+      return shapeConflict('Remote url is missing or empty.');
+    }
+    const headers = normalizeOptionalHeaders(entry['headers']);
+    if (typeof headers === 'string') {
+      return shapeConflict(headers);
+    }
+    const server: OvertureMcpServer = {
+      type: 'remote',
+      url,
+      ...(headers !== undefined ? { headers } : {}),
+    };
+    return normalized(server);
+  }
+  return shapeConflict('Unsupported MCP server transport type.');
+}
 
 export const githubCopilotCli: AgentDefinition = defineAgent({
   id: 'github-copilot-cli',
@@ -56,13 +134,10 @@ export const githubCopilotCli: AgentDefinition = defineAgent({
   executableNames: ['copilot'],
   mcp: {
     parseServers: parseGitHubCopilotCliMcpServers,
+    normalize: asRegistryNormalizeHandler(normalizeGitHubCopilotCliMcpServers),
   },
 });
 
-/**
- * Local (subprocess) Copilot CLI MCP server. `type` is the literal
- * `'local'` and the entry is keyed on it for a discriminated union.
- */
 export interface GitHubCopilotCliLocalServer {
   type: 'local';
   command: string;
@@ -71,9 +146,6 @@ export interface GitHubCopilotCliLocalServer {
   tools?: ToolList;
 }
 
-/**
- * Remote (HTTP) Copilot CLI MCP server. `type` is the literal `'http'`.
- */
 export interface GitHubCopilotCliRemoteServer {
   type: 'http';
   url: string;
@@ -81,31 +153,14 @@ export interface GitHubCopilotCliRemoteServer {
   tools?: ToolList;
 }
 
-/**
- * Union of every supported Copilot CLI MCP server variant. Discriminated
- * on the `type` field.
- */
 export type GitHubCopilotCliServer =
   | GitHubCopilotCliLocalServer
   | GitHubCopilotCliRemoteServer;
 
-/**
- * Native shape of `~/.copilot/mcp-config.json` (user-global; relocatable
- * via `COPILOT_HOME`). The top-level key is `mcpServers` (per the current
- * official Copilot CLI docs), NOT the legacy `servers` key referenced by
- * the stale registry metadata.
- */
 export interface GitHubCopilotCliMcpConfig {
   mcpServers?: McpServerMap<GitHubCopilotCliServer>;
 }
 
-/**
- * Read the agent's MCP config into the typed `GitHubCopilotCliMcpConfig` shape.
- * Thin wrapper over `readAgentMcpConfig` that casts the unknown document
- * to the agent's typed config. Returns the same `AgentMcpReadResult` shape
- * as `githubCopilotCli.mcp.read`, but with the generic `config` field
- * narrowed to `GitHubCopilotCliMcpConfig | null`.
- */
 export async function readGitHubCopilotCliMcpConfig(
   ctx: PathResolutionContext,
 ): Promise<AgentMcpReadResult<GitHubCopilotCliMcpConfig>> {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -74,6 +74,8 @@ export {
   type DefineAgentInput,
 } from './define-agent.js';
 
+export { asRegistryNormalizeHandler } from './normalize-mcp-config.js';
+
 import { claudeCode } from './claude-code.js';
 import { opencode } from './opencode.js';
 import { githubCopilotCli } from './github-copilot-cli.js';

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -17,6 +17,8 @@ import type { AgentDefinition, PlatformId } from './types.js';
 export type {
   AgentDefinition,
   AgentMcpHandlers,
+  AgentMcpNormalizeHandler,
+  AgentMcpNormalizeReason,
   AgentMcpParseServersHandler,
   AgentMcpReadHandler,
   AgentMcpReadHandlerTyped,
@@ -24,6 +26,7 @@ export type {
   AgentMcpWriteHandler,
   AgentMcpWriteInput,
   AgentMcpWriteResult,
+  AgentNormalizedMcpServer,
   JsonPrimitive,
   JsonValue,
   StringList,

--- a/packages/agents/src/normalize-claude-copilot.spec.ts
+++ b/packages/agents/src/normalize-claude-copilot.spec.ts
@@ -1,0 +1,517 @@
+// Tests for the per-agent MCP normalizers in `claude-code.ts` and
+// `github-copilot-cli.ts`.
+//
+// Group order matches the plan's per-agent scenario list:
+//   1. Claude Code
+//      - happy path stdio + remote
+//      - empty explicit fields preserved
+//      - read-result guards (parseError, config null, mcpServers absent, non-object)
+//      - per-server: non-object, both keys, neither key, empty command
+//      - per-server: bad args, bad env, bad headers
+//      - per-server: whitespace-only command is non-empty
+//   2. GitHub Copilot CLI
+//      - happy path local + http
+//      - empty explicit fields preserved
+//      - read-result guards (parseError, config null, mcpServers absent, non-object)
+//      - per-server: non-object, bad args/env/headers
+//      - per-server: empty command / empty url
+//      - per-server: unsupported transport type (incl. missing)
+import { describe, expect, it } from 'vitest';
+import type { AgentMcpReadResult } from './types.js';
+import {
+  normalizeClaudeCodeMcpServers,
+  type ClaudeCodeMcpConfig,
+} from './claude-code.js';
+import {
+  normalizeGitHubCopilotCliMcpServers,
+  type GitHubCopilotCliMcpConfig,
+} from './github-copilot-cli.js';
+
+type ClaudeInput = AgentMcpReadResult<ClaudeCodeMcpConfig>;
+type CopilotInput = AgentMcpReadResult<GitHubCopilotCliMcpConfig>;
+
+function ccInput(
+  config: unknown,
+  extras: { parseError?: string } = {},
+): ClaudeInput {
+  return {
+    config: config as ClaudeCodeMcpConfig | null,
+    nonEmpty: config !== null,
+    ...extras,
+  };
+}
+
+function copInput(
+  config: unknown,
+  extras: { parseError?: string } = {},
+): CopilotInput {
+  return {
+    config: config as GitHubCopilotCliMcpConfig | null,
+    nonEmpty: config !== null,
+    ...extras,
+  };
+}
+
+describe('normalizeClaudeCodeMcpServers', () => {
+  it('happy path: stdio + remote entries with valid args/env/headers', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: {
+          local_one: {
+            command: 'npx',
+            args: ['-y', 'mcp-server'],
+            env: { NODE_ENV: 'production' },
+          },
+          remote_one: {
+            url: 'https://mcp.example.com',
+            headers: { Authorization: 'Bearer token' },
+          },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      local_one: {
+        state: 'normalized',
+        server: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['-y', 'mcp-server'],
+          env: { NODE_ENV: 'production' },
+        },
+      },
+      remote_one: {
+        state: 'normalized',
+        server: {
+          type: 'remote',
+          url: 'https://mcp.example.com',
+          headers: { Authorization: 'Bearer token' },
+        },
+      },
+    });
+  });
+
+  it('preserves explicit empty args as []', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: { empty_args: { command: 'noop', args: [] } },
+      }),
+    );
+    expect(result).toEqual({
+      empty_args: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'noop', args: [] },
+      },
+    });
+  });
+
+  it('preserves explicit empty env as {}', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: { empty_env: { command: 'noop', env: {} } },
+      }),
+    );
+    expect(result).toEqual({
+      empty_env: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'noop', env: {} },
+      },
+    });
+  });
+
+  it('returns {} when config is null', () => {
+    expect(normalizeClaudeCodeMcpServers(ccInput(null))).toEqual({});
+  });
+
+  it('returns {} when parseError is set', () => {
+    expect(
+      normalizeClaudeCodeMcpServers(
+        ccInput(
+          { mcpServers: { x: { command: 'a' } } },
+          {
+            parseError: 'parse failed',
+          },
+        ),
+      ),
+    ).toEqual({});
+  });
+
+  it('returns {} when mcpServers is absent', () => {
+    expect(normalizeClaudeCodeMcpServers(ccInput({}))).toEqual({});
+  });
+
+  it('returns {} when mcpServers is an array', () => {
+    expect(
+      normalizeClaudeCodeMcpServers(
+        ccInput({ mcpServers: [] as unknown as Record<string, unknown> }),
+      ),
+    ).toEqual({});
+  });
+
+  it('returns {} when mcpServers is a string', () => {
+    expect(
+      normalizeClaudeCodeMcpServers(
+        ccInput({
+          mcpServers: 'not a map' as unknown as Record<string, unknown>,
+        }),
+      ),
+    ).toEqual({});
+  });
+
+  it('per-server: non-object entry returns shape-conflict', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: {
+          bad: 'not an object' as unknown as Record<string, unknown>,
+        },
+      }),
+    );
+    expect(result['bad']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected server entry to be an object.',
+    });
+  });
+
+  it('per-server: both command and url present returns both-keys reason', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: { conflict: { command: 'npx', url: 'https://x' } },
+      }),
+    );
+    expect(result['conflict']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Server declares both stdio command and remote url.',
+    });
+  });
+
+  it('per-server: both command (empty) and url present still returns both-keys reason', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: { conflict: { command: '', url: 'https://x' } },
+      }),
+    );
+    expect(result['conflict']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Server declares both stdio command and remote url.',
+    });
+  });
+
+  it('per-server: neither command nor url present returns neither-keys reason', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: { empty: { args: ['a'] } },
+      }),
+    );
+    expect(result['empty']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Server declares neither stdio command nor remote url.',
+    });
+  });
+
+  it('per-server: empty string command returns missing-or-empty reason', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: { empty_cmd: { command: '' } },
+      }),
+    );
+    expect(result['empty_cmd']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Stdio command is missing or empty.',
+    });
+  });
+
+  it('per-server: whitespace-only command is non-empty and normalizes', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: { ws_cmd: { command: ' ' } },
+      }),
+    );
+    expect(result['ws_cmd']).toEqual({
+      state: 'normalized',
+      server: { type: 'stdio', command: ' ' },
+    });
+  });
+
+  it('per-server: bad args (non-array) returns args reason', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: {
+          bad_args: { command: 'x', args: 42 as unknown as string[] },
+        },
+      }),
+    );
+    expect(result['bad_args']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string array for args.',
+    });
+  });
+
+  it('per-server: bad env (non-string value) returns env reason', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: {
+          bad_env: { command: 'x', env: { KEY: 42 as unknown as string } },
+        },
+      }),
+    );
+    expect(result['bad_env']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string map for env.',
+    });
+  });
+
+  it('per-server: bad headers (non-string value) returns headers reason', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        mcpServers: {
+          bad_headers: {
+            url: 'https://x',
+            headers: { K: 1 as unknown as string },
+          },
+        },
+      }),
+    );
+    expect(result['bad_headers']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string map for headers.',
+    });
+  });
+
+  it('ignores top-level imports extension (does not read it)', () => {
+    const result = normalizeClaudeCodeMcpServers(
+      ccInput({
+        imports: { './other.json': './other.json' },
+        mcpServers: { ok: { command: 'npx' } },
+      }),
+    );
+    expect(result).toEqual({
+      ok: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'npx' },
+      },
+    });
+  });
+});
+
+describe('normalizeGitHubCopilotCliMcpServers', () => {
+  it('happy path: local + http entries with valid args/env/headers', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: {
+          local_one: {
+            type: 'local',
+            command: 'npx',
+            args: ['-y', 'mcp-server'],
+            env: { NODE_ENV: 'production' },
+            tools: ['tool1', 'tool2'],
+          },
+          http_one: {
+            type: 'http',
+            url: 'https://mcp.example.com',
+            headers: { Authorization: 'Bearer token' },
+            tools: ['tool3'],
+          },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      local_one: {
+        state: 'normalized',
+        server: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['-y', 'mcp-server'],
+          env: { NODE_ENV: 'production' },
+        },
+      },
+      http_one: {
+        state: 'normalized',
+        server: {
+          type: 'remote',
+          url: 'https://mcp.example.com',
+          headers: { Authorization: 'Bearer token' },
+        },
+      },
+    });
+  });
+
+  it('preserves explicit empty args as []', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: {
+          empty_args: { type: 'local', command: 'noop', args: [] },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      empty_args: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'noop', args: [] },
+      },
+    });
+  });
+
+  it('preserves explicit empty env as {}', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: {
+          empty_env: { type: 'local', command: 'noop', env: {} },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      empty_env: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'noop', env: {} },
+      },
+    });
+  });
+
+  it('returns {} when config is null', () => {
+    expect(normalizeGitHubCopilotCliMcpServers(copInput(null))).toEqual({});
+  });
+
+  it('returns {} when parseError is set', () => {
+    expect(
+      normalizeGitHubCopilotCliMcpServers(
+        copInput(
+          { mcpServers: { x: { type: 'local', command: 'a' } } },
+          { parseError: 'parse failed' },
+        ),
+      ),
+    ).toEqual({});
+  });
+
+  it('returns {} when mcpServers is absent', () => {
+    expect(normalizeGitHubCopilotCliMcpServers(copInput({}))).toEqual({});
+  });
+
+  it('returns {} when mcpServers is an array', () => {
+    expect(
+      normalizeGitHubCopilotCliMcpServers(
+        copInput({ mcpServers: [] as unknown as Record<string, unknown> }),
+      ),
+    ).toEqual({});
+  });
+
+  it('returns {} when mcpServers is a string', () => {
+    expect(
+      normalizeGitHubCopilotCliMcpServers(
+        copInput({ mcpServers: 'nope' as unknown as Record<string, unknown> }),
+      ),
+    ).toEqual({});
+  });
+
+  it('per-server: non-object entry returns shape-conflict', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: { bad: 42 as unknown as Record<string, unknown> },
+      }),
+    );
+    expect(result['bad']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected server entry to be an object.',
+    });
+  });
+
+  it('per-server: type stdio returns unsupported reason', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: { bad: { type: 'stdio', command: 'a' } },
+      }),
+    );
+    expect(result['bad']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Unsupported MCP server transport type.',
+    });
+  });
+
+  it('per-server: missing type returns unsupported reason', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: { bad: { command: 'a' } },
+      }),
+    );
+    expect(result['bad']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Unsupported MCP server transport type.',
+    });
+  });
+
+  it('per-server: empty local command returns missing-or-empty reason', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: { bad: { type: 'local', command: '' } },
+      }),
+    );
+    expect(result['bad']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Stdio command is missing or empty.',
+    });
+  });
+
+  it('per-server: empty http url returns missing-or-empty reason', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: { bad: { type: 'http', url: '' } },
+      }),
+    );
+    expect(result['bad']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Remote url is missing or empty.',
+    });
+  });
+
+  it('per-server: bad args (non-array) returns args reason', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: {
+          bad_args: {
+            type: 'local',
+            command: 'x',
+            args: 'nope' as unknown as string[],
+          },
+        },
+      }),
+    );
+    expect(result['bad_args']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string array for args.',
+    });
+  });
+
+  it('per-server: bad env returns env reason', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: {
+          bad_env: {
+            type: 'local',
+            command: 'x',
+            env: { K: 1 as unknown as string },
+          },
+        },
+      }),
+    );
+    expect(result['bad_env']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string map for env.',
+    });
+  });
+
+  it('per-server: bad headers returns headers reason', () => {
+    const result = normalizeGitHubCopilotCliMcpServers(
+      copInput({
+        mcpServers: {
+          bad_headers: {
+            type: 'http',
+            url: 'https://x',
+            headers: { K: 1 as unknown as string },
+          },
+        },
+      }),
+    );
+    expect(result['bad_headers']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string map for headers.',
+    });
+  });
+});

--- a/packages/agents/src/normalize-contract.spec.ts
+++ b/packages/agents/src/normalize-contract.spec.ts
@@ -1,0 +1,152 @@
+// Registry-level contract guards for the B2 MCP normalization slice.
+//
+// These tests prove the agentRegistry aggregate exposed from
+// `packages/agents/src/index.ts` actually carries the `mcp.normalize`
+// handler on every supported local CLI agent — i.e. the per-file
+// normalizers wired in by Tasks 3, 4, and 5 reach the public surface
+// and the registry stays consistent with the in-tree
+// `AGENT_REGISTRY_ORDER`. They also pin the B2 scope: exactly the four
+// CLI agents called out by the plan, and no `@overture/scan-matrix`
+// import closes a package cycle (scan-matrix already imports
+// `McpSupport` from agents; the reverse direction would create a
+// circular dependency).
+//
+// The runtime assertions are intentionally narrow (id set + per-entry
+// handler presence + parseServers/normalize identity separation +
+// import statement scan). Per-agent normalization behavior lives in
+// the colocated per-agent specs (`normalize-claude-copilot.spec.ts`,
+// `normalize-opencode.spec.ts`, `normalize-openai-codex.spec.ts`) and
+// the shared helpers are covered by `normalize-mcp-config.spec.ts`.
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { agentRegistry } from './index.js';
+import type { AgentDefinition, PlatformId } from './types.js';
+
+// The four supported local CLI agents in scope for B2. Reordering or
+// renaming an id is a breaking change for any consumer that depends
+// on the registry's positional indices, so this constant pins both
+// the cardinality and the id set.
+const B2_SUPPORTED_AGENT_IDS: ReadonlySet<PlatformId> = new Set<PlatformId>([
+  'claude-code',
+  'opencode',
+  'github-copilot-cli',
+  'openai-codex',
+]);
+
+// Predicate narrowing the heterogeneous AgentDefinition union to the
+// B2-supported agents (mcpSupport === 'supported'). Untyped
+// `agentRegistry` returns a `readonly AgentDefinition[]`; this guard
+// is what the rest of the suite iterates over.
+function isSupported(
+  entry: AgentDefinition,
+): entry is AgentDefinition & { mcpSupport: 'supported' } {
+  return entry.mcpSupport === 'supported';
+}
+
+// Resolve the agents package src directory. The test is co-located
+// in `packages/agents/src/`, and the agents package compiles to
+// CommonJS (see `packages/agents/tsconfig.json` → `module: commonjs`),
+// so the standard CommonJS globals `__dirname` / `__filename` are
+// available without the `import.meta.url` ESM bridge.
+const AGENTS_SRC_DIR = __dirname;
+
+/**
+ * Recursively collect every `.ts` file under the given directory,
+ * excluding this test file (which contains the literal string
+ * `@overture/scan-matrix` as part of its assertions).
+ */
+function listTypeScriptSources(
+  rootDir: string,
+  exclude: ReadonlySet<string>,
+): readonly string[] {
+  const out: string[] = [];
+  const visit = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      if (entry === 'node_modules' || entry.startsWith('.')) {
+        continue;
+      }
+      const abs = join(dir, entry);
+      const st = statSync(abs);
+      if (st.isDirectory()) {
+        visit(abs);
+        continue;
+      }
+      if (entry.endsWith('.ts') && !exclude.has(abs)) {
+        out.push(abs);
+      }
+    }
+  };
+  visit(rootDir);
+  return out;
+}
+
+// Match an actual import statement referencing `@overture/scan-matrix`
+// (with or without a `type` modifier). The test self-preserves by
+// excluding this file from the scan, so comments and string literals
+// in this file do not produce a false positive.
+const SCAN_MATRIX_IMPORT_REGEX =
+  /import\s+(?:type\s+)?[^'"]*from\s+['"]@overture\/scan-matrix['"]/;
+
+describe('agentRegistry — B2 normalize contract', () => {
+  it('contains exactly the four B2-supported CLI agents', () => {
+    const ids = new Set(agentRegistry.map((entry) => entry.id));
+    expect(ids).toEqual(B2_SUPPORTED_AGENT_IDS);
+  });
+
+  it('contains no agents outside the B2 scope (no extras, no future drift)', () => {
+    expect(agentRegistry.length).toBe(B2_SUPPORTED_AGENT_IDS.size);
+  });
+
+  it('every supported agent exposes an mcp.normalize handler', () => {
+    const supported = agentRegistry.filter(isSupported);
+    expect(supported.length).toBe(B2_SUPPORTED_AGENT_IDS.size);
+    for (const entry of supported) {
+      expect(typeof entry.mcp.normalize).toBe('function');
+    }
+  });
+
+  it('mcp.parseServers and mcp.normalize are separate functions for every supported agent', () => {
+    // parseServers is the human-readable display path (renders the
+    // server list under the `mcp:` line); normalize is the canonical
+    // path the scan matrix compares against. They MUST be distinct
+    // functions — if they collapse to one, the display layer and the
+    // comparison layer share a contract and a future change to either
+    // silently breaks the other.
+    for (const entry of agentRegistry.filter(isSupported)) {
+      const parse = entry.mcp.parseServers;
+      const normalize = entry.mcp.normalize;
+      expect(typeof parse).toBe('function');
+      expect(typeof normalize).toBe('function');
+      expect(parse).not.toBe(normalize);
+    }
+  });
+
+  it('mcp.normalize is wired on exactly the four expected ids', () => {
+    // Belt-and-braces: even if a future agent sneaks in with
+    // mcpSupport === 'supported' and forgets a normalize handler, this
+    // test names the offenders.
+    const missing = agentRegistry
+      .filter((entry) => B2_SUPPORTED_AGENT_IDS.has(entry.id))
+      .filter((entry) => typeof entry.mcp.normalize !== 'function')
+      .map((entry) => entry.id);
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('packages/agents/src — package-cycle guard', () => {
+  it('does not import from @overture/scan-matrix in any source file', () => {
+    // scan-matrix already imports `McpSupport` from @overture/agents;
+    // a reverse import would close a circular dependency.
+    // Exclude this spec file: it intentionally contains the literal
+    // string `@overture/scan-matrix` in its docstring and matcher.
+    const sources = listTypeScriptSources(
+      AGENTS_SRC_DIR,
+      new Set([__filename]),
+    );
+    const offenders: readonly string[] = sources
+      .map((path) => ({ path, text: readFileSync(path, 'utf8') }))
+      .filter(({ text }) => SCAN_MATRIX_IMPORT_REGEX.test(text))
+      .map(({ path }) => relative(AGENTS_SRC_DIR, path));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/agents/src/normalize-mcp-config.spec.ts
+++ b/packages/agents/src/normalize-mcp-config.spec.ts
@@ -1,0 +1,422 @@
+// Tests for the shared MCP normalization helpers in normalize-mcp-config.ts.
+//
+// Group order follows the helper export order in normalize-mcp-config.ts:
+//   1. NORMALIZE_SHAPE_CONFLICT_REASONS (the constant)
+//   2. normalized / shapeConflict / asRegistryNormalizeHandler (constructors
+//      and the registry-slot adapter)
+//   3. isRecord / isStringMap (type guards)
+//   4. validateOptionalStringMap / validateOptionalStringArray (validators
+//      that only report a reason)
+//   5. normalizeOptionalArgs / normalizeOptionalEnv / normalizeOptionalHeaders
+//      (validators that also return a mutable canonical value)
+//
+// Each helper group covers:
+//   - happy path output
+//   - optional-field omission (absent value → undefined)
+//   - optional-field preservation (explicit empty `[]` / `{}` is kept as
+//     `[]` / `{}`, not collapsed to undefined — B1 equality contract)
+//   - readonly native input handling (the return is a fresh mutable copy)
+//   - invalid value outcomes (the canonical reason string)
+import { describe, expect, it } from 'vitest';
+import type { OvertureMcpServer } from '@overture/config';
+import type {
+  AgentMcpNormalizeHandler,
+  AgentMcpNormalizeReason,
+} from './types.js';
+import {
+  NORMALIZE_SHAPE_CONFLICT_REASONS,
+  asRegistryNormalizeHandler,
+  isRecord,
+  isStringMap,
+  normalized,
+  normalizeOptionalArgs,
+  normalizeOptionalEnv,
+  normalizeOptionalHeaders,
+  shapeConflict,
+  validateOptionalStringArray,
+  validateOptionalStringMap,
+} from './normalize-mcp-config.js';
+
+describe('NORMALIZE_SHAPE_CONFLICT_REASONS', () => {
+  it('contains exactly nine canonical reason strings', () => {
+    expect(NORMALIZE_SHAPE_CONFLICT_REASONS.size).toBe(9);
+  });
+
+  it.each([
+    'Expected server entry to be an object.',
+    'Stdio command is missing or empty.',
+    'Remote url is missing or empty.',
+    'Server declares both stdio command and remote url.',
+    'Server declares neither stdio command nor remote url.',
+    'Expected string array for args.',
+    'Expected string map for env.',
+    'Expected string map for headers.',
+    'Unsupported MCP server transport type.',
+  ] as const)('contains %s', (reason) => {
+    expect(
+      NORMALIZE_SHAPE_CONFLICT_REASONS.has(reason as AgentMcpNormalizeReason),
+    ).toBe(true);
+  });
+});
+
+describe('normalized()', () => {
+  it('wraps a stdio server as a success result', () => {
+    const server: OvertureMcpServer = { type: 'stdio', command: 'npx' };
+    expect(normalized(server)).toEqual({ state: 'normalized', server });
+  });
+
+  it('wraps a remote server as a success result', () => {
+    const server: OvertureMcpServer = {
+      type: 'remote',
+      url: 'https://mcp.example.com',
+    };
+    expect(normalized(server)).toEqual({ state: 'normalized', server });
+  });
+});
+
+describe('shapeConflict()', () => {
+  it('wraps a reason string in the shape-conflict arm', () => {
+    expect(shapeConflict('Expected server entry to be an object.')).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected server entry to be an object.',
+    });
+  });
+});
+
+describe('asRegistryNormalizeHandler()', () => {
+  it('adapts a typed normalizer to the unknown slot and forwards the input', () => {
+    let received: unknown = null;
+    const typed: AgentMcpNormalizeHandler<{ foo: string }> = (input) => {
+      received = input;
+      return {};
+    };
+    const adapted = asRegistryNormalizeHandler(typed);
+    const input = { config: { foo: 'bar' }, nonEmpty: true };
+    const result = adapted(input);
+    expect(received).toEqual(input);
+    expect(received).toBe(input);
+    expect(result).toEqual({});
+  });
+
+  it('returns whatever the typed handler returns (success results)', () => {
+    const server: OvertureMcpServer = { type: 'stdio', command: 'npx' };
+    const typed: AgentMcpNormalizeHandler<unknown> = () => ({
+      a: normalized(server),
+    });
+    const adapted = asRegistryNormalizeHandler(typed);
+    expect(adapted({ config: null, nonEmpty: false })).toEqual({
+      a: { state: 'normalized', server },
+    });
+  });
+
+  it('returns whatever the typed handler returns (shape-conflict results)', () => {
+    const typed: AgentMcpNormalizeHandler<unknown> = () => ({
+      a: shapeConflict('Stdio command is missing or empty.'),
+    });
+    const adapted = asRegistryNormalizeHandler(typed);
+    expect(adapted({ config: null, nonEmpty: false })).toEqual({
+      a: {
+        state: 'shape-conflict',
+        reason: 'Stdio command is missing or empty.',
+      },
+    });
+  });
+});
+
+describe('isRecord()', () => {
+  it('returns true for plain objects (empty and populated)', () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+    expect(isRecord({ a: 'b', c: 2 })).toBe(true);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+  });
+
+  it('returns false for primitives', () => {
+    expect(isRecord('string')).toBe(false);
+    expect(isRecord(42)).toBe(false);
+    expect(isRecord(true)).toBe(false);
+    expect(isRecord(false)).toBe(false);
+  });
+
+  it('returns false for arrays (empty and populated)', () => {
+    expect(isRecord([])).toBe(false);
+    expect(isRecord([1, 2, 3])).toBe(false);
+  });
+});
+
+describe('isStringMap()', () => {
+  it('returns true for empty objects', () => {
+    expect(isStringMap({})).toBe(true);
+  });
+
+  it('returns true for objects whose every own value is a string', () => {
+    expect(isStringMap({ a: 'b' })).toBe(true);
+    expect(isStringMap({ a: 'b', c: 'd' })).toBe(true);
+  });
+
+  it('returns false when any own value is not a string', () => {
+    expect(isStringMap({ a: 1 })).toBe(false);
+    expect(isStringMap({ a: 'b', c: 2 })).toBe(false);
+    expect(isStringMap({ a: null })).toBe(false);
+    expect(isStringMap({ a: undefined })).toBe(false);
+    expect(isStringMap({ a: { b: 'c' } })).toBe(false);
+    expect(isStringMap({ a: ['b'] })).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(isStringMap(null)).toBe(false);
+    expect(isStringMap(undefined)).toBe(false);
+    expect(isStringMap([])).toBe(false);
+    expect(isStringMap(['a', 'b'])).toBe(false);
+    expect(isStringMap('foo')).toBe(false);
+    expect(isStringMap(42)).toBe(false);
+  });
+});
+
+describe('validateOptionalStringMap()', () => {
+  it('returns undefined when the value is absent', () => {
+    expect(validateOptionalStringMap(undefined, 'env')).toBeUndefined();
+    expect(validateOptionalStringMap(undefined, 'headers')).toBeUndefined();
+    expect(validateOptionalStringMap(undefined, 'environment')).toBeUndefined();
+    expect(
+      validateOptionalStringMap(undefined, 'http_headers'),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for env-aliased valid string maps', () => {
+    expect(validateOptionalStringMap({}, 'env')).toBeUndefined();
+    expect(validateOptionalStringMap({ A: '1' }, 'env')).toBeUndefined();
+    expect(
+      validateOptionalStringMap({ A: '1' }, 'environment'),
+    ).toBeUndefined();
+  });
+
+  it('returns the env reason for env-aliased invalid values', () => {
+    expect(validateOptionalStringMap([], 'env')).toBe(
+      'Expected string map for env.',
+    );
+    expect(validateOptionalStringMap('foo', 'env')).toBe(
+      'Expected string map for env.',
+    );
+    expect(validateOptionalStringMap({ A: 1 }, 'env')).toBe(
+      'Expected string map for env.',
+    );
+    expect(validateOptionalStringMap({ A: 1 }, 'environment')).toBe(
+      'Expected string map for env.',
+    );
+  });
+
+  it('returns undefined for headers-aliased valid string maps', () => {
+    expect(validateOptionalStringMap({}, 'headers')).toBeUndefined();
+    expect(validateOptionalStringMap({ A: '1' }, 'headers')).toBeUndefined();
+    expect(
+      validateOptionalStringMap({ A: '1' }, 'http_headers'),
+    ).toBeUndefined();
+  });
+
+  it('returns the headers reason for headers-aliased invalid values', () => {
+    expect(validateOptionalStringMap([], 'headers')).toBe(
+      'Expected string map for headers.',
+    );
+    expect(validateOptionalStringMap({ A: 1 }, 'headers')).toBe(
+      'Expected string map for headers.',
+    );
+    expect(validateOptionalStringMap({ A: 1 }, 'http_headers')).toBe(
+      'Expected string map for headers.',
+    );
+  });
+
+  it('returns undefined for unrecognized field names (the helper only knows env / headers)', () => {
+    expect(validateOptionalStringMap([], 'somethingElse')).toBeUndefined();
+    expect(validateOptionalStringMap({ A: 1 }, 'cwd')).toBeUndefined();
+  });
+});
+
+describe('validateOptionalStringArray()', () => {
+  it('returns undefined when the value is absent', () => {
+    expect(validateOptionalStringArray(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for empty arrays (empty is valid)', () => {
+    expect(validateOptionalStringArray([])).toBeUndefined();
+  });
+
+  it('returns undefined for populated string arrays', () => {
+    expect(validateOptionalStringArray(['a'])).toBeUndefined();
+    expect(validateOptionalStringArray(['a', 'b', 'c'])).toBeUndefined();
+  });
+
+  it('returns the args reason for non-array values', () => {
+    expect(validateOptionalStringArray('foo')).toBe(
+      'Expected string array for args.',
+    );
+    expect(validateOptionalStringArray({})).toBe(
+      'Expected string array for args.',
+    );
+    expect(validateOptionalStringArray(null)).toBe(
+      'Expected string array for args.',
+    );
+  });
+
+  it('returns the args reason when any array entry is not a string', () => {
+    expect(validateOptionalStringArray([1, 2])).toBe(
+      'Expected string array for args.',
+    );
+    expect(validateOptionalStringArray(['a', 1])).toBe(
+      'Expected string array for args.',
+    );
+    expect(validateOptionalStringArray(['a', null])).toBe(
+      'Expected string array for args.',
+    );
+  });
+});
+
+describe('normalizeOptionalArgs()', () => {
+  it('returns undefined when the value is absent', () => {
+    expect(normalizeOptionalArgs(undefined)).toBeUndefined();
+  });
+
+  it('returns a fresh mutable string[] for valid string arrays', () => {
+    const out = normalizeOptionalArgs(['-y', 'pkg']);
+    expect(out).toEqual(['-y', 'pkg']);
+    // The return is a real string[] (not a readonly tuple).
+    expect(Array.isArray(out)).toBe(true);
+    if (Array.isArray(out)) {
+      out.push('extra');
+      expect(out).toEqual(['-y', 'pkg', 'extra']);
+    }
+  });
+
+  it('preserves empty arrays as [] (does not collapse to undefined)', () => {
+    const out = normalizeOptionalArgs([]);
+    expect(out).toEqual([]);
+    expect(out).not.toBeUndefined();
+  });
+
+  it('returns a fresh copy, not the same reference (readonly input handling)', () => {
+    const input: readonly string[] = ['-y', 'pkg'] as const;
+    const out = normalizeOptionalArgs(input);
+    expect(out).toEqual(['-y', 'pkg']);
+    if (Array.isArray(out)) {
+      out.push('extra');
+      expect(input).toEqual(['-y', 'pkg']);
+    }
+  });
+
+  it('does not trim whitespace-only strings (byte-exact equality, B1 contract)', () => {
+    expect(normalizeOptionalArgs(['  '])).toEqual(['  ']);
+    expect(normalizeOptionalArgs(['  ', 'a'])).toEqual(['  ', 'a']);
+  });
+
+  it('returns the args reason for non-array values', () => {
+    expect(normalizeOptionalArgs('foo')).toBe(
+      'Expected string array for args.',
+    );
+    expect(normalizeOptionalArgs({})).toBe('Expected string array for args.');
+    expect(normalizeOptionalArgs(null)).toBe('Expected string array for args.');
+  });
+
+  it('returns the args reason when any array entry is not a string', () => {
+    expect(normalizeOptionalArgs([1, 2])).toBe(
+      'Expected string array for args.',
+    );
+    expect(normalizeOptionalArgs(['a', 1])).toBe(
+      'Expected string array for args.',
+    );
+  });
+});
+
+describe('normalizeOptionalEnv()', () => {
+  it('returns undefined when the value is absent', () => {
+    expect(normalizeOptionalEnv(undefined)).toBeUndefined();
+  });
+
+  it('returns a fresh mutable map for valid string maps', () => {
+    const out = normalizeOptionalEnv({ A: '1' });
+    expect(out).toEqual({ A: '1' });
+    if (out && typeof out === 'object') {
+      out['B'] = '2';
+      expect(out).toEqual({ A: '1', B: '2' });
+    }
+  });
+
+  it('preserves empty maps as {} (does not collapse to undefined)', () => {
+    const out = normalizeOptionalEnv({});
+    expect(out).toEqual({});
+    expect(out).not.toBeUndefined();
+  });
+
+  it('returns a fresh copy, not the same reference', () => {
+    const input = { A: '1' };
+    const out = normalizeOptionalEnv(input);
+    expect(out).not.toBe(input);
+    expect(out).toEqual(input);
+  });
+
+  it('does not trim whitespace-only string values (byte-exact equality)', () => {
+    expect(normalizeOptionalEnv({ K: '  ' })).toEqual({ K: '  ' });
+  });
+
+  it('returns the env reason for non-map values', () => {
+    expect(normalizeOptionalEnv([])).toBe('Expected string map for env.');
+    expect(normalizeOptionalEnv('foo')).toBe('Expected string map for env.');
+    expect(normalizeOptionalEnv(null)).toBe('Expected string map for env.');
+  });
+
+  it('returns the env reason when any value is not a string', () => {
+    expect(normalizeOptionalEnv({ A: 1 })).toBe('Expected string map for env.');
+    expect(normalizeOptionalEnv({ A: '1', B: 2 })).toBe(
+      'Expected string map for env.',
+    );
+  });
+});
+
+describe('normalizeOptionalHeaders()', () => {
+  it('returns undefined when the value is absent', () => {
+    expect(normalizeOptionalHeaders(undefined)).toBeUndefined();
+  });
+
+  it('returns a fresh mutable map for valid string maps', () => {
+    const out = normalizeOptionalHeaders({ Authorization: 'token' });
+    expect(out).toEqual({ Authorization: 'token' });
+  });
+
+  it('preserves empty maps as {} (does not collapse to undefined)', () => {
+    const out = normalizeOptionalHeaders({});
+    expect(out).toEqual({});
+    expect(out).not.toBeUndefined();
+  });
+
+  it('returns a fresh copy, not the same reference', () => {
+    const input = { Authorization: 'token' };
+    const out = normalizeOptionalHeaders(input);
+    expect(out).not.toBe(input);
+    expect(out).toEqual(input);
+  });
+
+  it('does not trim whitespace-only string values (byte-exact equality)', () => {
+    expect(normalizeOptionalHeaders({ K: '  ' })).toEqual({ K: '  ' });
+  });
+
+  it('returns the headers reason for non-map values', () => {
+    expect(normalizeOptionalHeaders([])).toBe(
+      'Expected string map for headers.',
+    );
+    expect(normalizeOptionalHeaders('foo')).toBe(
+      'Expected string map for headers.',
+    );
+    expect(normalizeOptionalHeaders(null)).toBe(
+      'Expected string map for headers.',
+    );
+  });
+
+  it('returns the headers reason when any value is not a string', () => {
+    expect(normalizeOptionalHeaders({ A: 1 })).toBe(
+      'Expected string map for headers.',
+    );
+  });
+});

--- a/packages/agents/src/normalize-mcp-config.ts
+++ b/packages/agents/src/normalize-mcp-config.ts
@@ -1,0 +1,258 @@
+// Shared normalization helpers used by every per-agent MCP normalizer.
+//
+// These helpers convert each agent's native MCP config shape into the
+// canonical `OvertureMcpServer` union exposed by `@overture/config`. They
+// are intentionally narrow: the per-agent normalizer decides which
+// `type` to pick, and the helpers do the structural validation for the
+// optional `args` / `env` / `headers` fields. The helpers are total
+// (no thrown exceptions) and never mutate their input.
+//
+// Behavior rules (from the B2 plan):
+// - Omit optional fields only when the native field is `undefined`.
+//   Preserve explicitly present valid empty arrays/maps (`[]` / `{}`)
+//   because B1's `serverSettingsEqual` treats them as distinct from
+//   `undefined`.
+// - Copy readonly native arrays/maps into mutable canonical values
+//   BEFORE returning. The helper return types are mutable so the
+//   resulting `OvertureMcpServer` can be passed straight into a
+//   canonical constructor without an extra copy.
+// - Do NOT trim strings; whitespace-only strings are valid non-empty
+//   strings (B1 does byte-exact equality).
+// - All helpers are total: invalid values return the canonical reason
+//   string instead of throwing.
+import type { OvertureMcpServer } from '@overture/config';
+import type {
+  AgentMcpNormalizeHandler,
+  AgentMcpNormalizeReason,
+  AgentMcpReadResult,
+  AgentNormalizedMcpServer,
+} from './types.js';
+
+/**
+ * Runtime set of every `AgentMcpNormalizeReason` string. Useful for
+ * guards (e.g. `if (NORMALIZE_SHAPE_CONFLICT_REASONS.has(reason)) ...`)
+ * and for exhaustiveness checks inside per-agent normalizers. The
+ * union in `types.ts` is the source of truth for the strings; this
+ * constant mirrors that union at runtime so the value set can be
+ * inspected without re-listing the literals.
+ */
+export const NORMALIZE_SHAPE_CONFLICT_REASONS: ReadonlySet<AgentMcpNormalizeReason> =
+  new Set<AgentMcpNormalizeReason>([
+    'Expected server entry to be an object.',
+    'Stdio command is missing or empty.',
+    'Remote url is missing or empty.',
+    'Server declares both stdio command and remote url.',
+    'Server declares neither stdio command nor remote url.',
+    'Expected string array for args.',
+    'Expected string map for env.',
+    'Expected string map for headers.',
+    'Unsupported MCP server transport type.',
+  ]);
+
+/**
+ * Wrap a canonical `OvertureMcpServer` as a successful normalization
+ * result. Per-agent normalizers return a `Readonly<Record<string,
+ * AgentNormalizedMcpServer>>` keyed by server name; this helper builds
+ * the success arm.
+ */
+export function normalized(
+  server: OvertureMcpServer,
+): AgentNormalizedMcpServer {
+  return { state: 'normalized', server };
+}
+
+/**
+ * Build a shape-conflict result carrying the canonical reason string.
+ * The reason union is enforced by the `AgentMcpNormalizeReason` type
+ * so callers cannot pass an arbitrary string.
+ */
+export function shapeConflict(
+  reason: AgentMcpNormalizeReason,
+): AgentNormalizedMcpServer {
+  return { state: 'shape-conflict', reason };
+}
+
+/**
+ * Adapt a typed per-agent normalizer to the registry's non-generic
+ * `AgentMcpNormalizeHandler<unknown>` slot. The cast is sound because
+ * `AgentMcpReadResult<TConfig>` is covariant in `TConfig` for the
+ * shape the normalizer reads (the normalizer only inspects the typed
+ * `config` field) and the registry invokes the handler through the
+ * `unknown` slot without re-narrowing.
+ *
+ * Keeping the cast on the adapter (not on the per-agent file) means
+ * every typed normalizer calls `asRegistryNormalizeHandler(myHandler)`
+ * at the call site and the narrowing happens in one well-tested
+ * place. The registry stays non-generic; per-agent types stay
+ * precise.
+ */
+export function asRegistryNormalizeHandler<TConfig>(
+  handler: AgentMcpNormalizeHandler<TConfig>,
+): AgentMcpNormalizeHandler<unknown> {
+  return (input) => handler(input as AgentMcpReadResult<TConfig>);
+}
+
+/**
+ * Type guard: true for non-null, non-array objects. Used to gate
+ * the `args` / `env` / `headers` validators before they look at
+ * own-property values.
+ */
+export function isRecord(
+  value: unknown,
+): value is Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Type guard: true for plain objects where every own enumerable
+ * value is a string. Empty objects are valid string maps. Arrays,
+ * `null`, and primitives return false. Symbol keys are ignored
+ * (`Object.keys` returns own string keys only); MCP config files
+ * don't use symbol-keyed maps, so this is safe in practice.
+ */
+export function isStringMap(
+  value: unknown,
+): value is Readonly<Record<string, string>> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  for (const key of Object.keys(value)) {
+    if (typeof value[key] !== 'string') {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Type guard: true for arrays whose every entry is a string. Used by
+ * the args validator and normalizer. Accepts both mutable `string[]`
+ * and readonly `readonly string[]` shapes; both are valid native
+ * MCP arg vectors.
+ */
+function isStringArray(value: unknown): value is readonly string[] {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Validate an optional string-map field (env / headers). Returns
+ * `undefined` when the value is absent or is a valid string map;
+ * returns the canonical reason string for the named field when the
+ * value is present but not a string map.
+ *
+ * The helper recognizes the four field-name aliases used across the
+ * supported agents' native shapes:
+ * - `'env' | 'environment'` → `'Expected string map for env.'`
+ * - `'headers' | 'http_headers'` → `'Expected string map for headers.'`
+ *
+ * For any other field name the helper returns `undefined` (it only
+ * knows the env / headers reason strings). Per-agent normalizers
+ * that need to validate a different field should branch on the
+ * field name before calling this helper.
+ */
+export function validateOptionalStringMap(
+  value: unknown,
+  field: string,
+): AgentMcpNormalizeReason | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (field === 'env' || field === 'environment') {
+    return isStringMap(value) ? undefined : 'Expected string map for env.';
+  }
+  if (field === 'headers' || field === 'http_headers') {
+    return isStringMap(value) ? undefined : 'Expected string map for headers.';
+  }
+  return undefined;
+}
+
+/**
+ * Validate an optional string-array field (args). Returns
+ * `undefined` when the value is absent or is a valid string array;
+ * returns the canonical reason string when the value is present but
+ * not a string array. Empty arrays are valid (B1 distinguishes
+ * `[]` from `undefined`).
+ */
+export function validateOptionalStringArray(
+  value: unknown,
+): AgentMcpNormalizeReason | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return isStringArray(value) ? undefined : 'Expected string array for args.';
+}
+
+/**
+ * Normalize an optional args field. Returns `undefined` when absent;
+ * a fresh mutable `string[]` copy when present and valid; the
+ * canonical reason string when present but not a string array.
+ *
+ * Empty arrays are preserved as empty `[]` (not collapsed to
+ * `undefined`) so the resulting `OvertureMcpServer.args` is
+ * byte-exact equal to the native value under B1's
+ * `serverSettingsEqual`. The return is always a fresh mutable
+ * `string[]` so callers can mutate it without affecting the
+ * native shape.
+ */
+export function normalizeOptionalArgs(
+  value: unknown,
+): string[] | undefined | AgentMcpNormalizeReason {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isStringArray(value)) {
+    return 'Expected string array for args.';
+  }
+  return [...value];
+}
+
+/**
+ * Normalize an optional env field. Returns `undefined` when absent;
+ * a fresh mutable `Record<string, string>` copy when present and
+ * valid; the canonical reason string when present but not a string
+ * map.
+ *
+ * Empty maps are preserved as empty `{}` (not collapsed to
+ * `undefined`) for the same B1 equality reason as `args`. The
+ * return is always a fresh mutable map so callers can mutate it
+ * without affecting the native shape.
+ */
+export function normalizeOptionalEnv(
+  value: unknown,
+): Record<string, string> | undefined | AgentMcpNormalizeReason {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isStringMap(value)) {
+    return 'Expected string map for env.';
+  }
+  return { ...value };
+}
+
+/**
+ * Normalize an optional headers field. Same contract as
+ * `normalizeOptionalEnv` but with the headers-specific reason
+ * string (`'Expected string map for headers.'`). Per-agent
+ * normalizers that read a `headers` (or `http_headers`) field
+ * from a native MCP config call this helper to validate and copy
+ * in one step.
+ */
+export function normalizeOptionalHeaders(
+  value: unknown,
+): Record<string, string> | undefined | AgentMcpNormalizeReason {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isStringMap(value)) {
+    return 'Expected string map for headers.';
+  }
+  return { ...value };
+}

--- a/packages/agents/src/normalize-openai-codex.spec.ts
+++ b/packages/agents/src/normalize-openai-codex.spec.ts
@@ -1,0 +1,367 @@
+// Tests for the per-agent MCP normalizer in `openai-codex.ts`.
+//
+// Group order matches the plan's per-agent scenario list:
+//   - happy path stdio + remote
+//   - empty explicit fields preserved
+//   - read-result guards (parseError, config null, mcp_servers absent, non-object)
+//   - per-server: non-object, both keys, neither key, empty command
+//   - per-server: bad args, bad env, bad http_headers
+//   - per-server: whitespace-only command is non-empty
+//   - ignored Codex extension fields (env_vars, cwd, timeouts, oauth, etc.)
+import { describe, expect, it } from 'vitest';
+import type { AgentMcpReadResult } from './types.js';
+import {
+  normalizeOpenAICodexMcpServers,
+  type OpenAICodexMcpConfig,
+} from './openai-codex.js';
+
+type CodexInput = AgentMcpReadResult<OpenAICodexMcpConfig>;
+
+function cxInput(
+  config: unknown,
+  extras: { parseError?: string } = {},
+): CodexInput {
+  return {
+    config: config as OpenAICodexMcpConfig | null,
+    nonEmpty: config !== null,
+    ...extras,
+  };
+}
+
+describe('normalizeOpenAICodexMcpServers', () => {
+  it('happy path: stdio + remote entries with valid args/env/http_headers', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: {
+          local_one: {
+            command: 'npx',
+            args: ['pkg', '--flag'],
+            env: { NODE_ENV: 'production' },
+          },
+          remote_one: {
+            url: 'https://mcp.example.com',
+            http_headers: { Auth: 'Bearer x' },
+          },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      local_one: {
+        state: 'normalized',
+        server: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['pkg', '--flag'],
+          env: { NODE_ENV: 'production' },
+        },
+      },
+      remote_one: {
+        state: 'normalized',
+        server: {
+          type: 'remote',
+          url: 'https://mcp.example.com',
+          headers: { Auth: 'Bearer x' },
+        },
+      },
+    });
+  });
+
+  it('preserves explicit empty args as []', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { empty_args: { command: 'noop', args: [] } },
+      }),
+    );
+    expect(result).toEqual({
+      empty_args: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'noop', args: [] },
+      },
+    });
+  });
+
+  it('preserves explicit empty env as {}', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { empty_env: { command: 'noop', env: {} } },
+      }),
+    );
+    expect(result).toEqual({
+      empty_env: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'noop', env: {} },
+      },
+    });
+  });
+
+  it('omits args/env keys when native fields are absent', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { bare: { command: 'noop' } },
+      }),
+    );
+    expect(result).toEqual({
+      bare: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'noop' },
+      },
+    });
+  });
+
+  it('omits headers key when native http_headers is absent', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { bare: { url: 'https://mcp.example.com' } },
+      }),
+    );
+    expect(result).toEqual({
+      bare: {
+        state: 'normalized',
+        server: { type: 'remote', url: 'https://mcp.example.com' },
+      },
+    });
+  });
+
+  it('returns {} when config is null', () => {
+    expect(normalizeOpenAICodexMcpServers(cxInput(null))).toEqual({});
+  });
+
+  it('returns {} when parseError is set', () => {
+    expect(
+      normalizeOpenAICodexMcpServers(
+        cxInput(
+          { mcp_servers: { x: { command: 'a' } } },
+          { parseError: 'parse failed' },
+        ),
+      ),
+    ).toEqual({});
+  });
+
+  it('returns {} when mcp_servers is absent', () => {
+    expect(normalizeOpenAICodexMcpServers(cxInput({}))).toEqual({});
+  });
+
+  it('returns {} when mcp_servers is an array', () => {
+    expect(
+      normalizeOpenAICodexMcpServers(
+        cxInput({
+          mcp_servers: [] as unknown as Record<string, unknown>,
+        }),
+      ),
+    ).toEqual({});
+  });
+
+  it('returns {} when mcp_servers is a string', () => {
+    expect(
+      normalizeOpenAICodexMcpServers(
+        cxInput({
+          mcp_servers: 'not a map' as unknown as Record<string, unknown>,
+        }),
+      ),
+    ).toEqual({});
+  });
+
+  it('per-server: non-object entry returns shape-conflict', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: {
+          bad: 'not an object' as unknown as Record<string, unknown>,
+        },
+      }),
+    );
+    expect(result['bad']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected server entry to be an object.',
+    });
+  });
+
+  it('per-server: both command and url present returns both-keys reason', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { conflict: { command: 'npx', url: 'https://x' } },
+      }),
+    );
+    expect(result['conflict']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Server declares both stdio command and remote url.',
+    });
+  });
+
+  it('per-server: both command (empty) and url present still returns both-keys reason', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { conflict: { command: '', url: 'https://x' } },
+      }),
+    );
+    expect(result['conflict']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Server declares both stdio command and remote url.',
+    });
+  });
+
+  it('per-server: both url (empty) and command present still returns both-keys reason', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { conflict: { url: '', command: 'noop' } },
+      }),
+    );
+    expect(result['conflict']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Server declares both stdio command and remote url.',
+    });
+  });
+
+  it('per-server: neither command nor url present returns neither-keys reason', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { empty: { args: ['a'] } },
+      }),
+    );
+    expect(result['empty']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Server declares neither stdio command nor remote url.',
+    });
+  });
+
+  it('per-server: empty string command returns missing-or-empty reason', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { empty_cmd: { command: '' } },
+      }),
+    );
+    expect(result['empty_cmd']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Stdio command is missing or empty.',
+    });
+  });
+
+  it('per-server: empty string url returns missing-or-empty reason', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { empty_url: { url: '' } },
+      }),
+    );
+    expect(result['empty_url']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Remote url is missing or empty.',
+    });
+  });
+
+  it('per-server: whitespace-only command is non-empty and normalizes', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { ws_cmd: { command: ' ' } },
+      }),
+    );
+    expect(result['ws_cmd']).toEqual({
+      state: 'normalized',
+      server: { type: 'stdio', command: ' ' },
+    });
+  });
+
+  it('per-server: bad args (non-array) returns args reason', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: {
+          bad_args: { command: 'x', args: 42 as unknown as string[] },
+        },
+      }),
+    );
+    expect(result['bad_args']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string array for args.',
+    });
+  });
+
+  it('per-server: bad env (non-string value) returns env reason', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: {
+          bad_env: { command: 'x', env: { KEY: 42 as unknown as string } },
+        },
+      }),
+    );
+    expect(result['bad_env']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string map for env.',
+    });
+  });
+
+  it('per-server: bad http_headers (non-string value) returns headers reason', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: {
+          bad_headers: {
+            url: 'https://x',
+            http_headers: { K: 1 as unknown as string },
+          },
+        },
+      }),
+    );
+    expect(result['bad_headers']).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string map for headers.',
+    });
+  });
+
+  it('ignores stdio extension field `enabled: false` (still normalizes)', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: { disabled: { command: 'noop', enabled: false } },
+      }),
+    );
+    expect(result).toEqual({
+      disabled: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'noop' },
+      },
+    });
+  });
+
+  it('ignores every Codex stdio extension field (timeouts, oauth, cwd, env_vars, tools, scopes, required)', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: {
+          noisy: {
+            command: 'noop',
+            startup_timeout_sec: 30,
+            tool_timeout_sec: 60,
+            enabled_tools: ['x'],
+            disabled_tools: ['y'],
+            env_vars: ['FOO'],
+            cwd: '/tmp',
+            scopes: ['s'],
+            oauth_resource: 'https://x',
+            required: true,
+          },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      noisy: {
+        state: 'normalized',
+        server: { type: 'stdio', command: 'noop' },
+      },
+    });
+  });
+
+  it('ignores remote extension fields bearer_token_env_var + env_http_headers (no canonical headers)', () => {
+    const result = normalizeOpenAICodexMcpServers(
+      cxInput({
+        mcp_servers: {
+          tokenized: {
+            url: 'https://mcp.example.com',
+            bearer_token_env_var: 'TOKEN',
+            env_http_headers: { X: 'Y' },
+          },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      tokenized: {
+        state: 'normalized',
+        server: { type: 'remote', url: 'https://mcp.example.com' },
+      },
+    });
+  });
+});

--- a/packages/agents/src/normalize-opencode.spec.ts
+++ b/packages/agents/src/normalize-opencode.spec.ts
@@ -1,0 +1,425 @@
+// Tests for the OpenCode per-agent MCP normalizer.
+//
+// OpenCode is the only supported agent whose native MCP config uses a
+// top-level `mcp` map (not `mcpServers`) and where each entry is a
+// discriminated union on `type: 'local' | 'remote'`. These tests pin
+// the native -> canonical mapping for both arms plus every guarded
+// failure mode enumerated in the B2 plan Task 4 (lines 412-417).
+import { describe, expect, it } from 'vitest';
+import type { OpenCodeMcpConfig } from './opencode.js';
+import { normalizeOpenCodeMcpServers } from './opencode.js';
+import type { AgentMcpReadResult } from './types.js';
+
+function makeRead(
+  config: OpenCodeMcpConfig | null,
+  extras: { parseError?: string } = {},
+): AgentMcpReadResult<OpenCodeMcpConfig> {
+  return {
+    config,
+    nonEmpty: config !== null && config.mcp !== undefined,
+    ...extras,
+  };
+}
+
+describe('normalizeOpenCodeMcpServers() - read-result guards', () => {
+  it('returns {} when input.parseError is set', () => {
+    const input = makeRead(null, { parseError: 'bad json' });
+    expect(normalizeOpenCodeMcpServers(input)).toEqual({});
+  });
+
+  it('returns {} when input.config is null', () => {
+    expect(normalizeOpenCodeMcpServers(makeRead(null))).toEqual({});
+  });
+
+  it('returns {} when the top-level mcp key is absent', () => {
+    const input = makeRead({});
+    expect(normalizeOpenCodeMcpServers(input)).toEqual({});
+  });
+
+  it('returns {} when the top-level mcp value is not an object (array)', () => {
+    const input = makeRead({
+      mcp: [] as unknown as OpenCodeMcpConfig['mcp'],
+    });
+    expect(normalizeOpenCodeMcpServers(input)).toEqual({});
+  });
+
+  it('returns {} when the top-level mcp value is a primitive (string)', () => {
+    const input = makeRead({
+      mcp: 'nope' as unknown as OpenCodeMcpConfig['mcp'],
+    });
+    expect(normalizeOpenCodeMcpServers(input)).toEqual({});
+  });
+
+  it('returns {} when the top-level mcp value is null', () => {
+    const input = makeRead({
+      mcp: null as unknown as OpenCodeMcpConfig['mcp'],
+    });
+    expect(normalizeOpenCodeMcpServers(input)).toEqual({});
+  });
+});
+
+describe('normalizeOpenCodeMcpServers() - per-server guards', () => {
+  it('reports shape conflict for a per-server entry that is not an object (string)', () => {
+    const input = makeRead({
+      mcp: {
+        bad: 'string',
+      } as unknown as OpenCodeMcpConfig['mcp'],
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result).toEqual({
+      bad: {
+        state: 'shape-conflict',
+        reason: 'Expected server entry to be an object.',
+      },
+    });
+  });
+
+  it('reports shape conflict for a per-server entry that is an array', () => {
+    const input = makeRead({
+      mcp: { bad: [] } as unknown as OpenCodeMcpConfig['mcp'],
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.bad).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected server entry to be an object.',
+    });
+  });
+
+  it("reports shape conflict for an unsupported discriminator value ('stdio')", () => {
+    const input = makeRead({
+      mcp: {
+        bad: {
+          type: 'stdio' as unknown as 'local',
+          command: ['npx'],
+        },
+      } as unknown as OpenCodeMcpConfig['mcp'],
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.bad).toEqual({
+      state: 'shape-conflict',
+      reason: 'Unsupported MCP server transport type.',
+    });
+  });
+
+  it('reports shape conflict when the discriminator is missing entirely', () => {
+    const input = makeRead({
+      mcp: {
+        bad: {
+          command: ['npx'],
+        },
+      } as unknown as OpenCodeMcpConfig['mcp'],
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.bad).toEqual({
+      state: 'shape-conflict',
+      reason: 'Unsupported MCP server transport type.',
+    });
+  });
+});
+
+describe('normalizeOpenCodeMcpServers() - local arm', () => {
+  it('happy path: command vector splits into command + args, no env', () => {
+    const input = makeRead({
+      mcp: {
+        pkg: {
+          type: 'local',
+          command: ['npx', 'pkg', '--flag'],
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.pkg).toEqual({
+      state: 'normalized',
+      server: { type: 'stdio', command: 'npx', args: ['pkg', '--flag'] },
+    });
+  });
+
+  it('happy path with env: environment maps to canonical env', () => {
+    const input = makeRead({
+      mcp: {
+        server: {
+          type: 'local',
+          command: ['node', 'server.js'],
+          environment: { NODE_ENV: 'production' },
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.server).toEqual({
+      state: 'normalized',
+      server: {
+        type: 'stdio',
+        command: 'node',
+        args: ['server.js'],
+        env: { NODE_ENV: 'production' },
+      },
+    });
+  });
+
+  it('single-element command vector produces canonical stdio with no args', () => {
+    const input = makeRead({
+      mcp: {
+        only: {
+          type: 'local',
+          command: ['only'],
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.only).toEqual({
+      state: 'normalized',
+      server: { type: 'stdio', command: 'only' },
+    });
+    const server =
+      result.only?.state === 'normalized' ? result.only.server : null;
+    expect(server).not.toBeNull();
+    if (server !== null) {
+      expect('args' in server).toBe(false);
+    }
+  });
+
+  it('empty command array produces a shape conflict', () => {
+    const input = makeRead({
+      mcp: {
+        bad: { type: 'local', command: [] },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.bad).toEqual({
+      state: 'shape-conflict',
+      reason: 'Stdio command is missing or empty.',
+    });
+  });
+
+  it('non-array command produces a shape conflict', () => {
+    const input = makeRead({
+      mcp: {
+        bad: {
+          type: 'local',
+          command: 'npx' as unknown as readonly string[],
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.bad).toEqual({
+      state: 'shape-conflict',
+      reason: 'Stdio command is missing or empty.',
+    });
+  });
+
+  it('non-string environment map produces the env reason', () => {
+    const input = makeRead({
+      mcp: {
+        bad: {
+          type: 'local',
+          command: ['npx'],
+          environment: { KEY: 42 } as unknown as Record<string, string>,
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.bad).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string map for env.',
+    });
+  });
+
+  it('omits env when environment is undefined', () => {
+    const input = makeRead({
+      mcp: {
+        pkg: {
+          type: 'local',
+          command: ['npx', 'pkg'],
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    const server =
+      result.pkg?.state === 'normalized' ? result.pkg.server : null;
+    expect(server).not.toBeNull();
+    if (server !== null) {
+      expect('env' in server).toBe(false);
+    }
+  });
+
+  it('ignores enabled: false (not a shape conflict; field is dropped)', () => {
+    const input = makeRead({
+      mcp: {
+        pkg: {
+          type: 'local',
+          command: ['npx', 'pkg'],
+          enabled: false,
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.pkg).toEqual({
+      state: 'normalized',
+      server: { type: 'stdio', command: 'npx', args: ['pkg'] },
+    });
+  });
+
+  it('ignores timeout and oauth (fields are dropped from the canonical output)', () => {
+    const input = makeRead({
+      mcp: {
+        pkg: {
+          type: 'local',
+          command: ['npx', 'pkg'],
+          timeout: 5000,
+          oauth: { clientId: 'x' },
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    const server =
+      result.pkg?.state === 'normalized' ? result.pkg.server : null;
+    expect(server).not.toBeNull();
+    if (server !== null) {
+      expect('timeout' in server).toBe(false);
+      expect('oauth' in server).toBe(false);
+      expect('enabled' in server).toBe(false);
+    }
+  });
+});
+
+describe('normalizeOpenCodeMcpServers() - remote arm', () => {
+  it('happy path: url and headers preserved', () => {
+    const input = makeRead({
+      mcp: {
+        upstream: {
+          type: 'remote',
+          url: 'https://mcp.example.com',
+          headers: { Auth: 'Bearer x' },
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.upstream).toEqual({
+      state: 'normalized',
+      server: {
+        type: 'remote',
+        url: 'https://mcp.example.com',
+        headers: { Auth: 'Bearer x' },
+      },
+    });
+  });
+
+  it('happy path without headers: no headers key in canonical output', () => {
+    const input = makeRead({
+      mcp: {
+        upstream: {
+          type: 'remote',
+          url: 'https://mcp.example.com',
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    const server =
+      result.upstream?.state === 'normalized' ? result.upstream.server : null;
+    expect(server).not.toBeNull();
+    if (server !== null) {
+      expect('headers' in server).toBe(false);
+    }
+  });
+
+  it('empty url produces a shape conflict', () => {
+    const input = makeRead({
+      mcp: {
+        bad: {
+          type: 'remote',
+          url: '',
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.bad).toEqual({
+      state: 'shape-conflict',
+      reason: 'Remote url is missing or empty.',
+    });
+  });
+
+  it('missing url key produces a shape conflict', () => {
+    const input = makeRead({
+      mcp: {
+        bad: {
+          type: 'remote',
+        },
+      } as unknown as OpenCodeMcpConfig['mcp'],
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.bad).toEqual({
+      state: 'shape-conflict',
+      reason: 'Remote url is missing or empty.',
+    });
+  });
+
+  it('non-string headers map produces the headers reason', () => {
+    const input = makeRead({
+      mcp: {
+        bad: {
+          type: 'remote',
+          url: 'https://mcp.example.com',
+          headers: { K: 1 } as unknown as Record<string, string>,
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.bad).toEqual({
+      state: 'shape-conflict',
+      reason: 'Expected string map for headers.',
+    });
+  });
+
+  it('ignores enabled, timeout, and oauth on remote entries', () => {
+    const input = makeRead({
+      mcp: {
+        upstream: {
+          type: 'remote',
+          url: 'https://mcp.example.com',
+          enabled: true,
+          timeout: 1000,
+          oauth: { clientId: 'y' },
+        },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    const server =
+      result.upstream?.state === 'normalized' ? result.upstream.server : null;
+    expect(server).not.toBeNull();
+    if (server !== null) {
+      expect('enabled' in server).toBe(false);
+      expect('timeout' in server).toBe(false);
+      expect('oauth' in server).toBe(false);
+    }
+  });
+});
+
+describe('normalizeOpenCodeMcpServers() - multi-entry mixes', () => {
+  it('processes a config with both local and remote entries independently', () => {
+    const input = makeRead({
+      mcp: {
+        alpha: { type: 'local', command: ['npx', 'a'] },
+        beta: { type: 'remote', url: 'https://b.example.com' },
+        gamma: { type: 'local', command: [] },
+      },
+    });
+    const result = normalizeOpenCodeMcpServers(input);
+    expect(result.alpha).toEqual({
+      state: 'normalized',
+      server: { type: 'stdio', command: 'npx', args: ['a'] },
+    });
+    expect(result.beta).toEqual({
+      state: 'normalized',
+      server: { type: 'remote', url: 'https://b.example.com' },
+    });
+    expect(result.gamma).toEqual({
+      state: 'shape-conflict',
+      reason: 'Stdio command is missing or empty.',
+    });
+  });
+
+  it('returns an empty object for an empty mcp map', () => {
+    const input = makeRead({ mcp: {} });
+    expect(normalizeOpenCodeMcpServers(input)).toEqual({});
+  });
+});

--- a/packages/agents/src/openai-codex.ts
+++ b/packages/agents/src/openai-codex.ts
@@ -1,11 +1,22 @@
 // OpenAI Codex agent definition.
+import {
+  asRegistryNormalizeHandler,
+  isRecord,
+  normalized,
+  normalizeOptionalArgs,
+  normalizeOptionalEnv,
+  normalizeOptionalHeaders,
+  shapeConflict,
+} from './normalize-mcp-config.js';
 import { parseTomlMcpServerMap } from './parse-mcp-servers.js';
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import { defineAgent } from './define-agent.js';
+import type { OvertureMcpServer } from '@overture/config';
 import type {
   AgentDefinition,
   AgentMcpParseServersHandler,
   AgentMcpReadResult,
+  AgentNormalizedMcpServer,
   StringMap,
 } from './types.js';
 import type { PathResolutionContext } from './types.js';
@@ -13,6 +24,101 @@ import type { PathResolutionContext } from './types.js';
 export const parseOpenAICodexMcpServers: AgentMcpParseServersHandler = (
   resolvedPath,
 ) => parseTomlMcpServerMap(resolvedPath, 'mcp_servers');
+
+/**
+ * Normalize an OpenAI Codex MCP config read result into the canonical
+ * `OvertureMcpServer` shape the scan matrix consumes.
+ *
+ * Codex has no explicit `type` discriminator: the transport is inferred
+ * from key presence on the per-server entry. `'command' in entry` means
+ * stdio; `'url' in entry` means remote. When both or neither key is
+ * present the entry is a shape conflict. Codex-specific extension fields
+ * (`env_vars`, `cwd`, `startup_timeout_sec`, `tool_timeout_sec`,
+ * `enabled_tools`, `disabled_tools`, `scopes`, `oauth_resource`,
+ * `required`, `enabled`, `bearer_token_env_var`, `env_http_headers`) are
+ * intentionally dropped: the canonical `OvertureMcpServer` union has no
+ * slot for them and the B1 scan matrix compares only canonical fields.
+ *
+ * Returns `{}` when the read result is `null`, has a `parseError`, is
+ * missing the top-level `mcp_servers` map, or has a non-object
+ * `mcp_servers` value (the registry uses the empty object to mean "no
+ * normalized entries to surface").
+ */
+export function normalizeOpenAICodexMcpServers(
+  input: AgentMcpReadResult<OpenAICodexMcpConfig>,
+): Readonly<Record<string, AgentNormalizedMcpServer>> {
+  if (input.parseError !== undefined) {
+    return {};
+  }
+  if (input.config === null) {
+    return {};
+  }
+  const mcpServers = input.config.mcp_servers;
+  if (mcpServers === undefined) {
+    return {};
+  }
+  if (!isRecord(mcpServers)) {
+    return {};
+  }
+  const out: Record<string, AgentNormalizedMcpServer> = {};
+  for (const name of Object.keys(mcpServers)) {
+    out[name] = normalizeOpenAICodexServerEntry(mcpServers[name]);
+  }
+  return out;
+}
+
+function normalizeOpenAICodexServerEntry(
+  entry: unknown,
+): AgentNormalizedMcpServer {
+  if (!isRecord(entry)) {
+    return shapeConflict('Expected server entry to be an object.');
+  }
+  const hasCommand = 'command' in entry;
+  const hasUrl = 'url' in entry;
+  if (hasCommand && hasUrl) {
+    return shapeConflict('Server declares both stdio command and remote url.');
+  }
+  if (!hasCommand && !hasUrl) {
+    return shapeConflict(
+      'Server declares neither stdio command nor remote url.',
+    );
+  }
+  if (hasCommand) {
+    const command = entry['command'];
+    if (typeof command !== 'string' || command.length === 0) {
+      return shapeConflict('Stdio command is missing or empty.');
+    }
+    const args = normalizeOptionalArgs(entry['args']);
+    if (typeof args === 'string') {
+      return shapeConflict(args);
+    }
+    const env = normalizeOptionalEnv(entry['env']);
+    if (typeof env === 'string') {
+      return shapeConflict(env);
+    }
+    const server: OvertureMcpServer = {
+      type: 'stdio',
+      command,
+      ...(args !== undefined ? { args } : {}),
+      ...(env !== undefined ? { env } : {}),
+    };
+    return normalized(server);
+  }
+  const url = entry['url'];
+  if (typeof url !== 'string' || url.length === 0) {
+    return shapeConflict('Remote url is missing or empty.');
+  }
+  const headers = normalizeOptionalHeaders(entry['http_headers']);
+  if (typeof headers === 'string') {
+    return shapeConflict(headers);
+  }
+  const server: OvertureMcpServer = {
+    type: 'remote',
+    url,
+    ...(headers !== undefined ? { headers } : {}),
+  };
+  return normalized(server);
+}
 
 export const openaiCodex: AgentDefinition = defineAgent({
   id: 'openai-codex',
@@ -59,6 +165,7 @@ export const openaiCodex: AgentDefinition = defineAgent({
   executableNames: ['codex'],
   mcp: {
     parseServers: parseOpenAICodexMcpServers,
+    normalize: asRegistryNormalizeHandler(normalizeOpenAICodexMcpServers),
   },
 });
 

--- a/packages/agents/src/opencode.ts
+++ b/packages/agents/src/opencode.ts
@@ -2,9 +2,21 @@
 import { parseOpenCodeMcpServerMap } from './parse-mcp-servers.js';
 import { readAgentMcpConfig } from './read-mcp-config.js';
 import { defineAgent } from './define-agent.js';
+import {
+  asRegistryNormalizeHandler,
+  isRecord,
+  normalizeOptionalArgs,
+  normalizeOptionalEnv,
+  normalizeOptionalHeaders,
+  normalized,
+  shapeConflict,
+} from './normalize-mcp-config.js';
+import type { OvertureMcpServer } from '@overture/config';
 import type {
   AgentDefinition,
+  AgentMcpNormalizeHandler,
   AgentMcpParseServersHandler,
+  AgentNormalizedMcpServer,
   OAuthConfig,
   StringMap,
   AgentMcpReadResult,
@@ -44,6 +56,110 @@ export type OpenCodeMcpServer =
 export const parseOpenCodeMcpServers: AgentMcpParseServersHandler = (
   resolvedPath,
 ) => parseOpenCodeMcpServerMap(resolvedPath);
+
+/**
+ * Normalize an OpenCode MCP config read result into the canonical
+ * `OvertureMcpServer` shape the scan matrix consumes.
+ *
+ * OpenCode is discriminator-driven: each server entry's `type` selects
+ * the transport. `'local'` requires a non-empty `command` array
+ * (argv[0] becomes the canonical `command`, argv[1..] becomes the
+ * optional canonical `args`); `'remote'` requires a non-empty `url`
+ * plus an optional `headers` map. OpenCode extension fields
+ * (`enabled`, `timeout`, `oauth`) are intentionally ignored because
+ * the canonical `OvertureMcpServer` union does not have a slot for
+ * them. Any other `type` value (including a missing `type` key)
+ * produces the canonical `'Unsupported MCP server transport type.'`
+ * reason.
+ *
+ * Returns `{}` when the read result is `null`, has a `parseError`, is
+ * missing the top-level `mcp` map, or has a non-object `mcp` value
+ * (the registry uses the empty object to mean "no normalized entries
+ * to surface" — there is no implicit error to render in that case).
+ */
+export const normalizeOpenCodeMcpServers: AgentMcpNormalizeHandler<
+  OpenCodeMcpConfig
+> = (input) => {
+  if (input.parseError !== undefined) {
+    return {};
+  }
+  if (input.config === null) {
+    return {};
+  }
+  const mcp = input.config.mcp;
+  if (mcp === undefined) {
+    return {};
+  }
+  if (!isRecord(mcp)) {
+    return {};
+  }
+
+  const out: Record<string, AgentNormalizedMcpServer> = {};
+  for (const name of Object.keys(mcp)) {
+    const entry = mcp[name];
+    if (!isRecord(entry)) {
+      out[name] = shapeConflict('Expected server entry to be an object.');
+      continue;
+    }
+
+    const entryType = entry['type'];
+
+    if (entryType === 'local') {
+      const command = entry['command'];
+      if (!Array.isArray(command) || command.length === 0) {
+        out[name] = shapeConflict('Stdio command is missing or empty.');
+        continue;
+      }
+      const canonical: OvertureMcpServer = {
+        type: 'stdio',
+        command: command[0] as string,
+      };
+      if (command.length > 1) {
+        const args = normalizeOptionalArgs(command.slice(1));
+        if (typeof args === 'string') {
+          out[name] = shapeConflict(args);
+          continue;
+        }
+        // `args` is a non-empty `string[]` here: `command.length > 1`
+        // guarantees `command.slice(1)` is non-empty, and the helper
+        // preserves non-empty arrays as `string[]` (not `undefined`).
+        canonical.args = args;
+      }
+      const env = normalizeOptionalEnv(entry['environment']);
+      if (typeof env === 'string') {
+        out[name] = shapeConflict(env);
+        continue;
+      }
+      if (env !== undefined) {
+        canonical.env = env;
+      }
+      out[name] = normalized(canonical);
+      continue;
+    }
+
+    if (entryType === 'remote') {
+      const url = entry['url'];
+      if (typeof url !== 'string' || url.length === 0) {
+        out[name] = shapeConflict('Remote url is missing or empty.');
+        continue;
+      }
+      const canonical: OvertureMcpServer = { type: 'remote', url };
+      const headers = normalizeOptionalHeaders(entry['headers']);
+      if (typeof headers === 'string') {
+        out[name] = shapeConflict(headers);
+        continue;
+      }
+      if (headers !== undefined) {
+        canonical.headers = headers;
+      }
+      out[name] = normalized(canonical);
+      continue;
+    }
+
+    out[name] = shapeConflict('Unsupported MCP server transport type.');
+  }
+  return out;
+};
 
 /**
  * Native OpenCode MCP config shape. The top-level `mcp` key holds a
@@ -154,6 +270,7 @@ export const opencode: AgentDefinition = defineAgent({
   executableNames: ['opencode'],
   mcp: {
     parseServers: parseOpenCodeMcpServers,
+    normalize: asRegistryNormalizeHandler(normalizeOpenCodeMcpServers),
   },
 });
 

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -3,6 +3,7 @@
 // from @overture/agents. The MCP config parser is internal (not exported from
 // index.ts); per-agent readers use it via the internal mcp-config-parser.
 import type { HostPlatform } from '@overture/os';
+import type { OvertureMcpServer } from '@overture/config';
 export type { HostPlatform };
 
 export type PlatformId =
@@ -147,6 +148,54 @@ export type AgentMcpWriteHandler = (
 ) => Promise<AgentMcpWriteResult>;
 
 /**
+ * Canonical reason a per-agent MCP server entry could not be normalized to
+ * `OvertureMcpServer`. The union is the contract shared by every agent's
+ * `normalize` handler; the `shape-conflict` arm of `AgentNormalizedMcpServer`
+ * is restricted to one of these strings so downstream renderers can surface
+ * a stable, human-readable message without inspecting the agent's native shape.
+ * Task 2's `NORMALIZE_SHAPE_CONFLICT_REASONS` constant re-uses this union.
+ */
+export type AgentMcpNormalizeReason =
+  | 'Expected server entry to be an object.'
+  | 'Stdio command is missing or empty.'
+  | 'Remote url is missing or empty.'
+  | 'Server declares both stdio command and remote url.'
+  | 'Server declares neither stdio command nor remote url.'
+  | 'Expected string array for args.'
+  | 'Expected string map for env.'
+  | 'Expected string map for headers.'
+  | 'Unsupported MCP server transport type.';
+
+/**
+ * Per-agent normalized server entry. The `normalized` arm carries a canonical
+ * `OvertureMcpServer` that the scan matrix compares against the canonical intent;
+ * the `shape-conflict` arm carries the human-readable reason the entry could not
+ * be normalized. This is the agents-local output type consumed by the scan
+ * matrix; the `state` discriminant aligns with the downstream consumer so
+ * scan matrix can consume the agents output as-is once the `server` field is set.
+ */
+export type AgentNormalizedMcpServer =
+  | {
+      readonly state: 'normalized';
+      readonly server: OvertureMcpServer;
+    }
+  | {
+      readonly state: 'shape-conflict';
+      readonly reason: AgentMcpNormalizeReason;
+    };
+
+/**
+ * Per-agent typed normalize handler. The `TConfig` type parameter is the agent's
+ * native MCP config shape (e.g. `ClaudeCodeMcpConfig`); the default of `unknown`
+ * matches the registry's heterogeneous non-generic slot. Per-agent normalizers
+ * expose a typed variant and adapt it to `unknown` via Task 2's
+ * `asRegistryNormalizeHandler<TConfig>()` helper at the call site.
+ */
+export type AgentMcpNormalizeHandler<TConfig = unknown> = (
+  input: AgentMcpReadResult<TConfig>,
+) => Readonly<Record<string, AgentNormalizedMcpServer>>;
+
+/**
  * Bundled MCP handlers exposed by an agent.
  *
  * `read` is always required. `write` is optional on the input shape
@@ -165,6 +214,17 @@ export interface AgentMcpHandlers {
    * The CLI calls this generically — no per-id string dispatch.
    */
   parseServers?: AgentMcpParseServersHandler;
+  /**
+   * Optional handler that converts an agent's native MCP config into the
+   * normalized `OvertureMcpServer` shape the scan matrix consumes. Agents
+   * whose native schema is rich enough to express every canonical field wire a
+   * typed normalizer; agents whose shape is too narrow omit it and rely on the
+   * shared "no entry" behavior. The CLI invokes this through the registry's
+   * non-generic `AgentMcpNormalizeHandler<unknown>` slot, so per-agent
+   * normalizers expose a typed variant and adapt it at the call site (Task 2
+   * introduces `asRegistryNormalizeHandler`).
+   */
+  normalize?: AgentMcpNormalizeHandler<unknown>;
 }
 
 /** Complete (non-optional) MCP handlers, as exposed on every exported `AgentDefinition`. */

--- a/packages/agents/tsconfig.lib.json
+++ b/packages/agents/tsconfig.lib.json
@@ -20,5 +20,8 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx"
+  ],
+  "references": [
+    { "path": "../config/tsconfig.lib.json" }
   ]
 }

--- a/packages/agents/tsconfig.lib.json
+++ b/packages/agents/tsconfig.lib.json
@@ -21,7 +21,5 @@
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx"
   ],
-  "references": [
-    { "path": "../config/tsconfig.lib.json" }
-  ]
+  "references": [{ "path": "../config/tsconfig.lib.json" }]
 }

--- a/packages/agents/tsconfig.spec.json
+++ b/packages/agents/tsconfig.spec.json
@@ -23,5 +23,8 @@
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx",
     "src/**/*.d.ts"
+  ],
+  "references": [
+    { "path": "../config/tsconfig.lib.json" }
   ]
 }

--- a/packages/agents/tsconfig.spec.json
+++ b/packages/agents/tsconfig.spec.json
@@ -24,7 +24,5 @@
     "src/**/*.spec.jsx",
     "src/**/*.d.ts"
   ],
-  "references": [
-    { "path": "../config/tsconfig.lib.json" }
-  ]
+  "references": [{ "path": "../config/tsconfig.lib.json" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,10 +2494,12 @@ __metadata:
 "@overture/agents@workspace:packages/agents":
   version: 0.0.0-use.local
   resolution: "@overture/agents@workspace:packages/agents"
+  dependencies:
+    "@overture/config": "workspace:*"
   languageName: unknown
   linkType: soft
 
-"@overture/config@workspace:packages/config":
+"@overture/config@workspace:*, @overture/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@overture/config@workspace:packages/config"
   dependencies:


### PR DESCRIPTION
## Summary

Adds `mcp.normalize` to the `@overture/agents` interface so each of the four supported CLI agents can convert its native MCP config shape into canonical `OvertureMcpServer` entries for B1 scan-matrix comparison.

* **Task 1**: Agents-local normalization contract in `packages/agents/src/types.ts` (`AgentMcpNormalizeReason`, `AgentNormalizedMcpServer`, `AgentMcpNormalizeHandler<TConfig>`) and safe package wiring (agents → `@overture/config` for `OvertureMcpServer`; NOT → `@overture/scan-matrix` to avoid a package cycle).
* **Task 2**: Shared normalization helpers in `packages/agents/src/normalize-mcp-config.ts` with exact deterministic shape-conflict reason strings, empty-field preservation, and `asRegistryNormalizeHandler<TConfig>()` adapter so per-agent typed normalizers wire into the non-generic `AgentMcpHandlers.normalize` slot.
* **Task 3**: Claude Code (inferred transport via key presence) and GitHub Copilot CLI (discriminator-driven transport: `type: "local" | "http"`).
* **Task 4**: OpenCode (discriminator-driven: `type: "local" | "remote"`; ignores `enabled` / `timeout` / `oauth`).
* **Task 5**: OpenAI Codex (inferred transport; `http_headers` → `headers`; ignores `bearer_token_env_var` / `env_http_headers` and all other Codex extensions).
* **Task 6**: Registry-level contract guard spec, corrected B2 doc section, full quality gates.

## Design decisions

* `mcp.parseServers` and `mcp.normalize` are separate functions; the display path stays in `parseServers`, the canonical path lives in `normalize`.
* Normalize is fed by typed native config (`AgentMcpReadResult<TConfig>`), not by the `parseServers` output, to avoid losing comparison fields like `headers` / `env`.
* Empty explicit `[]` / `{}` is preserved (B1 `serverSettingsEqual` treats them as distinct from `undefined`).
* Whitespace-only `command` / `url` strings are valid non-empty values (B1 byte-exact equality).
* `@overture/scan-matrix` does not become a dependency of `@overture/agents` (cycle: scan-matrix already imports `McpSupport` from agents).

## Scope

Only 4 agents in this PR: `claude-code`, `opencode`, `github-copilot-cli`, `openai-codex`. The 10 agents removed in PR #108 stay removed.

## Test surface

* 224 tests pass in `@overture/agents` (133 pre-Task-3 + 91 B2 additions).
* 67 tests pass in `@overture/scan-matrix` (B1 — unchanged).
* 87 tests pass in `@jander99/overture` (CLI).
* `yarn nx build @jander99/overture --skip-nx-cache` exits 0.
* `./node_modules/.bin/prettier --check .` exits 0.

## Pre-existing tsc warnings (not introduced by this PR)

`apps/cli/src/platforms/registry.spec.ts` and `apps/cli/src/platforms/types.ts` have pre-existing TS7006 / TS6305 errors in this worktree. Verified via `git stash` that the errors are independent of the B2 work. The B2-changed files (`packages/agents/src/**`) compile clean.

## Docs

`docs/overture-implementation-slices.md` B2 section updated to describe the agents-local output type, the `asRegistryNormalizeHandler` pattern, and the agents → config (not scan-matrix) dependency. Status: **completed**.

## Final Verification Wave

* F1 Plan Compliance — APPROVE
* F2 Code Quality — APPROVE
* F3 Real Manual QA — APPROVE
* F4 Scope Fidelity — APPROVE