### PR TITLE
feat(scan-matrix): B3 - classify MCP conflicts

### DIFF
--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -152,10 +152,31 @@ Rules:
 - Same server name with type/shape mismatch is a hard refuse.
 - Parse errors are hard refuses until the user fixes the source file.
 
+**Status: completed.**
+
 Approval gate: conflict taxonomy and refusal language.
 
 Expected result: tests prove pickable conflicts and hard-refuse conflicts are
 separate states.
+
+Delivered: the `@overture/scan-matrix` package gains a pure, deterministic
+`classifyConflicts(matrix: ScanMatrix): ConflictClassification` function plus
+five exported types — `ConflictClassification`, `PickableConflict`,
+`PickableConflictCandidate`, `HardRefuseConflict`, and `HardRefuseReason`.
+The classifier populates `hardRefuses` with one entry per parse-error
+`AgentSnapshot`, per `shape-conflict` row, per `different-settings` row in
+canonical-ready mode (`canonical-settings-drift`), and per same-name
+`extra-in-agent` group spanning both `stdio` and `remote`
+(`mixed-transport-types`). It populates `pickable` only when canonical
+intent is absent: one `PickableConflict` per server-name group with at
+least two non-equal normalized candidates. Output is JSON-serializable
+plain data; ordering is deterministic (`pickable` by server name,
+candidates by matrix agent order; `hardRefuses` by reason, server name,
+agent id). C1 (`overture scan --json`), C2 (human `overture scan`), and
+D2 (bootstrap prompt) consume this contract; B3 implements no CLI,
+prompt, writer, or `conflictPolicy` behavior. Purity guards in
+`packages/scan-matrix/src/scope-guards.spec.ts` keep the classifier free
+of I/O, renderers, async, `JSON.stringify`, and per-agent branches.
 
 ## Track C: read behavior surface
 

--- a/packages/scan-matrix/src/index.ts
+++ b/packages/scan-matrix/src/index.ts
@@ -738,14 +738,114 @@ export interface ConflictClassification {
 }
 
 /**
+ * B3 - Resolve the human-readable display name for a row's agent.
+ *
+ * Looks the agent up in `matrix.agents` by `row.agentId` so the refusal
+ * message names the platform, not the internal id. Falls back to the
+ * `agentId` itself when the snapshot is missing (defensive — callers
+ * must include every agent referenced by the row list).
+ */
+function displayNameFor(matrix: ScanMatrix, agentId: string): string {
+  for (const snapshot of matrix.agents) {
+    if (snapshot.id === agentId) {
+      return snapshot.displayName;
+    }
+  }
+  return agentId;
+}
+
+/**
+ * B3 - Compare two sort keys ascending. Returns the conventional
+ * three-way -1 / 0 / +1 used by `Array.prototype.sort`.
+ */
+function compareStrings(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
  * B3 - Classify a scan matrix into pickable conflicts and hard-refuse conflicts.
- * Initial implementation returns empty arrays; Task 2 and Task 3 populate them.
+ * Task 2 populates `hardRefuses` for parse-error snapshots, shape-conflict rows,
+ * and canonical-settings-drift rows with deterministic ordering. Task 3 will
+ * populate `pickable` and the `mixed-transport-types` reason.
  *
  * Pure, synchronous, no I/O. Deterministic ordering:
  *   - `pickable` sorted by `serverName` ascending.
  *   - pickable `candidates` sorted by matrix agent order, falling back to `agentId` ascending.
  *   - `hardRefuses` sorted by `reason`, then `serverName ?? ''`, then `agentId ?? ''`.
+ *
+ * The implementation never mutates the input matrix: every emitted
+ * `HardRefuseConflict` is built from snapshot/row fields read by value.
  */
 export function classifyConflicts(matrix: ScanMatrix): ConflictClassification {
-  return { pickable: [], hardRefuses: [] };
+  const hardRefuses: HardRefuseConflict[] = [];
+
+  for (const snapshot of matrix.agents) {
+    if (snapshot.readState !== 'parse-error') {
+      continue;
+    }
+    const path = snapshot.resolvedPath ?? '<unknown path>';
+    const reason = snapshot.reason ?? '<no reason provided>';
+    hardRefuses.push({
+      reason: 'parse-error',
+      serverName: null,
+      agentId: snapshot.id,
+      displayName: snapshot.displayName,
+      message: `Cannot classify MCP conflicts because ${snapshot.displayName} could not parse ${path}: ${reason}. Fix that config file and retry.`,
+    });
+  }
+
+  for (const row of matrix.rows) {
+    if (row.status === 'shape-conflict') {
+      const displayName = displayNameFor(matrix, row.agentId);
+      const serverName = row.canonicalName ?? row.agentServerName;
+      hardRefuses.push({
+        reason: 'shape-conflict',
+        serverName,
+        agentId: row.agentId,
+        displayName,
+        message: `Cannot classify server "${serverName}" from ${displayName}: ${row.reason ?? '<no reason>'}. Fix that config entry and retry.`,
+      });
+      continue;
+    }
+    if (
+      row.status === 'different-settings' &&
+      matrix.canonicalState === 'ready'
+    ) {
+      const displayName = displayNameFor(matrix, row.agentId);
+      // `different-settings` rows always carry a non-null `canonicalName`
+      // when canonical is `ready` — the row was emitted from the
+      // canonical-loop branch, never the agent-only extras branch.
+      const serverName = row.canonicalName ?? '';
+      hardRefuses.push({
+        reason: 'canonical-settings-drift',
+        serverName,
+        agentId: row.agentId,
+        displayName,
+        message: `Refusing to continue for server "${serverName}" on ${displayName}: canonical and agent settings differ. Update the canonical config or the agent config and retry.`,
+      });
+    }
+  }
+
+  hardRefuses.sort((left, right) => {
+    const reasonOrder = compareStrings(left.reason, right.reason);
+    if (reasonOrder !== 0) {
+      return reasonOrder;
+    }
+    const serverOrder = compareStrings(
+      left.serverName ?? '',
+      right.serverName ?? '',
+    );
+    if (serverOrder !== 0) {
+      return serverOrder;
+    }
+    return compareStrings(left.agentId ?? '', right.agentId ?? '');
+  });
+
+  return { pickable: [], hardRefuses };
 }

--- a/packages/scan-matrix/src/index.ts
+++ b/packages/scan-matrix/src/index.ts
@@ -685,3 +685,67 @@ export function buildScanMatrix(input: BuildScanMatrixInput): ScanMatrix {
   }
   return result;
 }
