### PR TITLE
fix(cli): resolve detect mcp paths from xdg root

### DIFF
--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -14,8 +20,14 @@ import type {
 describe('run', () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
   let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let originalXdgConfigHome: string | undefined;
+  let originalPath: string | undefined;
+  let tempRoots: string[];
 
   beforeEach(() => {
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalPath = process.env.PATH;
+    tempRoots = [];
     stdoutSpy = vi
       .spyOn(process.stdout, 'write')
       .mockImplementation(() => true);
@@ -25,6 +37,19 @@ describe('run', () => {
   });
 
   afterEach(() => {
+    for (const dir of tempRoots) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
     stdoutSpy.mockRestore();
     stderrSpy.mockRestore();
   });
@@ -90,6 +115,56 @@ describe('run', () => {
     expect(code).toBe(2);
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining('Unknown flag: --bogus'),
+    );
+  });
+
+  it('detect uses XDG config root for agent MCP paths (regression)', async () => {
+    const xdgConfigHome = mkdtempSync(join(tmpdir(), 'overture-xdg-config-'));
+    const pathDir = mkdtempSync(join(tmpdir(), 'overture-path-'));
+    tempRoots.push(xdgConfigHome, pathDir);
+
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    process.env.PATH = `${pathDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`;
+
+    const opencodeDir = join(xdgConfigHome, 'opencode');
+    mkdirSync(opencodeDir, { recursive: true });
+    writeFileSync(
+      join(opencodeDir, 'opencode.jsonc'),
+      '// comment\n{"mcp": {"context7": {"type": "remote", "url": "https://example.test"}}}',
+    );
+
+    const opencodeBin = join(pathDir, 'opencode');
+    writeFileSync(opencodeBin, '#!/bin/sh\nexit 0\n');
+    chmodSync(opencodeBin, 0o755);
+
+    const code = await run(['detect', '--json']);
+    expect(code).toBe(0);
+
+    const stdout = (
+      stdoutSpy.mock.calls as ReadonlyArray<ReadonlyArray<unknown>>
+    )
+      .map((call) => String(call[0] ?? ''))
+      .join('');
+    const parsed = JSON.parse(stdout) as {
+      platforms: Array<{
+        id: string;
+        installed: boolean;
+        mcpSupport: string;
+        mcpConfigured: boolean;
+        matchedMcpLocations: Array<{ resolvedPath: string }>;
+      }>;
+    };
+    const opencode = parsed.platforms.find(
+      (platform) => platform.id === 'opencode',
+    );
+
+    expect(opencode).toBeDefined();
+    expect(opencode?.installed).toBe(true);
+    expect(opencode?.mcpSupport).toBe('supported');
+    expect(opencode?.mcpConfigured).toBe(true);
+    expect(opencode?.matchedMcpLocations.length).toBeGreaterThanOrEqual(1);
+    expect(opencode?.matchedMcpLocations[0]?.resolvedPath).toContain(
+      'opencode/opencode.jsonc',
     );
   });
 });

--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -140,19 +140,17 @@ describe('run', () => {
     const code = await run(['detect', '--json']);
     expect(code).toBe(0);
 
-    const stdout = (
-      stdoutSpy.mock.calls as ReadonlyArray<ReadonlyArray<unknown>>
-    )
-      .map((call) => String(call[0] ?? ''))
+    const stdout = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
       .join('');
     const parsed = JSON.parse(stdout) as {
-      platforms: Array<{
+      platforms: {
         id: string;
         installed: boolean;
         mcpSupport: string;
         mcpConfigured: boolean;
-        matchedMcpLocations: Array<{ resolvedPath: string }>;
-      }>;
+        matchedMcpLocations: { resolvedPath: string }[];
+      }[];
     };
     const opencode = parsed.platforms.find(
       (platform) => platform.id === 'opencode',

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -7,7 +7,10 @@ import {
   type OvertureConfig,
   type OverturePaths,
 } from '@overture/config';
-import { detectPlatforms } from './platforms/detect.js';
+import {
+  defaultPathResolutionContext,
+  detectPlatforms,
+} from './platforms/detect.js';
 import { agentRegistry, type McpServerEntry } from '@overture/agents';
 import type { DetectJsonOutput } from './platforms/types.js';
 
@@ -162,9 +165,7 @@ async function runDetect(flags: readonly string[]): Promise<number> {
     );
     return 2;
   }
-  const output = await detectPlatforms(
-    defaultOverturePaths({ workspaceDir: process.cwd() }),
-  );
+  const output = await detectPlatforms(defaultPathResolutionContext());
   if (flags.includes('--json')) {
     process.stdout.write(formatJsonOutput(output));
     return 0;


### PR DESCRIPTION
## Summary

Lock the `overture detect` entry point to the generic XDG path context (`defaultPathResolutionContext`) instead of `defaultOverturePaths`, so agent MCP configs resolve from `XDG_CONFIG_HOME` rather than Overture's own config dir.

Before the fix, OpenCode MCP configs were reported as `mcp-not-configured` even when the user had a valid `~/.config/opencode/opencode.jsonc` because `detectPlatforms()` was being called with `defaultOverturePaths({ workspaceDir: process.cwd() })`, which makes `configDir` resolve to `~/.config/overture`. OpenCode's `mcpLocations` use `base: "config"` with `relativePath: "opencode/opencode.jsonc"`, so the resolved path became `~/.config/overture/opencode/opencode.jsonc` and missed the real config entirely.

`runConfigShow(defaultOverturePaths())` is preserved — Overture's own config still resolves correctly under `~/.config/overture/overture.jsonc`.

## Changes

- `apps/cli/src/cli.ts`: import `defaultPathResolutionContext` from `./platforms/detect.js`; replace the `runDetect` call site to use it.
- `apps/cli/src/cli.spec.ts`: add a regression test that drives `run(["detect", "--json"])` end-to-end with a temp `XDG_CONFIG_HOME`, a temp `PATH` containing a fake `opencode` executable, and a temp `opencode.jsonc` (with a `//` JSONC comment to prove the JSONC location is exercised). Asserts OpenCode is `installed`, `mcpSupport: "supported"`, `mcpConfigured: true`, and `matchedMcpLocations` resolves a path ending in `opencode/opencode.jsonc`.

## Verification

- `yarn nx test @jander99/overture --skip-nx-cache`: 88/88 pass
- `yarn nx build @jander99/overture --skip-nx-cache`: green
- `node apps/cli/scripts/verify-package.mjs`: green
- `yarn prettier --check .`: green
- `node apps/cli/dist/main.js detect --json` reports OpenCode as MCP-configured with `resolvedPath: /home/jeff/.config/opencode/opencode.jsonc`
- `overture detect --json` (global binary) reports the same
- `overture config show` still resolves `~/.config/overture/overture.jsonc`

## Diff scope

- `apps/cli/src/cli.spec.ts` (+77/-1)
- `apps/cli/src/cli.ts` (+9/-5)

No protected files touched: `apps/cli/package.json`, `packages/config/src/paths.ts`, `packages/agents/src/opencode.ts`, `apps/cli/src/platforms/detect.ts` are all unchanged.
