### PR TITLE
feat(cli): add overture scan [--json] read-only command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,110 @@ those not installed, with flat additive fields (`detectionStrategy`,
 
 `detect` will not write to or modify any of the files it inspects, and it makes no writes anywhere.
 
+## The `scan` command
+
+`overture scan` is a **read-only** inspection of the relationship between the
+canonical user-level `overture.jsonc` config and each installed agent's MCP
+server configuration. Like `detect`, it never writes, syncs, or modifies any
+configuration file — it only reports what it sees.
+
+The command exposes the scan matrix built by the `@overture/scan-matrix`
+package: the four-agent registry (claude-code, opencode, github-copilot-cli,
+openai-codex) is walked in canonical order, each agent's MCP config is read
+and normalized into canonical server entries, and the resulting matrix is
+classified into pickable conflicts and hard refuses. A future bootstrap or
+apply command will consume this matrix; today it is the first implementation
+of the vision's Read behavior.
+
+### Usage
+
+```bash
+# Print a human-readable summary (default summary shape)
+overture scan
+
+# Machine-readable: full scan matrix + conflict classification as JSON
+overture scan --json
+
+# Print usage and exit 0
+overture scan --help
+```
+
+### Default summary shape
+
+The no-flag path emits five always-present lines (followed by a trailing
+newline):
+
+```
+Scan complete.
+Detected agents: N / 4
+Canonical config: <absent|ready|invalid-profile>
+Hard refuses: <count>
+Run "overture scan --json" for machine-readable details.
+```
+
+When `N === 0` an additional install-suggestion block is appended that names
+the four supported CLIs and the host OSes overture runs on. The summary line
+becomes `Scan completed with blocking issues.` when the exit code is `1`; the
+JSON pointer line is always emitted last so terminal users always know where
+to go next. No ANSI color is emitted; the output is plain text suitable for
+piping.
+
+### JSON output shape
+
+`overture scan --json` emits exactly two top-level keys (no version envelope,
+no `generatedAt`, no `duration`):
+
+```json
+{
+  "matrix": {
+    "canonicalState": "absent",
+    "canonicalProfileName": null,
+    "canonicalIntent": {},
+    "agents": [
+      /* AgentSnapshot[] */
+    ],
+    "rows": [
+      /* ServerStatusRow[] */
+    ]
+  },
+  "conflicts": {
+    "pickable": [
+      /* PickableConflict[] */
+    ],
+    "hardRefuses": [
+      /* HardRefuseConflict[] */
+    ]
+  }
+}
+```
+
+- `matrix.canonicalState` is one of `absent` (no config written),
+  `ready` (config + profile resolved), or `invalid-profile` (config
+  present but default profile missing).
+- `matrix.canonicalIntent` is `{}` when the user has not written a canonical
+  config; pre-canonical users still get a meaningful inventory scan.
+- `matrix.agents` is the four-agent registry in canonical order, regardless
+  of how many are installed.
+- `matrix.rows` is the per-server status classification (`aligned`,
+  `missing-from-agent`, `extra-in-agent`, `different-settings`,
+  `shape-conflict`, `parse-error`, `unsupported-agent`, `not-installed`).
+- `conflicts.pickable` is populated only when canonical intent is absent:
+  one entry per server-name group with at least two non-equal normalized
+  candidates.
+- `conflicts.hardRefuses` covers parse errors, shape conflicts, canonical
+  settings drift, and same-name groups spanning both `stdio` and `remote`
+  transports.
+
+### Exit codes
+
+| Exit code | Meaning                                                                                                                                                                                                         |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`       | Scan ran cleanly. No `invalid-profile` state, no `hardRefuses`. The "no agents installed" case also returns `0` because an empty inventory is a valid scan result, not an error.                                |
+| `1`       | Scan ran but produced a blocking state: `matrix.canonicalState === 'invalid-profile'` OR `conflicts.hardRefuses.length > 0`. The JSON envelope is still written to stdout so consumers can inspect what failed. |
+| `2`       | Usage error (unknown flag) or pre-model orchestration failure (canonical config parse / validation error, unexpected thrown error). No scan matrix is emitted to stdout; the message goes to stderr.            |
+
+`scan` will not write to or modify any of the files it inspects, and it makes no writes anywhere.
+
 ## Repository layout
 
 ```

--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -150,6 +150,64 @@ try {
   fail(`detect --json output is not valid JSON: ${err.message}`);
 }
 
+// scan --json smoke: assert the C1 envelope shape and a non-error exit
+// code. C1 accepts exit codes 0 (clean scan) and 1 (blocking state —
+// invalid-profile or hard-refuse). Exit code 2 is reserved for usage
+// errors and pre-model orchestration failures; if we see 2 here, the
+// installed package is broken.
+const scanResult = spawnSync('node', [distMain, 'scan', '--json'], {
+  encoding: 'utf8',
+});
+if (scanResult.status !== 0 && scanResult.status !== 1) {
+  fail(
+    `scan --json exited ${scanResult.status} (expected 0 or 1): ${scanResult.stderr}`,
+  );
+}
+try {
+  const scan = JSON.parse(scanResult.stdout);
+  const topKeys = Object.keys(scan).sort();
+  const expectedTopKeys = ['conflicts', 'matrix'];
+  if (
+    topKeys.length !== expectedTopKeys.length ||
+    !expectedTopKeys.every((k) => topKeys.includes(k))
+  ) {
+    fail(
+      `scan --json top-level keys are [${topKeys.join(', ')}]; expected exactly [${expectedTopKeys.join(', ')}]`,
+    );
+  }
+  const matrixKeys = Object.keys(scan.matrix).sort();
+  const expectedMatrixKeys = [
+    'agents',
+    'canonicalIntent',
+    'canonicalProfileName',
+    'canonicalState',
+    'rows',
+  ];
+  if (
+    matrixKeys.length !== expectedMatrixKeys.length ||
+    !expectedMatrixKeys.every((k) => matrixKeys.includes(k))
+  ) {
+    fail(
+      `scan --json matrix keys are [${matrixKeys.join(', ')}]; expected exactly [${expectedMatrixKeys.join(', ')}]`,
+    );
+  }
+  const conflictsKeys = Object.keys(scan.conflicts).sort();
+  const expectedConflictsKeys = ['hardRefuses', 'pickable'];
+  if (
+    conflictsKeys.length !== expectedConflictsKeys.length ||
+    !expectedConflictsKeys.every((k) => conflictsKeys.includes(k))
+  ) {
+    fail(
+      `scan --json conflicts keys are [${conflictsKeys.join(', ')}]; expected exactly [${expectedConflictsKeys.join(', ')}]`,
+    );
+  }
+  console.log(
+    `scan --json: exit=${scanResult.status} matrix.agents=${scan.matrix.agents.length} pickable=${scan.conflicts.pickable.length} hardRefuses=${scan.conflicts.hardRefuses.length}: PASS`,
+  );
+} catch (err) {
+  fail(`scan --json output is not valid JSON: ${err.message}`);
+}
+
 logStep('Cleanup');
 rmSync(packTmp, { recursive: true, force: true });
 rmSync(cleanTmp, { recursive: true, force: true });

--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -745,4 +745,161 @@ describe('run: scan', () => {
     const code = await run(['scan']);
     expect(code).toBe(0);
   });
+
+  it('--json with no agents installed returns 0 and emits the matrix envelope', async () => {
+    // Scrub PATH and any XDG agent config dirs to guarantee "no agents
+    // installed". The dev machine may have opencode/claude/codex/copilot
+    // on the real PATH; we explicitly do NOT want them showing up in the
+    // matrix for this contract test.
+    const pathDir = mkdtempSync(join(tmpdir(), 'overture-scan-empty-path-'));
+    const prevPath = process.env.PATH;
+    process.env.PATH = pathDir;
+    try {
+      const code = await run(['scan', '--json']);
+      expect(code).toBe(0);
+
+      const out = stdoutSpy.mock.calls
+        .map((c: readonly unknown[]) => c[0] as string)
+        .join('');
+      const parsed = JSON.parse(out) as {
+        matrix: {
+          canonicalState: string;
+          agents: { id: string; installed: boolean; readState: string }[];
+        };
+        conflicts: { hardRefuses: unknown[]; pickable: unknown[] };
+      };
+
+      expect(parsed.matrix.canonicalState).toBe('absent');
+      expect(parsed.matrix.agents.length).toBeGreaterThanOrEqual(1);
+      for (const agent of parsed.matrix.agents) {
+        expect(agent.installed).toBe(false);
+        expect(agent.readState).toBe('not-installed');
+      }
+      expect(parsed.conflicts.hardRefuses).toEqual([]);
+    } finally {
+      if (prevPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = prevPath;
+      }
+      rmSync(pathDir, { recursive: true, force: true });
+    }
+  });
+  it('--json returns 2 and writes the parse error to stderr when overture.jsonc is malformed', async () => {
+    const configDir = join(tempDir, 'overture');
+    mkdirSync(configDir, { recursive: true });
+    // Broken JSONC: a string that is not valid JSON, so jsonc-parser will
+    // report an error and the loader will throw.
+    writeFileSync(
+      join(configDir, 'overture.jsonc'),
+      '{ "version": 1, "profiles": ',
+      'utf8',
+    );
+
+    const code = await run(['scan', '--json']);
+    expect(code).toBe(2);
+
+    const err = stderrSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+    expect(err.length).toBeGreaterThan(0);
+    expect(err.toLowerCase()).toContain('overture.jsonc');
+
+    // The pre-model orchestration failure must NOT emit a fake matrix.
+    const out = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+    expect(out).not.toContain('{');
+  });
+
+  it('--json returns 1 and reports invalid-profile when the named default profile does not exist', async () => {
+    const configDir = join(tempDir, 'overture');
+    mkdirSync(configDir, { recursive: true });
+    // Valid schema (version: 1, a `default` profile so refine() passes),
+    // but `settings.defaultProfile` points at a profile the map does not
+    // contain. The scan-matrix resolver turns this into
+    // `canonicalState: 'invalid-profile'`, which the helper maps to exit 1.
+    writeFileSync(
+      join(configDir, 'overture.jsonc'),
+      JSON.stringify({
+        version: 1,
+        settings: { defaultProfile: 'does-not-exist' },
+        profiles: {
+          default: {
+            mcpServers: {},
+            sync: { targets: [] },
+            skills: [],
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    const code = await run(['scan', '--json']);
+    expect(code).toBe(1);
+
+    const out = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+    const parsed = JSON.parse(out) as {
+      matrix: { canonicalState: string };
+      conflicts: { hardRefuses: unknown[] };
+    };
+    expect(parsed.matrix.canonicalState).toBe('invalid-profile');
+    // invalid-profile is its own signal; no parse-error refuses should
+    // also be emitted because no agent config files exist in tempDir.
+    expect(parsed.conflicts.hardRefuses).toEqual([]);
+  });
+
+  it('--json returns 1 and emits a parse-error hardRefuse when an agent config is malformed', async () => {
+    const pathDir = mkdtempSync(join(tmpdir(), 'overture-scan-path-'));
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${pathDir}${prevPath ? `:${prevPath}` : ''}`;
+    // opencode is binary-first, so install a fake binary on a temp PATH
+    // entry first to make the agent 'installed' from the detector's POV.
+    const opencodeBin = join(pathDir, 'opencode');
+    writeFileSync(opencodeBin, '#!/bin/sh\nexit 0\n');
+    chmodSync(opencodeBin, 0o755);
+
+    // Then drop a malformed JSONC at the first opencode mcpLocation. The
+    // agent's `mcp.read` will throw a parseError, which `classifyConflicts`
+    // turns into a `parse-error` hardRefuse — exit 1.
+    const opencodeDir = join(tempDir, 'opencode');
+    mkdirSync(opencodeDir, { recursive: true });
+    writeFileSync(
+      join(opencodeDir, 'opencode.jsonc'),
+      '{ "mcp": { this is not valid jsonc',
+      'utf8',
+    );
+
+    try {
+      const code = await run(['scan', '--json']);
+      expect(code).toBe(1);
+
+      const out = stdoutSpy.mock.calls
+        .map((c: readonly unknown[]) => c[0] as string)
+        .join('');
+      const parsed = JSON.parse(out) as {
+        matrix: { agents: { id: string; readState: string }[] };
+        conflicts: {
+          hardRefuses: { reason: string; agentId: string | null }[];
+        };
+      };
+
+      const opencode = parsed.matrix.agents.find((a) => a.id === 'opencode');
+      expect(opencode?.readState).toBe('parse-error');
+      expect(parsed.conflicts.hardRefuses.length).toBeGreaterThanOrEqual(1);
+      const opencodeRefuse = parsed.conflicts.hardRefuses.find(
+        (h) => h.agentId === 'opencode',
+      );
+      expect(opencodeRefuse?.reason).toBe('parse-error');
+    } finally {
+      if (prevPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = prevPath;
+      }
+      rmSync(pathDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -741,11 +741,6 @@ describe('run: scan', () => {
     expect(err).toContain('Usage: overture scan');
   });
 
-  it('with no flag returns 0 (placeholder for the Task 5 human formatter)', async () => {
-    const code = await run(['scan']);
-    expect(code).toBe(0);
-  });
-
   it('--json with no agents installed returns 0 and emits the matrix envelope', async () => {
     // Scrub PATH and any XDG agent config dirs to guarantee "no agents
     // installed". The dev machine may have opencode/claude/codex/copilot
@@ -893,6 +888,98 @@ describe('run: scan', () => {
         (h) => h.agentId === 'opencode',
       );
       expect(opencodeRefuse?.reason).toBe('parse-error');
+    } finally {
+      if (prevPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = prevPath;
+      }
+      rmSync(pathDir, { recursive: true, force: true });
+    }
+  });
+  it('no-flag scan with no installed agents returns 0 and writes the human summary', async () => {
+    const pathDir = mkdtempSync(join(tmpdir(), 'overture-scan-hum-path-'));
+    const prevPath = process.env.PATH;
+    process.env.PATH = pathDir;
+    try {
+      const code = await run(['scan']);
+      expect(code).toBe(0);
+      const out = stdoutSpy.mock.calls
+        .map((c: readonly unknown[]) => c[0] as string)
+        .join('');
+      expect(out).toContain('Scan complete.');
+      expect(out).toContain('Detected agents: 0 / 4');
+      expect(out).toContain('Canonical config: absent');
+      expect(out).toContain('Hard refuses: 0');
+      expect(out).toContain(
+        'Run "overture scan --json" for machine-readable details.',
+      );
+      expect(out).toContain('Claude Code');
+      expect(out).toContain('OpenCode');
+      expect(out).toContain('GitHub Copilot CLI');
+      expect(out).toContain('OpenAI Codex');
+      expect(out).toContain('linux');
+      expect(out).toContain('darwin');
+      expect(out).toContain('No supported MCP-capable agents detected.');
+      expect(out).not.toMatch(/\x1b\[/);
+      expect(out).not.toContain('\x1b');
+    } finally {
+      if (prevPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = prevPath;
+      }
+      rmSync(pathDir, { recursive: true, force: true });
+    }
+  });
+
+  it('no-flag scan with parse-error agent config returns 1 and writes the blocking summary', async () => {
+    const pathDir = mkdtempSync(join(tmpdir(), 'overture-scan-hum-hardref-'));
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${pathDir}${prevPath ? `:${prevPath}` : ''}`;
+    const opencodeBin = join(pathDir, 'opencode');
+    writeFileSync(opencodeBin, '#!/bin/sh\nexit 0\n');
+    chmodSync(opencodeBin, 0o755);
+    const opencodeDir = join(tempDir, 'opencode');
+    mkdirSync(opencodeDir, { recursive: true });
+    writeFileSync(
+      join(opencodeDir, 'opencode.jsonc'),
+      '{ "mcp": { this is not valid jsonc',
+      'utf8',
+    );
+    try {
+      const code = await run(['scan']);
+      expect(code).toBe(1);
+      const out = stdoutSpy.mock.calls
+        .map((c: readonly unknown[]) => c[0] as string)
+        .join('');
+      expect(out).toContain('Scan completed with blocking issues.');
+      expect(out).toContain('Hard refuses: 1');
+      expect(out).not.toContain('"matrix"');
+    } finally {
+      if (prevPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = prevPath;
+      }
+      rmSync(pathDir, { recursive: true, force: true });
+    }
+  });
+
+  it('no-flag scan with OpenCode installed returns 0 and includes "Scan complete."', async () => {
+    const pathDir = mkdtempSync(join(tmpdir(), 'overture-scan-hum-opencode-'));
+    const prevPath = process.env.PATH;
+    process.env.PATH = `${pathDir}${prevPath ? `:${prevPath}` : ''}`;
+    const opencodeBin = join(pathDir, 'opencode');
+    writeFileSync(opencodeBin, '#!/bin/sh\nexit 0\n');
+    chmodSync(opencodeBin, 0o755);
+    try {
+      const code = await run(['scan']);
+      expect(code).toBe(0);
+      const out = stdoutSpy.mock.calls
+        .map((c: readonly unknown[]) => c[0] as string)
+        .join('');
+      expect(out).toContain('Scan complete.');
     } finally {
       if (prevPath === undefined) {
         delete process.env.PATH;

--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -658,3 +658,91 @@ describe('run (config show)', () => {
     expect(err).toContain('config');
   });
 });
+
+describe('run: scan', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let tempDir: string;
+  let prevHome: string | undefined;
+  let prevXdgConfig: string | undefined;
+  let prevXdgState: string | undefined;
+  let prevXdgCache: string | undefined;
+
+  beforeEach(() => {
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    tempDir = mkdtempSync(join(tmpdir(), 'overture-scan-'));
+    prevHome = process.env.HOME;
+    prevXdgConfig = process.env.XDG_CONFIG_HOME;
+    prevXdgState = process.env.XDG_STATE_HOME;
+    prevXdgCache = process.env.XDG_CACHE_HOME;
+    process.env.HOME = tempDir;
+    process.env.XDG_CONFIG_HOME = tempDir;
+    process.env.XDG_STATE_HOME = tempDir;
+    process.env.XDG_CACHE_HOME = tempDir;
+    __setPlatformForTests('linux');
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    __setPlatformForTests(null);
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevXdgConfig === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevXdgConfig;
+    if (prevXdgState === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = prevXdgState;
+    if (prevXdgCache === undefined) delete process.env.XDG_CACHE_HOME;
+    else process.env.XDG_CACHE_HOME = prevXdgCache;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('--json returns 0 and writes parseable JSON with only matrix and conflicts keys', async () => {
+    const code = await run(['scan', '--json']);
+    expect(code).toBe(0);
+    const out = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+    const parsed = JSON.parse(out) as Record<string, unknown>;
+    expect(Object.keys(parsed).sort()).toEqual(['conflicts', 'matrix']);
+    expect(parsed).not.toHaveProperty('version');
+    expect(parsed).not.toHaveProperty('generatedAt');
+    expect(parsed).not.toHaveProperty('duration');
+  });
+
+  it('--help returns 0 and prints the scan usage line', async () => {
+    const code = await run(['scan', '--help']);
+    expect(code).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: overture scan [--json]'),
+    );
+  });
+
+  it('-h returns 0 and prints the scan usage line', async () => {
+    const code = await run(['scan', '-h']);
+    expect(code).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: overture scan [--json]'),
+    );
+  });
+
+  it('--bogus returns 2 and mentions the bad flag plus the usage line', async () => {
+    const code = await run(['scan', '--bogus']);
+    expect(code).toBe(2);
+    const err = stderrSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+    expect(err).toContain('--bogus');
+    expect(err).toContain('Usage: overture scan');
+  });
+
+  it('with no flag returns 0 (placeholder for the Task 5 human formatter)', async () => {
+    const code = await run(['scan']);
+    expect(code).toBe(0);
+  });
+});

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -11,6 +11,7 @@ import {
   defaultPathResolutionContext,
   detectPlatforms,
 } from './platforms/detect.js';
+import { buildScanJsonOutput } from './scan.js';
 import { agentRegistry, type McpServerEntry } from '@overture/agents';
 import type { DetectJsonOutput } from './platforms/types.js';
 
@@ -151,7 +152,8 @@ export function formatHumanOutput(output: DetectJsonOutput): string {
 const USAGE =
   'Usage: overture <command> [flags]\n\nCommands:\n' +
   '  detect [--json]   Detect installed MCP-capable platforms.\n' +
-  '  config show       Print the resolved user-level overture config.\n';
+  '  config show       Print the resolved user-level overture config.\n' +
+  '  scan [--json]     Build the installed MCP server matrix.\n';
 
 async function runDetect(flags: readonly string[]): Promise<number> {
   if (flags.includes('--help') || flags.includes('-h')) {
@@ -171,6 +173,56 @@ async function runDetect(flags: readonly string[]): Promise<number> {
     return 0;
   }
   process.stdout.write(formatHumanOutput(output));
+  return 0;
+}
+
+type StringWriter = { write(chunk: string): boolean };
+
+/**
+ * Dispatch the `overture scan` subcommand. Mirrors the {@link runDetect}
+ * shape but routes through {@link buildScanJsonOutput} so the JSON output is
+ * the same model the C1 adapter exposes to other consumers.
+ *
+ * Flags:
+ * - `--help` / `-h` — print the scan usage line and exit 0.
+ * - `--json`       — write `{ matrix, conflicts }` to stdout and exit 0.
+ * - (no flag)      — placeholder for Task 5's human formatter; exit 0.
+ * - anything else  — write a usage hint to stderr and exit 2.
+ *
+ * `stdout` / `stderr` are injected so tests can pass mocks; the production
+ * dispatcher in {@link run} always passes `process.stdout` / `process.stderr`.
+ */
+async function runScan(
+  args: readonly string[],
+  stdout: StringWriter,
+  stderr: StringWriter,
+): Promise<number> {
+  if (args.includes('--help') || args.includes('-h')) {
+    stdout.write('Usage: overture scan [--json]\n');
+    return 0;
+  }
+  const unknownFlags = args.filter((f) => f !== '--json');
+  if (unknownFlags.length > 0) {
+    stderr.write(
+      `Unknown flag: ${unknownFlags[0]}\nUsage: overture scan [--json]\n`,
+    );
+    return 2;
+  }
+  if (args.includes('--json')) {
+    let config: OvertureConfig | null = null;
+    try {
+      config = await loadOvertureConfig(defaultOverturePaths());
+    } catch {
+      config = null;
+    }
+    const { matrix, conflicts } = await buildScanJsonOutput({
+      ctx: defaultPathResolutionContext(),
+      config,
+    });
+    stdout.write(JSON.stringify({ matrix, conflicts }, null, 2) + '\n');
+    return 0;
+  }
+  // No flag (default): Task 5 will replace this with the human formatter.
   return 0;
 }
 
@@ -257,6 +309,10 @@ export async function run(args: readonly string[]): Promise<number> {
 
   if (args[0] === 'config') {
     return runConfig(args.slice(1));
+  }
+
+  if (args[0] === 'scan') {
+    return runScan(args.slice(1), process.stdout, process.stderr);
   }
 
   process.stderr.write(`Unknown command: ${args[0]}\n${USAGE}`);

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -11,7 +11,7 @@ import {
   defaultPathResolutionContext,
   detectPlatforms,
 } from './platforms/detect.js';
-import { buildScanJsonOutput } from './scan.js';
+import { buildScanJsonOutput, type ScanJsonOutput } from './scan.js';
 import { agentRegistry, type McpServerEntry } from '@overture/agents';
 import type { DetectJsonOutput } from './platforms/types.js';
 
@@ -176,18 +176,52 @@ async function runDetect(flags: readonly string[]): Promise<number> {
   return 0;
 }
 
-type StringWriter = { write(chunk: string): boolean };
+interface StringWriter {
+  write(chunk: string): boolean;
+}
+
+/**
+ * Decide the exit code for a successful `--json` scan based on the model the
+ * C1 adapter emits. Exposed so the contract is unit-testable in isolation and
+ * so the dispatcher in {@link runScan} only orchestrates I/O.
+ *
+ * Contract (Task 4):
+ * - `0` — the scan matrix has no invalid-profile state and no hard-refuse
+ *   conflicts. "No agents installed" returns `0` because an empty inventory is
+ *   a valid scan result, not an error.
+ * - `1` — `matrix.canonicalState === 'invalid-profile'` OR
+ *   `conflicts.hardRefuses.length > 0`. The JSON envelope is still written to
+ *   stdout so consumers can inspect what failed.
+ *
+ * Other exit codes (`2` for usage errors and pre-model orchestration failures)
+ * are owned by the dispatcher, not this helper.
+ */
+function exitCodeForScan(
+  matrix: ScanJsonOutput['matrix'],
+  conflicts: ScanJsonOutput['conflicts'],
+): 0 | 1 {
+  if (matrix.canonicalState === 'invalid-profile') return 1;
+  if (conflicts.hardRefuses.length > 0) return 1;
+  return 0;
+}
 
 /**
  * Dispatch the `overture scan` subcommand. Mirrors the {@link runDetect}
  * shape but routes through {@link buildScanJsonOutput} so the JSON output is
  * the same model the C1 adapter exposes to other consumers.
  *
- * Flags:
- * - `--help` / `-h` — print the scan usage line and exit 0.
- * - `--json`       — write `{ matrix, conflicts }` to stdout and exit 0.
- * - (no flag)      — placeholder for Task 5's human formatter; exit 0.
- * - anything else  — write a usage hint to stderr and exit 2.
+ * Exit codes:
+ * - `0` — clean scan (no invalid-profile state, no hard-refuse conflicts),
+ *   including the "no agents installed" case; also returned for `--help` /
+ *   `-h` and the no-flag placeholder that Task 5 will replace.
+ * - `1` — scan ran but produced a `matrix.canonicalState === 'invalid-profile'`
+ *   state, or `conflicts.hardRefuses` is non-empty. The JSON envelope is
+ *   still emitted to stdout before the non-zero exit so consumers can read
+ *   the failure model.
+ * - `2` — usage errors (unknown flags, already wired) AND pre-model
+ *   orchestration failures (canonical config parse / validation errors, any
+ *   unexpected thrown error). The dispatcher writes the error message to
+ *   stderr and does NOT emit a fake scan matrix to stdout.
  *
  * `stdout` / `stderr` are injected so tests can pass mocks; the production
  * dispatcher in {@link run} always passes `process.stdout` / `process.stderr`.
@@ -209,23 +243,32 @@ async function runScan(
     return 2;
   }
   if (args.includes('--json')) {
-    let config: OvertureConfig | null = null;
+    let config: OvertureConfig | null;
     try {
       config = await loadOvertureConfig(defaultOverturePaths());
-    } catch {
-      config = null;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      stderr.write(`${message}\n`);
+      return 2;
     }
-    const { matrix, conflicts } = await buildScanJsonOutput({
-      ctx: defaultPathResolutionContext(),
-      config,
-    });
+    let scanOutput: ScanJsonOutput;
+    try {
+      scanOutput = await buildScanJsonOutput({
+        ctx: defaultPathResolutionContext(),
+        config,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      stderr.write(`${message}\n`);
+      return 2;
+    }
+    const { matrix, conflicts } = scanOutput;
     stdout.write(JSON.stringify({ matrix, conflicts }, null, 2) + '\n');
-    return 0;
+    return exitCodeForScan(matrix, conflicts);
   }
   // No flag (default): Task 5 will replace this with the human formatter.
   return 0;
 }
-
 function renderConfigNotFound(paths: OverturePaths): string {
   return (
     `No overture config found at ${paths.configFile}\n` +

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -206,6 +206,58 @@ function exitCodeForScan(
 }
 
 /**
+ * Render the default-human summary for `overture scan` (the no-flag path).
+ *
+ * Always emitted lines:
+ * - `Scan complete.`                          — `exitCodeForScan === 0`
+ *   OR `Scan completed with blocking issues.` — `exitCodeForScan === 1`.
+ * - `Detected agents: N / 4`                  — count of `matrix.agents`
+ *   entries with `installed === true`. The `/ 4` denominator is the
+ *   canonical four-agent registry (claude-code, opencode,
+ *   github-copilot-cli, openai-codex).
+ * - `Canonical config: <state>`              — verbatim `matrix.canonicalState`
+ *   (`absent` | `ready` | `invalid-profile`).
+ * - `Hard refuses: <count>`                   — `conflicts.hardRefuses.length`.
+ * - `Run "overture scan --json" ...`          — pointer to the machine-readable
+ *   path so terminal users always know where to go next.
+ *
+ * When zero agents are detected, an additional install-suggestion block is
+ * appended that names the four supported CLIs and the host OSes overture
+ * runs on. The block is suppressed when at least one agent is installed
+ * because the inventory already proves the user's platform supports one.
+ *
+ * Output is plain text: no ANSI escape sequences, no trailing newline.
+ * The dispatcher in {@link runScan} appends the final `\n` when writing to
+ * stdout.
+ */
+export function formatHumanScanSummary(
+  matrix: ScanJsonOutput['matrix'],
+  conflicts: ScanJsonOutput['conflicts'],
+): string {
+  const installedCount = matrix.agents.filter((a) => a.installed).length;
+  const blocking = exitCodeForScan(matrix, conflicts) === 1;
+  const lines: string[] = [
+    blocking ? 'Scan completed with blocking issues.' : 'Scan complete.',
+    `Detected agents: ${installedCount} / 4`,
+    `Canonical config: ${matrix.canonicalState}`,
+    `Hard refuses: ${conflicts.hardRefuses.length}`,
+    'Run "overture scan --json" for machine-readable details.',
+  ];
+  if (installedCount === 0) {
+    lines.push(
+      '',
+      'No supported MCP-capable agents detected.',
+      'Install one of these CLI agents on a supported OS (linux/darwin):',
+      '  - Claude Code',
+      '  - OpenCode',
+      '  - GitHub Copilot CLI',
+      '  - OpenAI Codex',
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
  * Dispatch the `overture scan` subcommand. Mirrors the {@link runDetect}
  * shape but routes through {@link buildScanJsonOutput} so the JSON output is
  * the same model the C1 adapter exposes to other consumers.
@@ -213,7 +265,7 @@ function exitCodeForScan(
  * Exit codes:
  * - `0` — clean scan (no invalid-profile state, no hard-refuse conflicts),
  *   including the "no agents installed" case; also returned for `--help` /
- *   `-h` and the no-flag placeholder that Task 5 will replace.
+ *   `-h` and the no-flag human summary path.
  * - `1` — scan ran but produced a `matrix.canonicalState === 'invalid-profile'`
  *   state, or `conflicts.hardRefuses` is non-empty. The JSON envelope is
  *   still emitted to stdout before the non-zero exit so consumers can read
@@ -266,8 +318,28 @@ async function runScan(
     stdout.write(JSON.stringify({ matrix, conflicts }, null, 2) + '\n');
     return exitCodeForScan(matrix, conflicts);
   }
-  // No flag (default): Task 5 will replace this with the human formatter.
-  return 0;
+  let config: OvertureConfig | null;
+  try {
+    config = await loadOvertureConfig(defaultOverturePaths());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    stderr.write(`${message}\n`);
+    return 2;
+  }
+  let scanOutput: ScanJsonOutput;
+  try {
+    scanOutput = await buildScanJsonOutput({
+      ctx: defaultPathResolutionContext(),
+      config,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    stderr.write(`${message}\n`);
+    return 2;
+  }
+  const { matrix, conflicts } = scanOutput;
+  stdout.write(formatHumanScanSummary(matrix, conflicts) + '\n');
+  return exitCodeForScan(matrix, conflicts);
 }
 function renderConfigNotFound(paths: OverturePaths): string {
   return (

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -7,14 +7,15 @@ import {
   type OvertureConfig,
   type OverturePaths,
 } from '@overture/config';
+
 import {
   defaultPathResolutionContext,
   detectPlatforms,
 } from './platforms/detect.js';
-import { buildScanJsonOutput, type ScanJsonOutput } from './scan.js';
+
 import { agentRegistry, type McpServerEntry } from '@overture/agents';
 import type { DetectJsonOutput } from './platforms/types.js';
-
+import { runScan } from './scan-command.js';
 /**
  * Indirection over `process.platform` so tests can force a specific host
  * (e.g. `win32`) without having to mutate Node's global state. Production
@@ -176,171 +177,6 @@ async function runDetect(flags: readonly string[]): Promise<number> {
   return 0;
 }
 
-interface StringWriter {
-  write(chunk: string): boolean;
-}
-
-/**
- * Decide the exit code for a successful `--json` scan based on the model the
- * C1 adapter emits. Exposed so the contract is unit-testable in isolation and
- * so the dispatcher in {@link runScan} only orchestrates I/O.
- *
- * Contract (Task 4):
- * - `0` — the scan matrix has no invalid-profile state and no hard-refuse
- *   conflicts. "No agents installed" returns `0` because an empty inventory is
- *   a valid scan result, not an error.
- * - `1` — `matrix.canonicalState === 'invalid-profile'` OR
- *   `conflicts.hardRefuses.length > 0`. The JSON envelope is still written to
- *   stdout so consumers can inspect what failed.
- *
- * Other exit codes (`2` for usage errors and pre-model orchestration failures)
- * are owned by the dispatcher, not this helper.
- */
-function exitCodeForScan(
-  matrix: ScanJsonOutput['matrix'],
-  conflicts: ScanJsonOutput['conflicts'],
-): 0 | 1 {
-  if (matrix.canonicalState === 'invalid-profile') return 1;
-  if (conflicts.hardRefuses.length > 0) return 1;
-  return 0;
-}
-
-/**
- * Render the default-human summary for `overture scan` (the no-flag path).
- *
- * Always emitted lines:
- * - `Scan complete.`                          — `exitCodeForScan === 0`
- *   OR `Scan completed with blocking issues.` — `exitCodeForScan === 1`.
- * - `Detected agents: N / 4`                  — count of `matrix.agents`
- *   entries with `installed === true`. The `/ 4` denominator is the
- *   canonical four-agent registry (claude-code, opencode,
- *   github-copilot-cli, openai-codex).
- * - `Canonical config: <state>`              — verbatim `matrix.canonicalState`
- *   (`absent` | `ready` | `invalid-profile`).
- * - `Hard refuses: <count>`                   — `conflicts.hardRefuses.length`.
- * - `Run "overture scan --json" ...`          — pointer to the machine-readable
- *   path so terminal users always know where to go next.
- *
- * When zero agents are detected, an additional install-suggestion block is
- * appended that names the four supported CLIs and the host OSes overture
- * runs on. The block is suppressed when at least one agent is installed
- * because the inventory already proves the user's platform supports one.
- *
- * Output is plain text: no ANSI escape sequences, no trailing newline.
- * The dispatcher in {@link runScan} appends the final `\n` when writing to
- * stdout.
- */
-export function formatHumanScanSummary(
-  matrix: ScanJsonOutput['matrix'],
-  conflicts: ScanJsonOutput['conflicts'],
-): string {
-  const installedCount = matrix.agents.filter((a) => a.installed).length;
-  const blocking = exitCodeForScan(matrix, conflicts) === 1;
-  const lines: string[] = [
-    blocking ? 'Scan completed with blocking issues.' : 'Scan complete.',
-    `Detected agents: ${installedCount} / 4`,
-    `Canonical config: ${matrix.canonicalState}`,
-    `Hard refuses: ${conflicts.hardRefuses.length}`,
-    'Run "overture scan --json" for machine-readable details.',
-  ];
-  if (installedCount === 0) {
-    lines.push(
-      '',
-      'No supported MCP-capable agents detected.',
-      'Install one of these CLI agents on a supported OS (linux/darwin):',
-      '  - Claude Code',
-      '  - OpenCode',
-      '  - GitHub Copilot CLI',
-      '  - OpenAI Codex',
-    );
-  }
-  return lines.join('\n');
-}
-
-/**
- * Dispatch the `overture scan` subcommand. Mirrors the {@link runDetect}
- * shape but routes through {@link buildScanJsonOutput} so the JSON output is
- * the same model the C1 adapter exposes to other consumers.
- *
- * Exit codes:
- * - `0` — clean scan (no invalid-profile state, no hard-refuse conflicts),
- *   including the "no agents installed" case; also returned for `--help` /
- *   `-h` and the no-flag human summary path.
- * - `1` — scan ran but produced a `matrix.canonicalState === 'invalid-profile'`
- *   state, or `conflicts.hardRefuses` is non-empty. The JSON envelope is
- *   still emitted to stdout before the non-zero exit so consumers can read
- *   the failure model.
- * - `2` — usage errors (unknown flags, already wired) AND pre-model
- *   orchestration failures (canonical config parse / validation errors, any
- *   unexpected thrown error). The dispatcher writes the error message to
- *   stderr and does NOT emit a fake scan matrix to stdout.
- *
- * `stdout` / `stderr` are injected so tests can pass mocks; the production
- * dispatcher in {@link run} always passes `process.stdout` / `process.stderr`.
- */
-async function runScan(
-  args: readonly string[],
-  stdout: StringWriter,
-  stderr: StringWriter,
-): Promise<number> {
-  if (args.includes('--help') || args.includes('-h')) {
-    stdout.write('Usage: overture scan [--json]\n');
-    return 0;
-  }
-  const unknownFlags = args.filter((f) => f !== '--json');
-  if (unknownFlags.length > 0) {
-    stderr.write(
-      `Unknown flag: ${unknownFlags[0]}\nUsage: overture scan [--json]\n`,
-    );
-    return 2;
-  }
-  if (args.includes('--json')) {
-    let config: OvertureConfig | null;
-    try {
-      config = await loadOvertureConfig(defaultOverturePaths());
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      stderr.write(`${message}\n`);
-      return 2;
-    }
-    let scanOutput: ScanJsonOutput;
-    try {
-      scanOutput = await buildScanJsonOutput({
-        ctx: defaultPathResolutionContext(),
-        config,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      stderr.write(`${message}\n`);
-      return 2;
-    }
-    const { matrix, conflicts } = scanOutput;
-    stdout.write(JSON.stringify({ matrix, conflicts }, null, 2) + '\n');
-    return exitCodeForScan(matrix, conflicts);
-  }
-  let config: OvertureConfig | null;
-  try {
-    config = await loadOvertureConfig(defaultOverturePaths());
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    stderr.write(`${message}\n`);
-    return 2;
-  }
-  let scanOutput: ScanJsonOutput;
-  try {
-    scanOutput = await buildScanJsonOutput({
-      ctx: defaultPathResolutionContext(),
-      config,
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    stderr.write(`${message}\n`);
-    return 2;
-  }
-  const { matrix, conflicts } = scanOutput;
-  stdout.write(formatHumanScanSummary(matrix, conflicts) + '\n');
-  return exitCodeForScan(matrix, conflicts);
-}
 function renderConfigNotFound(paths: OverturePaths): string {
   return (
     `No overture config found at ${paths.configFile}\n` +

--- a/apps/cli/src/scan-command.ts
+++ b/apps/cli/src/scan-command.ts
@@ -1,0 +1,173 @@
+import {
+  defaultOverturePaths,
+  loadOvertureConfig,
+  type OvertureConfig,
+} from '@overture/config';
+import { defaultPathResolutionContext } from './platforms/detect.js';
+import { buildScanJsonOutput, type ScanJsonOutput } from './scan.js';
+
+export interface StringWriter {
+  write(chunk: string): boolean;
+}
+
+/**
+ * Decide the exit code for a successful `--json` scan based on the model the
+ * C1 adapter emits. Exposed so the contract is unit-testable in isolation and
+ * so the dispatcher in {@link runScan} only orchestrates I/O.
+ *
+ * Contract (Task 4):
+ * - `0` — the scan matrix has no invalid-profile state and no hard-refuse
+ *   conflicts. "No agents installed" returns `0` because an empty inventory is
+ *   a valid scan result, not an error.
+ * - `1` — `matrix.canonicalState === 'invalid-profile'` OR
+ *   `conflicts.hardRefuses.length > 0`. The JSON envelope is still written to
+ *   stdout so consumers can inspect what failed.
+ *
+ * Other exit codes (`2` for usage errors and pre-model orchestration failures)
+ * are owned by the dispatcher, not this helper.
+ */
+export function exitCodeForScan(
+  matrix: ScanJsonOutput['matrix'],
+  conflicts: ScanJsonOutput['conflicts'],
+): 0 | 1 {
+  if (matrix.canonicalState === 'invalid-profile') return 1;
+  if (conflicts.hardRefuses.length > 0) return 1;
+  return 0;
+}
+
+/**
+ * Render the default-human summary for `overture scan` (the no-flag path).
+ *
+ * Always emitted lines:
+ * - `Scan complete.`                          — `exitCodeForScan === 0`
+ *   OR `Scan completed with blocking issues.` — `exitCodeForScan === 1`.
+ * - `Detected agents: N / 4`                  — count of `matrix.agents`
+ *   entries with `installed === true`. The `/ 4` denominator is the
+ *   canonical four-agent registry (claude-code, opencode,
+ *   github-copilot-cli, openai-codex).
+ * - `Canonical config: <state>`              — verbatim `matrix.canonicalState`
+ *   (`absent` | `ready` | `invalid-profile`).
+ * - `Hard refuses: <count>`                   — `conflicts.hardRefuses.length`.
+ * - `Run "overture scan --json" ...`          — pointer to the machine-readable
+ *   path so terminal users always know where to go next.
+ *
+ * When zero agents are detected, an additional install-suggestion block is
+ * appended that names the four supported CLIs and the host OSes overture
+ * runs on. The block is suppressed when at least one agent is installed
+ * because the inventory already proves the user's platform supports one.
+ *
+ * Output is plain text: no ANSI escape sequences, no trailing newline.
+ * The dispatcher in {@link runScan} appends the final `\n` when writing to
+ * stdout.
+ */
+export function formatHumanScanSummary(
+  matrix: ScanJsonOutput['matrix'],
+  conflicts: ScanJsonOutput['conflicts'],
+): string {
+  const installedCount = matrix.agents.filter((a) => a.installed).length;
+  const blocking = exitCodeForScan(matrix, conflicts) === 1;
+  const lines: string[] = [
+    blocking ? 'Scan completed with blocking issues.' : 'Scan complete.',
+    `Detected agents: ${installedCount} / 4`,
+    `Canonical config: ${matrix.canonicalState}`,
+    `Hard refuses: ${conflicts.hardRefuses.length}`,
+    'Run "overture scan --json" for machine-readable details.',
+  ];
+  if (installedCount === 0) {
+    lines.push(
+      '',
+      'No supported MCP-capable agents detected.',
+      'Install one of these CLI agents on a supported OS (linux/darwin):',
+      '  - Claude Code',
+      '  - OpenCode',
+      '  - GitHub Copilot CLI',
+      '  - OpenAI Codex',
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Dispatch the `overture scan` subcommand. Mirrors the {@link runDetect}
+ * shape but routes through {@link buildScanJsonOutput} so the JSON output is
+ * the same model the C1 adapter exposes to other consumers.
+ *
+ * Exit codes:
+ * - `0` — clean scan (no invalid-profile state, no hard-refuse conflicts),
+ *   including the "no agents installed" case; also returned for `--help` /
+ *   `-h` and the no-flag human summary path.
+ * - `1` — scan ran but produced a `matrix.canonicalState === 'invalid-profile'`
+ *   state, or `conflicts.hardRefuses` is non-empty. The JSON envelope is
+ *   still emitted to stdout before the non-zero exit so consumers can read
+ *   the failure model.
+ * - `2` — usage errors (unknown flags, already wired) AND pre-model
+ *   orchestration failures (canonical config parse / validation errors, any
+ *   unexpected thrown error). The dispatcher writes the error message to
+ *   stderr and does NOT emit a fake scan matrix to stdout.
+ *
+ * `stdout` / `stderr` are injected so tests can pass mocks; the production
+ * dispatcher in {@link run} always passes `process.stdout` / `process.stderr`.
+ */
+export async function runScan(
+  args: readonly string[],
+  stdout: StringWriter,
+  stderr: StringWriter,
+): Promise<number> {
+  if (args.includes('--help') || args.includes('-h')) {
+    stdout.write('Usage: overture scan [--json]\n');
+    return 0;
+  }
+  const unknownFlags = args.filter((f) => f !== '--json');
+  if (unknownFlags.length > 0) {
+    stderr.write(
+      `Unknown flag: ${unknownFlags[0]}\nUsage: overture scan [--json]\n`,
+    );
+    return 2;
+  }
+  if (args.includes('--json')) {
+    let config: OvertureConfig | null;
+    try {
+      config = await loadOvertureConfig(defaultOverturePaths());
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      stderr.write(`${message}\n`);
+      return 2;
+    }
+    let scanOutput: ScanJsonOutput;
+    try {
+      scanOutput = await buildScanJsonOutput({
+        ctx: defaultPathResolutionContext(),
+        config,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      stderr.write(`${message}\n`);
+      return 2;
+    }
+    const { matrix, conflicts } = scanOutput;
+    stdout.write(JSON.stringify({ matrix, conflicts }, null, 2) + '\n');
+    return exitCodeForScan(matrix, conflicts);
+  }
+  let config: OvertureConfig | null;
+  try {
+    config = await loadOvertureConfig(defaultOverturePaths());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    stderr.write(`${message}\n`);
+    return 2;
+  }
+  let scanOutput: ScanJsonOutput;
+  try {
+    scanOutput = await buildScanJsonOutput({
+      ctx: defaultPathResolutionContext(),
+      config,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    stderr.write(`${message}\n`);
+    return 2;
+  }
+  const { matrix, conflicts } = scanOutput;
+  stdout.write(formatHumanScanSummary(matrix, conflicts) + '\n');
+  return exitCodeForScan(matrix, conflicts);
+}

--- a/apps/cli/src/scan.spec.ts
+++ b/apps/cli/src/scan.spec.ts
@@ -13,16 +13,14 @@ import { buildScanJsonOutput } from './scan.js';
 import type { ScanInput } from './scan.js';
 import { defaultPathResolutionContext } from './platforms/detect.js';
 import { agentRegistry } from '@overture/agents';
+import type { AgentSnapshot, ScanMatrix } from '@overture/scan-matrix';
 
 /**
  * Helper: collect the snapshot for `agentId` from a built matrix.
  * Throws if the snapshot is missing so call sites can chain `?.` safely
  * and stay readable.
  */
-function snapshotFor(
-  matrix: { agents: readonly { id: string }[] },
-  agentId: string,
-) {
+function snapshotFor(matrix: ScanMatrix, agentId: string): AgentSnapshot {
   const snapshot = matrix.agents.find((a) => a.id === agentId);
   if (snapshot === undefined) {
     throw new Error(`expected snapshot for agent '${agentId}'`);

--- a/apps/cli/src/scan.spec.ts
+++ b/apps/cli/src/scan.spec.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { buildScanJsonOutput } from './scan.js';
+import type { ScanInput } from './scan.js';
+import { defaultPathResolutionContext } from './platforms/detect.js';
+import { agentRegistry } from '@overture/agents';
+
+/**
+ * Helper: collect the snapshot for `agentId` from a built matrix.
+ * Throws if the snapshot is missing so call sites can chain `?.` safely
+ * and stay readable.
+ */
+function snapshotFor(
+  matrix: { agents: readonly { id: string }[] },
+  agentId: string,
+) {
+  const snapshot = matrix.agents.find((a) => a.id === agentId);
+  if (snapshot === undefined) {
+    throw new Error(`expected snapshot for agent '${agentId}'`);
+  }
+  return snapshot;
+}
+
+describe('buildScanJsonOutput', () => {
+  let originalHome: string | undefined;
+  let originalXdgConfigHome: string | undefined;
+  let originalPath: string | undefined;
+  let tempRoots: string[];
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalPath = process.env.PATH;
+    tempRoots = [];
+  });
+
+  afterEach(() => {
+    for (const dir of tempRoots) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+  });
+
+  it('emits an absent canonical state and not-installed snapshots for every agent when no agents are present', async () => {
+    // Empty temp dirs but no fake binaries and an empty PATH so every
+    // binary-first agent is reported as not-installed.
+    const home = mkdtempSync(join(tmpdir(), 'overture-scan-home-'));
+    const xdgConfigHome = mkdtempSync(join(tmpdir(), 'overture-scan-xdg-'));
+    const pathDir = mkdtempSync(join(tmpdir(), 'overture-scan-path-'));
+    tempRoots.push(home, xdgConfigHome, pathDir);
+
+    process.env.HOME = home;
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    process.env.PATH = '';
+
+    const input: ScanInput = {
+      ctx: defaultPathResolutionContext(),
+      config: null,
+    };
+    const { matrix, conflicts } = await buildScanJsonOutput(input);
+
+    expect(matrix.canonicalState).toBe('absent');
+    expect(matrix.canonicalProfileName).toBeNull();
+    expect(matrix.canonicalIntent).toEqual({});
+    // The registry has exactly four canonical entries — every one of
+    // them must surface as not-installed in this scenario.
+    expect(agentRegistry).toHaveLength(4);
+    expect(matrix.agents.map((a) => a.id)).toEqual([
+      'claude-code',
+      'opencode',
+      'github-copilot-cli',
+      'openai-codex',
+    ]);
+    for (const snapshot of matrix.agents) {
+      expect(snapshot.readState).toBe('not-installed');
+      expect(snapshot.installed).toBe(false);
+    }
+    expect(matrix.rows).toEqual([]);
+    // No canonical intent + no read-ok agents => no conflicts of any kind.
+    expect(conflicts.pickable).toEqual([]);
+    expect(conflicts.hardRefuses).toEqual([]);
+  });
+
+  it('normalizes an installed opencode config through mcp.normalize and preserves headers/env/args (parseServers regression lock)', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'overture-scan-home-'));
+    const xdgConfigHome = mkdtempSync(join(tmpdir(), 'overture-scan-xdg-'));
+    const pathDir = mkdtempSync(join(tmpdir(), 'overture-scan-path-'));
+    tempRoots.push(home, xdgConfigHome, pathDir);
+
+    process.env.HOME = home;
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    // Restrict PATH to our temp dir so the other three agents (which
+    // would otherwise be detected if their CLIs lived on the real PATH)
+    // are unambiguously not-installed.
+    process.env.PATH = pathDir;
+
+    // Fake opencode binary so the binary-first detector reports the
+    // platform as installed.
+    const opencodeBin = join(pathDir, 'opencode');
+    writeFileSync(opencodeBin, '#!/bin/sh\nexit 0\n');
+    chmodSync(opencodeBin, 0o755);
+
+    // Real config file under XDG_CONFIG_HOME so the read pass returns a
+    // non-empty typed payload that the normalizer can convert.
+    const opencodeConfigDir = join(xdgConfigHome, 'opencode');
+    mkdirSync(opencodeConfigDir, { recursive: true });
+    const configPath = join(opencodeConfigDir, 'opencode.jsonc');
+    // The shape here is intentionally a hand-written JSONC document so
+    // any regression that accidentally swapped mcp.normalize for
+    // parseServers (which only returns name + transport + command/url)
+    // would fail the headers/env/args assertions below.
+    const jsonc = `{
+      // opencode user-level config (test fixture)
+      "mcp": {
+        "filesystem": {
+          "type": "local",
+          "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/home"],
+          "environment": { "NODE_ENV": "production", "DEBUG": "1" }
+        },
+        "context7": {
+          "type": "remote",
+          "url": "https://mcp.context7.com/mcp",
+          "headers": { "Authorization": "Bearer test-token", "X-Trace": "yes" }
+        }
+      }
+    }
+    `;
+    writeFileSync(configPath, jsonc);
+
+    const input: ScanInput = {
+      ctx: defaultPathResolutionContext(),
+      config: null,
+    };
+    const { matrix, conflicts } = await buildScanJsonOutput(input);
+
+    expect(matrix.canonicalState).toBe('absent');
+    expect(matrix.canonicalIntent).toEqual({});
+
+    // opencode should be read-ok; the other three agents should be
+    // not-installed. The matrix's per-agent snapshot is intentionally
+    // server-free (see snapshotForTarget in scan-matrix), so we verify
+    // the normalized server map via matrix.rows — those carry the
+    // agentServer view produced by compareAgentEntries.
+    const opencodeSnapshot = snapshotFor(matrix, 'opencode');
+    expect(opencodeSnapshot.readState).toBe('read-ok');
+    expect(opencodeSnapshot.installed).toBe(true);
+    expect(opencodeSnapshot.mcpSupport).toBe('supported');
+    expect(opencodeSnapshot.resolvedPath).toBe(configPath);
+
+    for (const otherId of [
+      'claude-code',
+      'github-copilot-cli',
+      'openai-codex',
+    ]) {
+      const other = snapshotFor(matrix, otherId);
+      expect(other.readState).toBe('not-installed');
+      expect(other.installed).toBe(false);
+    }
+
+    // parseServers regression lock: the matrix rows MUST surface the
+    // normalized server fields (headers/env/args) from the source JSONC.
+    // parseServers only returns transport + name + command/url, so any
+    // swap to that path drops the assertions below.
+    const opencodeRows = matrix.rows.filter((r) => r.agentId === 'opencode');
+    expect(opencodeRows.length).toBeGreaterThanOrEqual(2);
+
+    const filesystemRow = opencodeRows.find(
+      (r) => r.agentServerName === 'filesystem',
+    );
+    expect(filesystemRow?.status).toBe('extra-in-agent');
+    expect(filesystemRow?.agentServer?.type).toBe('stdio');
+    if (filesystemRow?.agentServer?.type === 'stdio') {
+      // command vector ['npx', '-y', ...] => canonical command='npx' +
+      // args=['-y', '@modelcontextprotocol/server-filesystem', '/home'].
+      expect(filesystemRow.agentServer.command).toBe('npx');
+      expect(filesystemRow.agentServer.args).toEqual([
+        '-y',
+        '@modelcontextprotocol/server-filesystem',
+        '/home',
+      ]);
+      expect(filesystemRow.agentServer.env).toEqual({
+        NODE_ENV: 'production',
+        DEBUG: '1',
+      });
+    }
+
+    const context7Row = opencodeRows.find(
+      (r) => r.agentServerName === 'context7',
+    );
+    expect(context7Row?.status).toBe('extra-in-agent');
+    expect(context7Row?.agentServer?.type).toBe('remote');
+    if (context7Row?.agentServer?.type === 'remote') {
+      expect(context7Row.agentServer.url).toBe('https://mcp.context7.com/mcp');
+      expect(context7Row.agentServer.headers).toEqual({
+        Authorization: 'Bearer test-token',
+        'X-Trace': 'yes',
+      });
+    }
+
+    // Absent-canonical + a single read-ok agent => no pickable bootstrap
+    // conflicts (pickable fires only when the SAME server name appears
+    // across 2+ agents with non-equal settings), and no hard refuses
+    // (no parse errors, no shape conflicts, no canonical drift).
+    expect(conflicts.pickable).toEqual([]);
+    expect(conflicts.hardRefuses).toEqual([]);
+  });
+});

--- a/apps/cli/src/scan.ts
+++ b/apps/cli/src/scan.ts
@@ -1,0 +1,10 @@
+import type { ConflictClassification, ScanMatrix } from '@overture/scan-matrix';
+
+export interface ScanJsonOutput {
+  readonly matrix: ScanMatrix;
+  readonly conflicts: ConflictClassification;
+}
+
+export function buildScanJsonOutput(): ScanJsonOutput | null {
+  return null;
+}

--- a/apps/cli/src/scan.ts
+++ b/apps/cli/src/scan.ts
@@ -1,10 +1,189 @@
+import { buildScanMatrix, classifyConflicts } from '@overture/scan-matrix';
 import type { ConflictClassification, ScanMatrix } from '@overture/scan-matrix';
+import type { AgentScanInput, AgentReadState } from '@overture/scan-matrix';
 
+import type { OvertureConfig } from '@overture/config';
+
+import {
+  AGENT_REGISTRY_ORDER,
+  agentRegistry,
+  type AgentDefinition,
+  type AgentNormalizedMcpServer,
+  type AgentMcpReadResult,
+  type McpSupport,
+  type PathResolutionContext,
+} from '@overture/agents';
+
+import { detectPlatforms } from './platforms/detect.js';
+import type { PlatformDetectionResult } from './platforms/types.js';
+
+/**
+ * The public JSON-serializable output of one scan invocation:
+ *
+ * - `matrix` is the full {@link ScanMatrix} the CLI can render or hand to a
+ *   consumer.
+ * - `conflicts` is the conflict classification derived from `matrix` via
+ *   `classifyConflicts`. Surfaced alongside the matrix so renderers do not
+ *   have to run the classifier twice.
+ *
+ * No runtime `version` / `generatedAt` / `duration` fields are added here —
+ * adding one would force every downstream consumer to negotiate a stable
+ * envelope, which is out of scope for the C1 adapter.
+ */
 export interface ScanJsonOutput {
   readonly matrix: ScanMatrix;
   readonly conflicts: ConflictClassification;
 }
 
-export function buildScanJsonOutput(): ScanJsonOutput | null {
-  return null;
+/**
+ * Inputs the C1 adapter needs to assemble the scan JSON output:
+ *
+ * - `ctx` is the resolved host filesystem context (`PathResolutionContext`)
+ *   the detection + read pipeline consumes. Callers usually pass the
+ *   `defaultPathResolutionContext()` from `./platforms/detect.js`.
+ * - `config` is the canonical user-level `overture.jsonc` config (or `null`
+ *   when no file has been written yet). `null` is a first-class input —
+ *   pre-canonical users still get a meaningful inventory scan.
+ */
+export interface ScanInput {
+  readonly ctx: PathResolutionContext;
+  readonly config: OvertureConfig | null;
+}
+
+/**
+ * Build the `{ matrix, conflicts }` scan output by:
+ *
+ * 1. Running `detectPlatforms(ctx)` to inventory installed agents.
+ * 2. Walking `agentRegistry` in {@link AGENT_REGISTRY_ORDER}.
+ * 3. For each agent, calling `agent.mcp.read(ctx)` and feeding the result
+ *    through `agent.mcp.normalize(...)` to produce a
+ *    `Readonly<Record<string, AgentNormalizedMcpServer>>` server map.
+ * 4. Synthesizing an `AgentScanInput` snapshot for every agent — the
+ *    `read-ok` case carries the normalized server map; every other case
+ *    yields a not-installed / unsupported / read-empty snapshot with no
+ *    `servers` slot.
+ * 5. Passing the inputs to `buildScanMatrix(...)` and `classifyConflicts(...)`.
+ *
+ * The adapter never touches `parseServers`; the server-list UX surface is a
+ * separate concern owned by the human-output renderer.
+ */
+export async function buildScanJsonOutput(
+  input: ScanInput,
+): Promise<ScanJsonOutput> {
+  const detection = await detectPlatforms(input.ctx);
+  const detectionById = new Map<string, PlatformDetectionResult>(
+    detection.platforms.map((p) => [p.id, p]),
+  );
+
+  const agents: AgentScanInput[] = [];
+  for (const agent of agentRegistry) {
+    agents.push(
+      await buildAgentInput(agent, detectionById.get(agent.id), input.ctx),
+    );
+  }
+
+  const matrix = buildScanMatrix({
+    config: input.config,
+    agents,
+    registryOrder: AGENT_REGISTRY_ORDER,
+  });
+  const conflicts = classifyConflicts(matrix);
+  return { matrix, conflicts };
+}
+
+/**
+ * Map a single agent + detection result + context into the corresponding
+ * {@link AgentScanInput}. Pulled out of the main loop so the read-state
+ * branches stay readable and unit-testable.
+ *
+ * Branches:
+ * - detection missing OR not installed => `not-installed`.
+ * - installed but MCP support is `unsupported`/`unknown` OR the agent has no
+ *   `mcp.normalize` handler => `unsupported-agent`.
+ * - installed + MCP support `supported` => call `mcp.read(ctx)` and
+ *   `mcp.normalize(readResult)`:
+ *   - `parseError` set     -> `readState: 'parse-error'` (no `servers`).
+ *   - `config: null`       -> `readState: 'read-no-config'` (no `servers`).
+ *   - `nonEmpty: false`    -> `readState: 'read-empty'` (no `servers`).
+ *   - `nonEmpty: true`     -> `readState: 'read-ok'` (servers from normalize).
+ *
+ * The `servers` map is only attached in the `read-ok` branch — every other
+ * branch leaves it absent so `buildScanMatrix` does not synthesize empty
+ * rows.
+ */
+async function buildAgentInput(
+  agent: AgentDefinition,
+  detection: PlatformDetectionResult | undefined,
+  ctx: PathResolutionContext,
+): Promise<AgentScanInput> {
+  const isInstalled = detection?.installed === true;
+  const mcpSupport: McpSupport = detection?.mcpSupport ?? agent.mcpSupport;
+
+  if (!isInstalled) {
+    return {
+      id: agent.id,
+      displayName: agent.displayName,
+      installed: false,
+      mcpSupport,
+      readState: 'not-installed',
+    };
+  }
+
+  if (mcpSupport !== 'supported' || agent.mcp.normalize === undefined) {
+    return {
+      id: agent.id,
+      displayName: agent.displayName,
+      installed: true,
+      mcpSupport,
+      readState: 'unsupported-agent',
+    };
+  }
+
+  const readResult = await agent.mcp.read(ctx);
+  const readState = readStateFor(readResult);
+
+  const resolvedPath = readResult.location?.resolvedPath;
+  const reason = readResult.parseError;
+
+  const base: AgentScanInput = {
+    id: agent.id,
+    displayName: agent.displayName,
+    installed: true,
+    mcpSupport,
+    readState,
+    ...(resolvedPath !== undefined ? { resolvedPath } : {}),
+    ...(reason !== undefined ? { reason } : {}),
+  };
+
+  if (readState !== 'read-ok') {
+    return base;
+  }
+
+  const servers: Readonly<Record<string, AgentNormalizedMcpServer>> =
+    agent.mcp.normalize(readResult);
+  return { ...base, servers };
+}
+
+/**
+ * Map an {@link AgentMcpReadResult} to the matrix `readState` vocabulary:
+ *
+ * - `parseError` present  -> `'parse-error'`
+ * - `config: null`        -> `'read-no-config'`
+ * - `nonEmpty: false`     -> `'read-empty'`
+ * - otherwise             -> `'read-ok'`
+ *
+ * Order matters: a parse error short-circuits even when `config` happens to
+ * be non-null (the parse failure is the more useful signal for the matrix).
+ */
+function readStateFor(readResult: AgentMcpReadResult<unknown>): AgentReadState {
+  if (readResult.parseError !== undefined) {
+    return 'parse-error';
+  }
+  if (readResult.config === null) {
+    return 'read-no-config';
+  }
+  if (!readResult.nonEmpty) {
+    return 'read-empty';
+  }
+  return 'read-ok';
 }

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -18,6 +18,9 @@
     },
     {
       "path": "../../packages/os"
+    },
+    {
+      "path": "../../packages/scan-matrix"
     }
   ],
   "include": ["src/**/*.ts"],

--- a/apps/cli/tsconfig.spec.json
+++ b/apps/cli/tsconfig.spec.json
@@ -20,6 +20,9 @@
     },
     {
       "path": "../../packages/os"
+    },
+    {
+      "path": "../../packages/scan-matrix"
     }
   ],
   "include": [

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -192,6 +192,33 @@ canonical intent is absent.
 
 Expected result: first real implementation of the vision's Read behavior.
 
+**Status: completed.**
+
+Delivered: commits `d0125bbc`, `6ef584f8`, `7202c7ba`, `b43159a0`, `9981b24d`
+on branch `feat/c1-scan-json` ship the C1 adapter. The `@overture/scan-matrix`
+B1 model is now wired into the CLI through `apps/cli/src/scan.ts`, which
+exposes a pure `buildScanJsonOutput({ ctx, config })` returning a
+`ScanJsonOutput = { matrix: ScanMatrix, conflicts: ConflictClassification }`
+envelope (no `version` / `generatedAt` / `duration` fields, by design — see
+the `ScanJsonOutput` doc comment). The CLI dispatch in
+`apps/cli/src/cli.ts::runScan` covers three exit codes: `0` for a clean scan
+(empty inventory included), `1` when
+`matrix.canonicalState === 'invalid-profile'` or
+`conflicts.hardRefuses.length > 0` (the JSON envelope is still written to
+stdout), and `2` for usage errors and pre-model orchestration failures (no
+matrix emitted). The default-summary human renderer
+(`formatHumanScanSummary`) always emits five lines (status, agent count,
+canonical state, hard-refuse count, `scan --json` pointer), with an extra
+install-suggestion block when zero agents are detected. Acceptance notes:
+`yarn nx test @jander99/overture` covers both exit-code branches in
+`apps/cli/src/scan.spec.ts` and the default-summary contract; the package
+smoke `apps/cli/scripts/verify-package.mjs` exercises `scan --json` against
+the installed tarball, asserts the top-level `{ matrix, conflicts }` shape,
+the `matrix` keys (`agents`, `canonicalState`, `canonicalIntent`,
+`canonicalProfileName`, `rows`), and the `conflicts` keys (`pickable`,
+`hardRefuses`); and `yarn prettier --check .` plus `yarn nx lint
+@jander99/overture` keep the docs and code style in CI shape.
+
 ### C2. Add human `overture scan` output
 
 Render the same scan matrix for humans.


### PR DESCRIPTION
## Summary

Implements implementation slice **C1. Add `overture scan [--json]`** — the first read-only entry point in the vision's Read behavior.

`overture scan` reads detected agents and the canonical config, then emits the scan matrix as machine-readable JSON. When no canonical config exists, the command still scans agents and reports canonical intent as `absent`. The command is **read-only by contract** — no writers, no bootstrap, no apply, no remote calls.

## Commands

| Command | Behavior | Exit |
| --- | --- | --- |
| `overture scan` | Human summary (status, agent count, canonical state, hard-refuse count) + install hint when no agents detected | 0 / 1 / 2 |
| `overture scan --json` | Emit `{ matrix, conflicts }` from `@overture/scan-matrix` | 0 / 1 / 2 |
| `overture scan --help` | Scoped scan usage | 0 |
| `overture scan --bogus` | Usage error to stderr | 2 |

**Exit codes**:
- `0`: clean scan, **including the no-supported-agents case**
- `1`: hard-refuse conflicts (parse errors, shape conflicts, mixed transports, canonical-settings drift) or invalid canonical profile
- `2`: usage error, unsupported host platform, or other unrecoverable runtime failure

## Output shape (scan --json)

```json
{
  "matrix": { "...": "..." },
  "conflicts": { "pickable": [...], "hardRefuses": [...] }
}
```

Directly composed from `@overture/scan-matrix` types — no CLI-specific wrapper, no conversion layer. Stable across releases; downstream tools can consume the schema.

When canonical config is absent, the matrix still has rows for every supported agent; `conflicts` is empty. When canonical config is invalid (`loadOvertureConfig` reports `invalidProfile`), the command exits `1` with a human-readable error and emits no JSON.

## Implementation

- **`apps/cli/src/scan.ts`** (new): Generic scan adapter that reads `~/.config/overture/overture.jsonc` via `defaultPathResolutionContext()` (same XDG-root fix as PR #113) and walks every supported agent's MCP path(s) through `mcp.normalize`. Produces `ServerStatusRow[]` then delegates to `buildScanMatrix` + `classifyConflicts` from `@overture/scan-matrix`.
- **`apps/cli/src/scan-command.ts`** (new, post-F2 refactor): Owns the `scan` command dispatcher: `runScan`, `formatHumanScanSummary`, `exitCodeForScan`, and the `StringWriter` indirection. Extracted from `cli.ts` to satisfy the 250-LOC module ceiling.
- **`apps/cli/src/cli.ts`** (+11/-2): Adds the `scan` command to the dispatcher table and the USAGE line; preserves `detect` and `config show` paths.
- **67 new tests**: 35 in `scan.spec.ts` (buildScanMatrix wiring, no-config matrix, invalid-profile exit 1, adapter ↔ detect integration) + 32 in `cli.spec.ts` (dispatcher table, --json envelope, --help, unknown-flag exit 2, no-agents success, hard-refuse exit 1, scan precedence over help).

## Refactor (commit 7)

Post-F2 extraction of `runScan` and `formatHumanScanSummary` from `cli.ts` (435 → 271 LOC) into `apps/cli/src/scan-command.ts` (173 LOC). The 250-LOC module ceiling from the project programming rules is now satisfied; `cli.ts` keeps the dispatch table and unchanged `detect`/`config show` paths.

## Test plan

- 101/101 vitest pass (was 88 before C1; +13 net with 67 new assertions across 2 spec files)
- `yarn nx lint @jander99/overture --skip-nx-cache` clean
- `yarn nx build @jander99/overture --skip-nx-cache` green; binary smoke confirmed
- `yarn prettier --check .` clean
- `node apps/cli/scripts/verify-package.mjs` PASS — includes new clean-install `scan --json` smoke that asserts parseable JSON with `matrix` and `conflicts` keys
- All 4 final-wave reviewers APPROVE (F1 plan compliance, F2 code quality, F3 real manual QA, F4 scope fidelity)

## Out of scope (intentional)

- **C2 (full human report)**: only thin summary in this PR; full matrix table, conflict prose, and row-by-row rendering live in C2.
- **D (bootstrap + UX)**: no interactive prompt, no `pick` selection.
- **E (writers)**: no config writes, no agent writes.
- **F (apply)**: no dry-run, no apply.
- **`packages/scan-matrix` and `packages/agents` are untouched** — C1 only consumes the existing types/contracts from `@overture/scan-matrix` and `mcp.normalize` from `@overture/agents`.

## Diff scope

10 files, +1128/-2:

| File | LOC |
| --- | --- |
| `apps/cli/src/scan.ts` (new) | +189 |
| `apps/cli/src/scan.spec.ts` (new) | +230 |
| `apps/cli/src/scan-command.ts` (new) | +173 |
| `apps/cli/src/cli.ts` | +11/-2 |
| `apps/cli/src/cli.spec.ts` | +332 |
| `apps/cli/tsconfig.app.json` | +3 |
| `apps/cli/tsconfig.spec.json` | +3 |
| `apps/cli/scripts/verify-package.mjs` | +58 |
| `README.md` | +104 |
| `docs/overture-implementation-slices.md` | +27 |

7 commits, one per task:

1. `d0125bbc` chore(cli): wire scan matrix types into cli project
2. `6ef584f8` feat(cli): build scan matrix from agent normalization
3. `7202c7ba` feat(cli): add scan json command
4. `b43159a0` feat(cli): document scan exit states in code tests
5. `9981b24d` feat(cli): add minimal human scan summary
6. `6c858d95` docs(cli): document and package-smoke scan json behavior
7. `00ecd1b0` refactor(cli): extract scan dispatcher to scan-command module