+
+/**
+ * B3 - Per-name conflict classification reasons for hard-refuse entries.
+ * Exhaustive union; extend by adding a new literal AND a new message template.
+ */
+export type HardRefuseReason =
+  | 'parse-error'
+  | 'shape-conflict'
+  | 'mixed-transport-types'
+  | 'canonical-settings-drift';
+
+/**
+ * B3 - One candidate entry inside a `PickableConflict.candidates` list.
+ * Carries only stable data that renderers (C1/C2) and the bootstrap prompt (D2) need.
+ */
+export interface PickableConflictCandidate {
+  readonly agentId: string;
+  readonly displayName: string;
+  readonly server: OvertureMcpServer;
+}
+
+/**
+ * B3 - One bootstrap pickable conflict: same server name across two or more agents
+ * with non-equal settings (and only emitted when `matrix.canonicalState === 'absent'`).
+ */
+export interface PickableConflict {
+  readonly serverName: string;
+  readonly candidates: readonly PickableConflictCandidate[];
+  readonly message: string;
+}
+
+/**
+ * B3 - One hard-refuse entry. `serverName`, `agentId`, and `displayName` are nullable
+ * because some reasons span multiple agents without a single agent of blame.
+ */
+export interface HardRefuseConflict {
+  readonly reason: HardRefuseReason;
+  readonly serverName: string | null;
+  readonly agentId: string | null;
+  readonly displayName: string | null;
+  readonly message: string;
+}
+
+/**
+ * B3 - Full classification output. Both arrays are JSON-serializable plain data:
+ * no `Map`, `Set`, `Date`, functions, classes, or `ServerStatusRow` references.
+ */
+export interface ConflictClassification {
+  readonly pickable: readonly PickableConflict[];
+  readonly hardRefuses: readonly HardRefuseConflict[];
+}
+
+/**
+ * B3 - Classify a scan matrix into pickable conflicts and hard-refuse conflicts.
+ * Initial implementation returns empty arrays; Task 2 and Task 3 populate them.
+ *
+ * Pure, synchronous, no I/O. Deterministic ordering:
+ *   - `pickable` sorted by `serverName` ascending.
+ *   - pickable `candidates` sorted by matrix agent order, falling back to `agentId` ascending.
+ *   - `hardRefuses` sorted by `reason`, then `serverName ?? ''`, then `agentId ?? ''`.
+ */
+export function classifyConflicts(matrix: ScanMatrix): ConflictClassification {
+  return { pickable: [], hardRefuses: [] };
+}

--- a/packages/scan-matrix/src/index.ts
+++ b/packages/scan-matrix/src/index.ts
@@ -770,9 +770,12 @@ function compareStrings(left: string, right: string): number {
 
 /**
  * B3 - Classify a scan matrix into pickable conflicts and hard-refuse conflicts.
+ *
  * Task 2 populates `hardRefuses` for parse-error snapshots, shape-conflict rows,
- * and canonical-settings-drift rows with deterministic ordering. Task 3 will
- * populate `pickable` and the `mixed-transport-types` reason.
+ * and canonical-settings-drift rows. Task 3 adds bootstrap-only `pickable` and
+ * the `mixed-transport-types` reason, both built from same-name
+ * `extra-in-agent` row groups. When canonical intent exists, same-name extras
+ * are not conflicts.
  *
  * Pure, synchronous, no I/O. Deterministic ordering:
  *   - `pickable` sorted by `serverName` ascending.
@@ -780,7 +783,8 @@ function compareStrings(left: string, right: string): number {
  *   - `hardRefuses` sorted by `reason`, then `serverName ?? ''`, then `agentId ?? ''`.
  *
  * The implementation never mutates the input matrix: every emitted
- * `HardRefuseConflict` is built from snapshot/row fields read by value.
+ * `HardRefuseConflict` and `PickableConflict` is built from snapshot/row
+ * fields read by value.
  */
 export function classifyConflicts(matrix: ScanMatrix): ConflictClassification {
   const hardRefuses: HardRefuseConflict[] = [];
@@ -832,6 +836,135 @@ export function classifyConflicts(matrix: ScanMatrix): ConflictClassification {
     }
   }
 
+  // === B3 Task 3: group same-name `extra-in-agent` rows for bootstrap
+  // pickable conflicts and mixed-transport-types hard-refuses.
+  //
+  // Mixed-transport wins over pickable for a given `serverName`: when a
+  // group spans both 'stdio' and 'remote', emit ONE mixed-transport-types
+  // hard-refuse and skip the pickable pass for that group. Single-transport
+  // groups with all-equal settings emit nothing.
+  const pickable: PickableConflict[] = [];
+
+  const extrasByServerName = new Map<string, ServerStatusRow[]>();
+  for (const row of matrix.rows) {
+    if (
+      row.status === 'extra-in-agent' &&
+      row.agentServerName !== null &&
+      row.agentServer !== null
+    ) {
+      const list = extrasByServerName.get(row.agentServerName) ?? [];
+      list.push(row);
+      extrasByServerName.set(row.agentServerName, list);
+    }
+  }
+
+  const mixedTransportKeys = new Set<string>();
+  for (const [serverName, rows] of extrasByServerName) {
+    const types = new Set<string>();
+    for (const row of rows) {
+      if (row.agentServer !== null) {
+        types.add(row.agentServer.type);
+      }
+    }
+    if (types.has('stdio') && types.has('remote')) {
+      mixedTransportKeys.add(serverName);
+      const sortedTypes = [...types].sort().join(', ');
+      hardRefuses.push({
+        reason: 'mixed-transport-types',
+        serverName,
+        agentId: null,
+        displayName: null,
+        message: `Cannot classify server "${serverName}" because agents disagree on transport type (${sortedTypes}). Rename or fix the source entries and retry.`,
+      });
+    }
+  }
+
+  // Pickable fires only when `canonicalState === 'absent'`. When canonical
+  // intent exists, same-name extras are not conflicts (vision: client
+  // differences are information before intent).
+  if (matrix.canonicalState === 'absent') {
+    const agentPosition = new Map<string, number>();
+    matrix.agents.forEach((snapshot, index) => {
+      agentPosition.set(snapshot.id, index);
+    });
+
+    for (const [serverName, rows] of extrasByServerName) {
+      if (mixedTransportKeys.has(serverName)) {
+        continue;
+      }
+      const first = rows[0];
+      if (first === undefined || first.agentServer === null) {
+        continue;
+      }
+      const firstType = first.agentServer.type;
+      const sameTypeRows = rows.filter(
+        (row) => row.agentServer !== null && row.agentServer.type === firstType,
+      );
+      if (sameTypeRows.length < 2) {
+        continue;
+      }
+      let hasNonEqualPair = false;
+      for (let i = 0; i < sameTypeRows.length && !hasNonEqualPair; i++) {
+        const left = sameTypeRows[i];
+        if (left === undefined || left.agentServer === null) {
+          continue;
+        }
+        for (let j = i + 1; j < sameTypeRows.length; j++) {
+          const right = sameTypeRows[j];
+          if (right === undefined || right.agentServer === null) {
+            continue;
+          }
+          if (!serverSettingsEqual(left.agentServer, right.agentServer)) {
+            hasNonEqualPair = true;
+            break;
+          }
+        }
+      }
+      if (!hasNonEqualPair) {
+        continue;
+      }
+      const candidateRows: {
+        readonly agentId: string;
+        readonly displayName: string;
+        readonly server: OvertureMcpServer;
+        readonly agentPosition: number;
+      }[] = [];
+      for (const row of sameTypeRows) {
+        if (row.agentServer === null) {
+          continue;
+        }
+        candidateRows.push({
+          agentId: row.agentId,
+          displayName: displayNameFor(matrix, row.agentId),
+          server: row.agentServer,
+          agentPosition: agentPosition.get(row.agentId) ?? 0,
+        });
+      }
+      candidateRows.sort((left, right) => {
+        if (left.agentPosition !== right.agentPosition) {
+          return left.agentPosition - right.agentPosition;
+        }
+        return compareStrings(left.agentId, right.agentId);
+      });
+      const candidates: PickableConflictCandidate[] = candidateRows.map(
+        (candidate) => ({
+          agentId: candidate.agentId,
+          displayName: candidate.displayName,
+          server: candidate.server,
+        }),
+      );
+      pickable.push({
+        serverName,
+        candidates,
+        message: `Pickable conflict for "${serverName}" across ${candidates.length} agents (${firstType}): choose one canonical entry or skip.`,
+      });
+    }
+
+    pickable.sort((left, right) =>
+      compareStrings(left.serverName, right.serverName),
+    );
+  }
+
   hardRefuses.sort((left, right) => {
     const reasonOrder = compareStrings(left.reason, right.reason);
     if (reasonOrder !== 0) {
@@ -847,5 +980,5 @@ export function classifyConflicts(matrix: ScanMatrix): ConflictClassification {
     return compareStrings(left.agentId ?? '', right.agentId ?? '');
   });
 
-  return { pickable: [], hardRefuses };
+  return { pickable, hardRefuses };
 }

--- a/packages/scan-matrix/src/scan-matrix.spec.ts
+++ b/packages/scan-matrix/src/scan-matrix.spec.ts
@@ -4,6 +4,7 @@ import type { OvertureConfig, OvertureMcpServer } from '@overture/config';
 import {
   DEFAULT_REGISTRY_ORDER,
   buildScanMatrix,
+  classifyConflicts,
   compareAgentEntries,
   serverSettingsEqual,
 } from './index.js';
@@ -13,7 +14,12 @@ import type {
   AgentSnapshot,
   BuildScanMatrixInput,
   CompareAgentEntriesInput,
+  ConflictClassification,
+  HardRefuseConflict,
+  HardRefuseReason,
   NormalizedAgentServer,
+  PickableConflict,
+  PickableConflictCandidate,
   ScanMatrix,
   ServerStatus,
   ServerStatusRow,
@@ -1158,5 +1164,113 @@ describe('buildScanMatrix', () => {
 describe('scan-matrix package', () => {
   it('smokes', () => {
     expect(1).toBe(1);
+  });
+});
+
+describe('B3 conflict type contracts', () => {
+  it('HardRefuseReason is the approved four-reason vocabulary', () => {
+    expectTypeOf<HardRefuseReason>().toEqualTypeOf<
+      | 'parse-error'
+      | 'shape-conflict'
+      | 'mixed-transport-types'
+      | 'canonical-settings-drift'
+    >();
+  });
+
+  it('PickableConflictCandidate exposes agentId, displayName, server only', () => {
+    const c: PickableConflictCandidate = {
+      agentId: 'claude-code',
+      displayName: 'Claude Code',
+      server: { type: 'stdio', command: 'x' },
+    };
+    expectTypeOf(c).toMatchTypeOf<PickableConflictCandidate>();
+  });
+
+  it('PickableConflict is serverName + candidates + message', () => {
+    const p: PickableConflict = {
+      serverName: 'memory',
+      candidates: [
+        {
+          agentId: 'claude-code',
+          displayName: 'Claude Code',
+          server: { type: 'stdio', command: 'a' },
+        },
+        {
+          agentId: 'opencode',
+          displayName: 'OpenCode',
+          server: { type: 'stdio', command: 'b' },
+        },
+      ],
+      message: 'pickable: memory',
+    };
+    expectTypeOf(p).toMatchTypeOf<PickableConflict>();
+  });
+
+  it('HardRefuseConflict allows null serverName/agentId/displayName', () => {
+    const h: HardRefuseConflict = {
+      reason: 'parse-error',
+      serverName: null,
+      agentId: 'opencode',
+      displayName: 'OpenCode',
+      message:
+        'Cannot classify MCP conflicts because OpenCode could not parse /home/u/.config/opencode/config.json: Unexpected token.',
+    };
+    expectTypeOf(h).toMatchTypeOf<HardRefuseConflict>();
+  });
+
+  it('ConflictClassification has pickable and hardRefuses arrays only', () => {
+    const cc: ConflictClassification = { pickable: [], hardRefuses: [] };
+    expectTypeOf(cc).toMatchTypeOf<ConflictClassification>();
+  });
+});
+
+describe('classifyConflicts shell', () => {
+  const makeMatrix = (overrides: Partial<ScanMatrix> = {}): ScanMatrix => ({
+    canonicalState: 'ready',
+    canonicalProfileName: 'default',
+    canonicalIntent: {},
+    agents: [],
+    rows: [],
+    ...overrides,
+  });
+
+  it('returns empty arrays for a fully empty ready-state matrix', () => {
+    const result = classifyConflicts(makeMatrix());
+    expect(result).toEqual({ pickable: [], hardRefuses: [] });
+  });
+
+  it('returns empty arrays for an invalid-profile matrix', () => {
+    const result = classifyConflicts(
+      makeMatrix({
+        canonicalState: 'invalid-profile',
+        canonicalProfileName: 'missing',
+      }),
+    );
+    expect(result).toEqual({ pickable: [], hardRefuses: [] });
+  });
+
+  it('returns empty arrays for an absent canonical state', () => {
+    const result = classifyConflicts(
+      makeMatrix({ canonicalState: 'absent', canonicalProfileName: null }),
+    );
+    expect(result).toEqual({ pickable: [], hardRefuses: [] });
+  });
+
+  it('does not mutate the input matrix', () => {
+    const matrix = makeMatrix({
+      agents: [
+        {
+          id: 'claude-code',
+          displayName: 'Claude Code',
+          installed: true,
+          mcpSupport: 'supported',
+          readState: 'read-ok',
+        },
+      ],
+      rows: [],
+    });
+    const snapshot = JSON.stringify(matrix);
+    classifyConflicts(matrix);
+    expect(JSON.stringify(matrix)).toBe(snapshot);
   });
 });

--- a/packages/scan-matrix/src/scan-matrix.spec.ts
+++ b/packages/scan-matrix/src/scan-matrix.spec.ts
@@ -2059,3 +2059,80 @@ describe('classifyConflicts bootstrap pickable + mixed-transport (B3 Task 3)', (
     expect(result).toEqual({ pickable: [], hardRefuses: [] });
   });
 });
+
+describe('classifyConflicts determinism (B3 Task 4)', () => {
+  const makeMatrix = (overrides: Partial<ScanMatrix> = {}): ScanMatrix => ({
+    canonicalState: 'ready',
+    canonicalProfileName: 'default',
+    canonicalIntent: {},
+    agents: [],
+    rows: [],
+    ...overrides,
+  });
+
+  const populatedMatrix = (): ScanMatrix =>
+    makeMatrix({
+      canonicalState: 'absent',
+      canonicalProfileName: null,
+      canonicalIntent: {},
+      agents: [
+        {
+          id: 'claude-code',
+          displayName: 'Claude Code',
+          installed: true,
+          mcpSupport: 'supported',
+          readState: 'parse-error',
+          resolvedPath: '/home/u/.claude.json',
+          reason: 'Unexpected token at line 4',
+        },
+      ],
+      rows: [
+        {
+          agentId: 'opencode',
+          canonicalName: 'memory',
+          agentServerName: 'memory',
+          status: 'extra-in-agent',
+          canonicalServer: null,
+          agentServer: { type: 'stdio', command: 'npx', args: ['memory'] },
+          reason: 'Canonical intent has no server named "memory"',
+        },
+        {
+          agentId: 'github-copilot-cli',
+          canonicalName: 'memory',
+          agentServerName: 'memory',
+          status: 'extra-in-agent',
+          canonicalServer: null,
+          agentServer: { type: 'stdio', command: 'node', args: ['mem.js'] },
+          reason: 'Canonical intent has no server named "memory"',
+        },
+      ],
+    });
+
+  it('two calls with the same fixture return deeply equal objects', () => {
+    const matrix = populatedMatrix();
+    const a = classifyConflicts(matrix);
+    const b = classifyConflicts(matrix);
+    expect(a).toEqual(b);
+  });
+
+  it('JSON.stringify output is stable across calls', () => {
+    const matrix = populatedMatrix();
+    const a = JSON.stringify(classifyConflicts(matrix));
+    const b = JSON.stringify(classifyConflicts(matrix));
+    expect(a).toBe(b);
+  });
+
+  it('classifier output is JSON-serializable', () => {
+    const matrix = populatedMatrix();
+    const result = classifyConflicts(matrix);
+    expect(typeof JSON.stringify(result)).toBe('string');
+    for (const entry of result.hardRefuses) {
+      expect(typeof entry.message).toBe('string');
+      expect(typeof entry.reason).toBe('string');
+    }
+    for (const conflict of result.pickable) {
+      expect(typeof conflict.serverName).toBe('string');
+      expect(typeof conflict.message).toBe('string');
+    }
+  });
+});

--- a/packages/scan-matrix/src/scan-matrix.spec.ts
+++ b/packages/scan-matrix/src/scan-matrix.spec.ts
@@ -1670,3 +1670,392 @@ describe('classifyConflicts hard-refuse (B3 Task 2)', () => {
     ]);
   });
 });
+
+describe('classifyConflicts bootstrap pickable + mixed-transport (B3 Task 3)', () => {
+  // Server fixtures used across the bootstrap pickable tests. They are
+  // small and distinct so messages remain readable in failure output. Each
+  // helper composes a ScanMatrix by hand so the tests are independent of
+  // buildScanMatrix; B3 is a read model on top of scan-matrix data, not a
+  // pipeline that requires buildScanMatrix to run.
+  const stdioA: OvertureMcpServer = { type: 'stdio', command: 'npx' };
+  const stdioB: OvertureMcpServer = {
+    type: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+  };
+  const stdioC: OvertureMcpServer = {
+    type: 'stdio',
+    command: 'python',
+    args: ['-m', 'memory'],
+    env: { MODE: 'fast' },
+  };
+  const remoteA: OvertureMcpServer = {
+    type: 'remote',
+    url: 'https://example.com/mcp',
+  };
+  const remoteB: OvertureMcpServer = {
+    type: 'remote',
+    url: 'https://other.example.com/mcp',
+  };
+
+  const makeSnapshot = (overrides: Partial<AgentSnapshot>): AgentSnapshot => ({
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    installed: true,
+    mcpSupport: 'supported',
+    readState: 'read-ok',
+    ...overrides,
+  });
+
+  const makeRow = (overrides: Partial<ServerStatusRow>): ServerStatusRow => ({
+    agentId: 'claude-code',
+    canonicalName: null,
+    agentServerName: 'memory',
+    status: 'extra-in-agent',
+    canonicalServer: null,
+    agentServer: stdioA,
+    ...overrides,
+  });
+
+  const makeMatrix = (overrides: Partial<ScanMatrix>): ScanMatrix => ({
+    canonicalState: 'absent',
+    canonicalProfileName: null,
+    canonicalIntent: {},
+    agents: [],
+    rows: [],
+    ...overrides,
+  });
+
+  it('absent canonical + two same-name stdio extras with non-equal settings → one pickable with two candidates', () => {
+    const matrix = makeMatrix({
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'memory',
+          agentServer: stdioA,
+        }),
+        makeRow({
+          agentId: 'opencode',
+          agentServerName: 'memory',
+          agentServer: stdioB,
+        }),
+      ],
+    });
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toEqual([]);
+    expect(result.pickable).toHaveLength(1);
+    expect(result.pickable[0]?.serverName).toBe('memory');
+    expect(result.pickable[0]?.candidates.map((c) => c.agentId)).toEqual([
+      'claude-code',
+      'opencode',
+    ]);
+    expect(result.pickable[0]?.candidates[0]?.server).toEqual(stdioA);
+    expect(result.pickable[0]?.candidates[1]?.server).toEqual(stdioB);
+    expect(result.pickable[0]?.candidates[0]?.displayName).toBe('Claude Code');
+    expect(result.pickable[0]?.candidates[1]?.displayName).toBe('OpenCode');
+    expect(result.pickable[0]?.message).toBe(
+      'Pickable conflict for "memory" across 2 agents (stdio): choose one canonical entry or skip.',
+    );
+  });
+
+  it('absent canonical + three same-name stdio extras with non-equal settings → one pickable with three candidates', () => {
+    const matrix = makeMatrix({
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+        makeSnapshot({
+          id: 'github-copilot-cli',
+          displayName: 'GitHub Copilot CLI',
+        }),
+      ],
+      rows: [
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'memory',
+          agentServer: stdioA,
+        }),
+        makeRow({
+          agentId: 'opencode',
+          agentServerName: 'memory',
+          agentServer: stdioB,
+        }),
+        makeRow({
+          agentId: 'github-copilot-cli',
+          agentServerName: 'memory',
+          agentServer: stdioC,
+        }),
+      ],
+    });
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toEqual([]);
+    expect(result.pickable).toHaveLength(1);
+    expect(result.pickable[0]?.serverName).toBe('memory');
+    expect(result.pickable[0]?.candidates.map((c) => c.agentId)).toEqual([
+      'claude-code',
+      'opencode',
+      'github-copilot-cli',
+    ]);
+    expect(result.pickable[0]?.message).toBe(
+      'Pickable conflict for "memory" across 3 agents (stdio): choose one canonical entry or skip.',
+    );
+  });
+
+  it('absent canonical + same-name extras with all-equal settings → no pickable, no mixed-transport', () => {
+    const matrix = makeMatrix({
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'memory',
+          agentServer: stdioA,
+        }),
+        makeRow({
+          agentId: 'opencode',
+          agentServerName: 'memory',
+          agentServer: stdioA,
+        }),
+      ],
+    });
+    const result = classifyConflicts(matrix);
+    expect(result.pickable).toEqual([]);
+    expect(result.hardRefuses).toEqual([]);
+  });
+
+  it('absent canonical + mixed stdio+remote same-name extras → one mixed-transport-types hard-refuse, no pickable', () => {
+    const matrix = makeMatrix({
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'memory',
+          agentServer: stdioA,
+        }),
+        makeRow({
+          agentId: 'opencode',
+          agentServerName: 'memory',
+          agentServer: remoteA,
+        }),
+      ],
+    });
+    const result = classifyConflicts(matrix);
+    expect(result.pickable).toEqual([]);
+    expect(result.hardRefuses).toEqual([
+      {
+        reason: 'mixed-transport-types',
+        serverName: 'memory',
+        agentId: null,
+        displayName: null,
+        message:
+          'Cannot classify server "memory" because agents disagree on transport type (remote, stdio). Rename or fix the source entries and retry.',
+      },
+    ]);
+  });
+
+  it('ready canonical + same-name extras → no pickable, no hard-refuses (extras are not conflicts)', () => {
+    const matrix = makeMatrix({
+      canonicalState: 'ready',
+      canonicalProfileName: 'default',
+      canonicalIntent: { notes: stdioB },
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'memory',
+          agentServer: stdioA,
+        }),
+        makeRow({
+          agentId: 'opencode',
+          agentServerName: 'memory',
+          agentServer: stdioC,
+        }),
+      ],
+    });
+    const result = classifyConflicts(matrix);
+    expect(result.pickable).toEqual([]);
+    expect(result.hardRefuses).toEqual([]);
+  });
+
+  it('absent canonical + pickable candidates sort by matrix agent order', () => {
+    // The matrix.agents list intentionally puts opencode first, claude-code
+    // second, github-copilot-cli third, but the row array lists them in a
+    // different order. The candidate list must follow matrix.agents order.
+    const matrix = makeMatrix({
+      agents: [
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({
+          id: 'github-copilot-cli',
+          displayName: 'GitHub Copilot CLI',
+        }),
+      ],
+      rows: [
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'memory',
+          agentServer: stdioB,
+        }),
+        makeRow({
+          agentId: 'github-copilot-cli',
+          agentServerName: 'memory',
+          agentServer: stdioC,
+        }),
+        makeRow({
+          agentId: 'opencode',
+          agentServerName: 'memory',
+          agentServer: stdioA,
+        }),
+      ],
+    });
+    const result = classifyConflicts(matrix);
+    expect(result.pickable).toHaveLength(1);
+    expect(result.pickable[0]?.candidates.map((c) => c.agentId)).toEqual([
+      'opencode',
+      'claude-code',
+      'github-copilot-cli',
+    ]);
+  });
+
+  it('absent canonical + pickable list sorts by serverName ascending across multiple groups', () => {
+    const matrix = makeMatrix({
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        // Insert zebra first to prove the sort key is serverName, not row order.
+        makeRow({
+          agentId: 'opencode',
+          agentServerName: 'zebra',
+          agentServer: stdioC,
+        }),
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'alpha',
+          agentServer: stdioB,
+        }),
+        makeRow({
+          agentId: 'opencode',
+          agentServerName: 'alpha',
+          agentServer: stdioA,
+        }),
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'zebra',
+          agentServer: stdioA,
+        }),
+      ],
+    });
+    const result = classifyConflicts(matrix);
+    expect(result.pickable.map((p) => p.serverName)).toEqual([
+      'alpha',
+      'zebra',
+    ]);
+    expect(result.pickable[0]?.candidates.map((c) => c.agentId)).toEqual([
+      'claude-code',
+      'opencode',
+    ]);
+    expect(result.pickable[1]?.candidates.map((c) => c.agentId)).toEqual([
+      'claude-code',
+      'opencode',
+    ]);
+  });
+
+  it('ready canonical + same-name extras that are mixed stdio+remote → still one mixed-transport-types hard-refuse', () => {
+    // Mixed-transport detection happens regardless of canonical state: an
+    // agent-only disagreement about transport type is a hard-refuse, even
+    // when canonical intent exists.
+    const matrix = makeMatrix({
+      canonicalState: 'ready',
+      canonicalProfileName: 'default',
+      canonicalIntent: { notes: stdioB },
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'memory',
+          agentServer: stdioA,
+        }),
+        makeRow({
+          agentId: 'opencode',
+          agentServerName: 'memory',
+          agentServer: remoteB,
+        }),
+      ],
+    });
+    const result = classifyConflicts(matrix);
+    expect(result.pickable).toEqual([]);
+    expect(result.hardRefuses).toEqual([
+      {
+        reason: 'mixed-transport-types',
+        serverName: 'memory',
+        agentId: null,
+        displayName: null,
+        message:
+          'Cannot classify server "memory" because agents disagree on transport type (remote, stdio). Rename or fix the source entries and retry.',
+      },
+    ]);
+  });
+
+  it('absent canonical + same-name group with a shape-conflict extra → no pickable (only normalized entries are candidates)', () => {
+    // The shape-conflict row carries agentServer: null (the B2 reason text
+    // already produces a hard-refuse). It is filtered out of the candidate
+    // set, so the remaining single normalized row cannot form a pickable
+    // conflict and the group is silent.
+    const matrix = makeMatrix({
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        makeRow({
+          agentId: 'claude-code',
+          agentServerName: 'memory',
+          agentServer: stdioA,
+        }),
+        {
+          agentId: 'opencode',
+          canonicalName: null,
+          agentServerName: 'memory',
+          status: 'shape-conflict',
+          canonicalServer: null,
+          agentServer: null,
+          reason: 'Stdio command is missing or empty.',
+        },
+      ],
+    });
+    const result = classifyConflicts(matrix);
+    expect(result.pickable).toEqual([]);
+    expect(result.hardRefuses).toEqual([
+      {
+        reason: 'shape-conflict',
+        serverName: 'memory',
+        agentId: 'opencode',
+        displayName: 'OpenCode',
+        message:
+          'Cannot classify server "memory" from OpenCode: Stdio command is missing or empty.. Fix that config entry and retry.',
+      },
+    ]);
+  });
+
+  it('absent canonical + zero rows + zero agents → empty pickable + empty hardRefuses (smoke)', () => {
+    const matrix = makeMatrix({ agents: [], rows: [] });
+    const result = classifyConflicts(matrix);
+    expect(result).toEqual({ pickable: [], hardRefuses: [] });
+  });
+});

--- a/packages/scan-matrix/src/scan-matrix.spec.ts
+++ b/packages/scan-matrix/src/scan-matrix.spec.ts
@@ -1274,3 +1274,399 @@ describe('classifyConflicts shell', () => {
     expect(JSON.stringify(matrix)).toBe(snapshot);
   });
 });
+describe('classifyConflicts hard-refuse (B3 Task 2)', () => {
+  // Server fixtures used across the hard-refuse tests. They are small and
+  // distinct so messages remain readable in failure output. Each helper
+  // composes a ScanMatrix by hand so the tests are independent of
+  // buildScanMatrix; B3 is a read model on top of scan-matrix data, not a
+  // pipeline that requires buildScanMatrix to run.
+  const stdioA: OvertureMcpServer = { type: 'stdio', command: 'npx' };
+  const stdioB: OvertureMcpServer = {
+    type: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+  };
+
+  const makeSnapshot = (overrides: Partial<AgentSnapshot>): AgentSnapshot => ({
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    installed: true,
+    mcpSupport: 'supported',
+    readState: 'read-ok',
+    ...overrides,
+  });
+
+  const makeConfig = (
+    ready: boolean,
+    mcpServers: Record<string, OvertureMcpServer>,
+  ): {
+    canonicalState: 'ready' | 'absent';
+    canonicalProfileName: string | null;
+    canonicalIntent: Record<string, OvertureMcpServer>;
+    agents: AgentSnapshot[];
+    rows: ServerStatusRow[];
+  } => ({
+    canonicalState: ready ? 'ready' : 'absent',
+    canonicalProfileName: ready ? 'default' : null,
+    canonicalIntent: mcpServers,
+    agents: [],
+    rows: [],
+  });
+
+  it('parse-error snapshot produces one hard-refuse using displayName, resolvedPath, and reason verbatim', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(false, {}),
+      agents: [
+        makeSnapshot({
+          id: 'opencode',
+          displayName: 'OpenCode',
+          readState: 'parse-error',
+          resolvedPath: '/home/u/.config/opencode/config.json',
+          reason: 'Unexpected token at position 42',
+        }),
+      ],
+      rows: [],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.pickable).toEqual([]);
+    expect(result.hardRefuses).toEqual([
+      {
+        reason: 'parse-error',
+        serverName: null,
+        agentId: 'opencode',
+        displayName: 'OpenCode',
+        message:
+          'Cannot classify MCP conflicts because OpenCode could not parse /home/u/.config/opencode/config.json: Unexpected token at position 42. Fix that config file and retry.',
+      },
+    ]);
+  });
+
+  it('parse-error snapshot without resolvedPath uses <unknown path> fallback', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(false, {}),
+      agents: [
+        makeSnapshot({
+          id: 'opencode',
+          displayName: 'OpenCode',
+          readState: 'parse-error',
+          reason: 'Bad token',
+        }),
+      ],
+      rows: [],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toHaveLength(1);
+    expect(result.hardRefuses[0]?.message).toBe(
+      'Cannot classify MCP conflicts because OpenCode could not parse <unknown path>: Bad token. Fix that config file and retry.',
+    );
+  });
+
+  it('parse-error snapshot without reason uses <no reason provided> fallback', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(false, {}),
+      agents: [
+        makeSnapshot({
+          id: 'opencode',
+          displayName: 'OpenCode',
+          readState: 'parse-error',
+          resolvedPath: '/etc/opencode.json',
+        }),
+      ],
+      rows: [],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toHaveLength(1);
+    expect(result.hardRefuses[0]?.message).toBe(
+      'Cannot classify MCP conflicts because OpenCode could not parse /etc/opencode.json: <no reason provided>. Fix that config file and retry.',
+    );
+  });
+
+  it('shape-conflict row produces one hard-refuse wrapping the B2 reason verbatim', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(true, { memory: stdioA }),
+      agents: [makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' })],
+      rows: [
+        {
+          agentId: 'claude-code',
+          canonicalName: 'memory',
+          agentServerName: 'memory',
+          status: 'shape-conflict',
+          canonicalServer: stdioA,
+          agentServer: null,
+          reason: 'Stdio command is missing or empty.',
+        },
+      ],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.pickable).toEqual([]);
+    expect(result.hardRefuses).toEqual([
+      {
+        reason: 'shape-conflict',
+        serverName: 'memory',
+        agentId: 'claude-code',
+        displayName: 'Claude Code',
+        message:
+          'Cannot classify server "memory" from Claude Code: Stdio command is missing or empty.. Fix that config entry and retry.',
+      },
+    ]);
+  });
+
+  it('shape-conflict row in extra-in-agent slot uses agentServerName as the offending server name', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(false, {}),
+      agents: [makeSnapshot({ id: 'opencode', displayName: 'OpenCode' })],
+      rows: [
+        {
+          agentId: 'opencode',
+          canonicalName: null,
+          agentServerName: 'orphan',
+          status: 'shape-conflict',
+          canonicalServer: null,
+          agentServer: null,
+          reason: 'agent entry is missing required "command" field',
+        },
+      ],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toEqual([
+      {
+        reason: 'shape-conflict',
+        serverName: 'orphan',
+        agentId: 'opencode',
+        displayName: 'OpenCode',
+        message:
+          'Cannot classify server "orphan" from OpenCode: agent entry is missing required "command" field. Fix that config entry and retry.',
+      },
+    ]);
+  });
+
+  it('different-settings row in canonical ready state produces one canonical-settings-drift hard-refuse', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(true, { memory: stdioA }),
+      agents: [makeSnapshot({ id: 'opencode', displayName: 'OpenCode' })],
+      rows: [
+        {
+          agentId: 'opencode',
+          canonicalName: 'memory',
+          agentServerName: 'memory',
+          status: 'different-settings',
+          canonicalServer: stdioA,
+          agentServer: stdioB,
+          reason: 'Canonical and agent settings differ',
+        },
+      ],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toEqual([
+      {
+        reason: 'canonical-settings-drift',
+        serverName: 'memory',
+        agentId: 'opencode',
+        displayName: 'OpenCode',
+        message:
+          'Refusing to continue for server "memory" on OpenCode: canonical and agent settings differ. Update the canonical config or the agent config and retry.',
+      },
+    ]);
+  });
+
+  it('different-settings row in canonical absent state does NOT produce a canonical-settings-drift entry (no canonical to drift from)', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(false, {}),
+      agents: [makeSnapshot({ id: 'opencode', displayName: 'OpenCode' })],
+      rows: [
+        {
+          agentId: 'opencode',
+          canonicalName: 'memory',
+          agentServerName: 'memory',
+          status: 'different-settings',
+          canonicalServer: stdioA,
+          agentServer: stdioB,
+          reason: 'Canonical and agent settings differ',
+        },
+      ],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toEqual([]);
+  });
+
+  it('aligned, missing-from-agent, extra-in-agent rows produce no hard-refuse entries', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(true, { memory: stdioA, notes: stdioB }),
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        {
+          agentId: 'claude-code',
+          canonicalName: 'memory',
+          agentServerName: 'memory',
+          status: 'aligned',
+          canonicalServer: stdioA,
+          agentServer: stdioA,
+        },
+        {
+          agentId: 'opencode',
+          canonicalName: 'notes',
+          agentServerName: null,
+          status: 'missing-from-agent',
+          canonicalServer: stdioB,
+          agentServer: null,
+          reason: 'Agent has no server named "notes"',
+        },
+        {
+          agentId: 'claude-code',
+          canonicalName: null,
+          agentServerName: 'bonus',
+          status: 'extra-in-agent',
+          canonicalServer: null,
+          agentServer: stdioB,
+          reason: 'Canonical intent has no server named "bonus"',
+        },
+      ],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toEqual([]);
+  });
+
+  it('not-installed, unsupported-agent, not-read, read-empty, read-no-config snapshots produce no hard-refuse entries', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(true, { memory: stdioA }),
+      agents: [
+        makeSnapshot({
+          id: 'claude-code',
+          displayName: 'Claude Code',
+          readState: 'not-installed',
+          installed: false,
+          mcpSupport: 'unknown',
+        }),
+        makeSnapshot({
+          id: 'opencode',
+          displayName: 'OpenCode',
+          readState: 'unsupported-agent',
+          installed: false,
+          mcpSupport: 'unsupported',
+        }),
+        makeSnapshot({ id: 'github-copilot-cli', readState: 'not-read' }),
+        makeSnapshot({ id: 'openai-codex', readState: 'read-empty' }),
+        makeSnapshot({
+          id: 'aider',
+          displayName: 'Aider',
+          readState: 'read-no-config',
+        }),
+      ],
+      rows: [],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toEqual([]);
+  });
+
+  it('two hard-refuses sort by (reason, serverName, agentId) ascending', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(true, { alpha: stdioA, beta: stdioB }),
+      agents: [
+        makeSnapshot({ id: 'claude-code', displayName: 'Claude Code' }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        // Intentionally reversed canonical name + agentId ordering: alpha/zulu
+        // sorts after bravo/alpha when reason and serverName tie.
+        {
+          agentId: 'opencode',
+          canonicalName: 'beta',
+          agentServerName: 'beta',
+          status: 'different-settings',
+          canonicalServer: stdioB,
+          agentServer: stdioA,
+          reason: 'Canonical and agent settings differ',
+        },
+        {
+          agentId: 'claude-code',
+          canonicalName: 'alpha',
+          agentServerName: 'alpha',
+          status: 'different-settings',
+          canonicalServer: stdioA,
+          agentServer: stdioB,
+          reason: 'Canonical and agent settings differ',
+        },
+      ],
+    };
+    const result = classifyConflicts(matrix);
+    expect(
+      result.hardRefuses.map((h) => [h.reason, h.serverName, h.agentId]),
+    ).toEqual([
+      ['canonical-settings-drift', 'alpha', 'claude-code'],
+      ['canonical-settings-drift', 'beta', 'opencode'],
+    ]);
+  });
+
+  it('multiple parse-error snapshots produce one hard-refuse per snapshot (no aggregation)', () => {
+    const matrix: ScanMatrix = {
+      ...makeConfig(false, {}),
+      agents: [
+        makeSnapshot({
+          id: 'opencode',
+          displayName: 'OpenCode',
+          readState: 'parse-error',
+          resolvedPath: '/etc/opencode.json',
+          reason: 'bad',
+        }),
+        makeSnapshot({
+          id: 'github-copilot-cli',
+          displayName: 'GitHub Copilot CLI',
+          readState: 'parse-error',
+          resolvedPath: '/etc/copilot.json',
+          reason: 'worse',
+        }),
+      ],
+      rows: [],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses).toHaveLength(2);
+    expect(result.hardRefuses.map((h) => h.agentId)).toEqual([
+      'github-copilot-cli',
+      'opencode',
+    ]);
+    expect(result.hardRefuses[0]?.message).toBe(
+      'Cannot classify MCP conflicts because GitHub Copilot CLI could not parse /etc/copilot.json: worse. Fix that config file and retry.',
+    );
+    expect(result.hardRefuses[1]?.message).toBe(
+      'Cannot classify MCP conflicts because OpenCode could not parse /etc/opencode.json: bad. Fix that config file and retry.',
+    );
+  });
+
+  it('multiple parse-error + one canonical-settings-drift sorts canonical-settings-drift before parse-error (reason key)', () => {
+    // Reason alphabetical: 'canonical-settings-drift' ('c') < 'parse-error' ('p').
+    // The matrix literal lists the parse-error snapshot first to prove the
+    // sort key is the reason string, not insertion order.
+    const matrix: ScanMatrix = {
+      ...makeConfig(true, { memory: stdioA }),
+      agents: [
+        makeSnapshot({
+          id: 'claude-code',
+          displayName: 'Claude Code',
+          readState: 'parse-error',
+          resolvedPath: '/etc/claude.json',
+          reason: 'parse failed',
+        }),
+        makeSnapshot({ id: 'opencode', displayName: 'OpenCode' }),
+      ],
+      rows: [
+        {
+          agentId: 'opencode',
+          canonicalName: 'memory',
+          agentServerName: 'memory',
+          status: 'different-settings',
+          canonicalServer: stdioA,
+          agentServer: stdioB,
+          reason: 'Canonical and agent settings differ',
+        },
+      ],
+    };
+    const result = classifyConflicts(matrix);
+    expect(result.hardRefuses.map((h) => h.reason)).toEqual([
+      'canonical-settings-drift',
+      'parse-error',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Add `classifyConflicts(matrix: ScanMatrix): ConflictClassification` to `@overture/scan-matrix`. The classifier consumes a `ScanMatrix` and emits a JSON-serializable `ConflictClassification` with two buckets:

- **`pickable`** — bootstrap-only conflicts. When canonical intent is absent, same server-name `extra-in-agent` rows with non-equal settings group into one `PickableConflict` per server name. D2 will offer these to the user during bootstrap.
- **`hardRefuses`** — hard refusals. One entry per:
  - parse-error `AgentSnapshot` (canonical agent state is `parse-error`),
  - `shape-conflict` row from `compareAgentEntries` (B2 `NormalizedAgentServer` returned a shape-conflict, or canonical/agent `type` discriminators differ),
  - canonical-settings-drift `different-settings` row when canonical is `ready` (vision: settings conflicts are refused, not resolved once canonical intent exists),
  - mixed-transport-types same-name group spanning both `stdio` and `remote` (wins over pickable for that group).

## Public exports

`ConflictClassification`, `PickableConflict`, `PickableConflictCandidate`, `HardRefuseConflict`, `HardRefuseReason`, `classifyConflicts(matrix: ScanMatrix)`. Output is plain JSON data (strings, arrays, plain objects); no `Map`/`Set`/`Date`/function references.

## Deterministic ordering

- `pickable` sorted by `serverName` ascending.
- pickable `candidates` sorted by matrix agent order, ties broken by `agentId` ascending.
- `hardRefuses` sorted by `reason`, then `serverName ?? ''`, then `agentId ?? ''`.

## Tests

101 tests pass: 95 in `scan-matrix.spec.ts` + 6 in `scope-guards.spec.ts`. The purity guard spec asserts no `node:fs`, no `JSON.stringify(`, no `process.stdout`/`stderr`, no `console.log`, no per-agent imports, and no `conflictPolicy` branching in implementation.

## Scope

- `packages/scan-matrix/**` only.
- `docs/overture-implementation-slices.md` B3 section: `**Status: completed.**` and a Delivered paragraph.

No CLI commands, prompts, writers, apply behavior, or `conflictPolicy` execution. C1 (`overture scan --json`), C2 (human `overture scan`), and D2 (bootstrap prompt) will consume this contract in follow-up slices.

## Commits

1. `ccdec7c3` — feat(scan-matrix): add conflict classification contract
2. `cd91945e` — feat(scan-matrix): classify hard-refuse MCP conflicts
3. `840cbde7` — feat(scan-matrix): classify bootstrap pickable conflicts
4. `6430b90e` — test(scan-matrix): add conflict classifier determinism tests
5. `db107d6c` — docs(b3): mark MCP conflict classification slice complete
