### PR TITLE
feat(cli): add interactive bootstrap conflict prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,14 +239,19 @@ no `generatedAt`, no `duration`):
 `overture.jsonc` config that a future bootstrap write step (Track D3, not yet
 implemented) would produce from the agents' current MCP server inventories.
 
-D1 is the **planner** phase of bootstrap. It does not write, prompt, or
-modify any file. D2 will add the interactive prompt UX, and D3 will add the
-actual write step.
+D1 is the **planner** phase of bootstrap. D2 is the **interactive conflict
+prompt** phase: it walks the user through pickable conflicts one at a time,
+applies the chosen candidate or `skip` in memory, and prints a read-only
+summary. D2 still writes no files. D3 will add the actual write step.
 
 ### Usage
 
 ```bash
-# Preview the proposed canonical config (human-readable)
+# D2 interactive read-only: walk pickable conflicts one at a time, then print
+# a read-only summary. Does NOT write any file. D3 will own the write step.
+overture bootstrap
+
+# Non-interactive human-readable preview of the proposed canonical config
 overture bootstrap --dry-run
 
 # Machine-readable: full proposal + conflicts + blockers
@@ -256,9 +261,12 @@ overture bootstrap --dry-run --json
 overture bootstrap --help
 ```
 
-The no-flag `overture bootstrap` and `--dry-run` (without `--json`) are
-reserved for D2/D3 and exit `2` with a guidance message; they do not perform a
-write today.
+The no-flag `overture bootstrap` is the D2 read-only interactive prompt. It
+walks the user through pickable conflicts one at a time, applies the chosen
+candidate or `skip`, and prints a read-only summary. It does NOT write any
+file. Use `overture bootstrap --dry-run` for a non-interactive preview. The
+no-flag path exits `2` when stdin is not a TTY (hint: `Run overture bootstrap
+--dry-run for a non-interactive preview.`).
 
 ### Default summary shape
 
@@ -307,14 +315,14 @@ fingerprints.
 
 ### Exit codes
 
-| Exit code | Meaning                                                                                                                                                                            |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `0`       | Help, or dry-run proposal status `ready`.                                                                                                                                          |
-| `1`       | Dry-run proposal emitted but status `blocked` (pickables, hard refuses, no readable agents, or existing valid config).                                                             |
-| `2`       | Usage error, invalid flag combination (`--json` without `--dry-run`), `--dry-run` reserved for D3, invalid/parse-error existing canonical config, or unexpected pre-model failure. |
+| Exit code | Meaning                                                                                                                                                                                                                                                                                                                          |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`       | `--help`, `--dry-run [--json]` proposal status `ready`, or no-flag interactive run with no hard refuses/blockers remaining.                                                                                                                                                                                                      |
+| `1`       | Dry-run proposal emitted but status `blocked` (pickables, hard refuses, no readable agents, or existing valid config), OR no-flag interactive run whose plan is still blocked (hard refuses / blockers).                                                                                                                         |
+| `2`       | Usage error (unknown flag), invalid flag combination (`--json` without `--dry-run`), invalid/parse-error existing canonical config, non-TTY no-flag run with at least one pickable conflict (suggests rerunning with `overture bootstrap --dry-run`), user abort during the interactive prompt, or unexpected pre-model failure. |
 
 `bootstrap` will not write to or modify any of the files it inspects, and it
-makes no writes anywhere.
+makes no writes anywhere. D2 still writes no files; D3 will own the write step.
 
 ## Repository layout
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -28,6 +28,10 @@ npx @jander99/overture@latest --help
 - `overture detect --json` — full 4-platform inventory with all additive
   fields.
 - `overture config show` — print the resolved user-level `overture.jsonc`.
+- `overture bootstrap` (no flag, D2 interactive read-only) — walk pickable
+  conflicts one at a time, apply the chosen candidate or `skip` in memory,
+  and print a read-only summary. Does NOT write any file. Exits `2` when
+  stdin is not a TTY. D3 (future write step) will own the actual write.
 - `overture bootstrap --dry-run [--json]` — preview the canonical bootstrap
   proposal without writing any files.
 - `overture detect --help` / `overture --help` — print usage and exit 0.

--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -412,31 +412,66 @@ if (statSync(bootstrapPaths.configFile, { throwIfNoEntry: false })) {
 console.log(
   `bootstrap --dry-run: exit=${bootstrapHumanResult.status} headings=${bootstrapHumanHeadings.length} noWrite=PASS`,
 );
-
-const bootstrapReservedResult = spawnWithEnv(
+const bootstrapInteractiveResult = spawnWithEnv(
   [...bootstrapBin, 'bootstrap'],
   bootstrapEnv,
 );
-if (bootstrapReservedResult.status !== 2) {
+if (bootstrapInteractiveResult.status !== 1) {
   fail(
-    `bootstrap (no flags) exited ${bootstrapReservedResult.status} (expected 2): ${bootstrapReservedResult.stderr}`,
+    `bootstrap (no flags) exited ${bootstrapInteractiveResult.status} (expected 1): stderr:\n${bootstrapInteractiveResult.stderr}\nstdout:\n${bootstrapInteractiveResult.stdout}`,
   );
 }
+if (!bootstrapInteractiveResult.stdout.includes('Bootstrap proposal')) {
+  fail(
+    `bootstrap (no flags) stdout missing "Bootstrap proposal" heading\nstdout:\n${bootstrapInteractiveResult.stdout}`,
+  );
+}
+const forbiddenStderrFragments = [
+  'BOOTSTRAP_RESERVED_MESSAGE',
+  'Bootstrap writes are not implemented yet',
+];
+const leakedStderrFragments = forbiddenStderrFragments.filter((fragment) =>
+  bootstrapInteractiveResult.stderr.includes(fragment),
+);
+if (leakedStderrFragments.length > 0) {
+  fail(
+    `bootstrap (no flags) stderr contains forbidden fragments: ${leakedStderrFragments.join(', ')}\nstderr:\n${bootstrapInteractiveResult.stderr}`,
+  );
+}
+const forbiddenStdoutFragments = [
+  'Pickable conflict:',
+  'api_key=',
+  'Bearer ',
+  '$schema',
+  'matrix',
+  'agentServer',
+  'canonicalServer',
+];
+const leakedStdoutFragments = forbiddenStdoutFragments.filter((fragment) =>
+  bootstrapInteractiveResult.stdout.includes(fragment),
+);
+if (leakedStdoutFragments.length > 0) {
+  fail(
+    `bootstrap (no flags) stdout contains forbidden fragments: ${leakedStdoutFragments.join(', ')}\nstdout:\n${bootstrapInteractiveResult.stdout}`,
+  );
+}
+if (statSync(bootstrapPaths.configFile, { throwIfNoEntry: false })) {
+  fail(
+    `bootstrap (no flags) unexpectedly created ${bootstrapPaths.configFile}`,
+  );
+}
+const bootstrapAgentAfterStat = statSync(bootstrapAgentConfig);
 if (
-  !bootstrapReservedResult.stderr.includes(
-    'Bootstrap writes are not implemented yet. Run "overture bootstrap --dry-run"',
-  )
+  bootstrapAgentAfterStat.size !== bootstrapAgentBeforeStat.size ||
+  bootstrapAgentAfterStat.mtimeMs !== bootstrapAgentBeforeStat.mtimeMs
 ) {
   fail(
-    `bootstrap (no flags) stderr missing reserved message\nstderr:\n${bootstrapReservedResult.stderr}`,
+    `bootstrap (no flags) modified seeded agent config\nbefore: size=${bootstrapAgentBeforeStat.size} mtime=${bootstrapAgentBeforeStat.mtimeMs}\nafter: size=${bootstrapAgentAfterStat.size} mtime=${bootstrapAgentAfterStat.mtimeMs}`,
   );
 }
-if (bootstrapReservedResult.stdout.trim() !== '') {
-  fail(
-    `bootstrap (no flags) unexpectedly wrote stdout:\n${bootstrapReservedResult.stdout}`,
-  );
-}
-console.log('bootstrap (no flags): exit=2 reserved-message=PASS');
+console.log(
+  `bootstrap (no flags): exit=${bootstrapInteractiveResult.status} proposalHeading=PASS noReserved=PASS noLeak=PASS noWrite=PASS`,
+);
 
 const bootstrapHelpResult = spawnWithEnv(
   [...bootstrapBin, 'bootstrap', '--help'],

--- a/apps/cli/src/bootstrap-command.spec.ts
+++ b/apps/cli/src/bootstrap-command.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   chmodSync,
   existsSync,
@@ -15,7 +15,6 @@ import { tmpdir } from 'node:os';
 import { defaultOverturePaths } from '@overture/config';
 
 import {
-  BOOTSTRAP_RESERVED_MESSAGE,
   BOOTSTRAP_USAGE,
   exitCodeForBootstrap,
   runBootstrap,
@@ -56,6 +55,12 @@ function seedFakeOpencodeBin(pathDir: string): void {
   chmodSync(opencodeBin, 0o755);
 }
 
+function seedFakeClaudeBin(pathDir: string): void {
+  const claudeBin = join(pathDir, 'claude');
+  writeFileSync(claudeBin, '#!/bin/sh\nexit 0\n');
+  chmodSync(claudeBin, 0o755);
+}
+
 function opencodeFixtureJsonc(): string {
   return `{
     // bootstrap dispatcher fixture
@@ -75,6 +80,94 @@ function seedBootstrapAgentConfig(xdgConfigHome: string): string {
   const agentConfigPath = join(opencodeDir, 'opencode.jsonc');
   writeFileSync(agentConfigPath, opencodeFixtureJsonc());
   return agentConfigPath;
+}
+
+function claudeFilesystemFixtureJson(): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        filesystem: {
+          type: 'stdio',
+          command: 'pnpm',
+          args: ['dlx', '@modelcontextprotocol/server-filesystem', '/home'],
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function claudeRemoteFilesystemFixtureJson(): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        filesystem: {
+          type: 'remote',
+          url: 'https://mcp.example.test/filesystem',
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function claudeTwoPickablesFixtureJson(): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        context7: {
+          type: 'remote',
+          url: 'https://mcp.context7.com/mcp',
+          headers: { Authorization: 'Bearer claude-token' },
+        },
+        filesystem: {
+          type: 'stdio',
+          command: 'pnpm',
+          args: ['dlx', '@modelcontextprotocol/server-filesystem', '/home'],
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function opencodeTwoPickablesFixtureJsonc(): string {
+  return `{
+    // bootstrap dispatcher fixture
+    "mcp": {
+      "context7": {
+        "type": "remote",
+        "url": "https://mcp.context7.com/mcp",
+        "headers": { "Authorization": "Bearer opencode-token" }
+      },
+      "filesystem": {
+        "type": "local",
+        "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/home"],
+        "environment": { "NODE_ENV": "production", "DEBUG": "1" }
+      }
+    }
+  }`;
+}
+
+function seedClaudeConfig(home: string, contents: string): string {
+  const claudeConfigPath = join(home, '.claude.json');
+  writeFileSync(claudeConfigPath, contents);
+  return claudeConfigPath;
+}
+
+function seedOpencodeConfig(xdgConfigHome: string, contents: string): string {
+  const opencodeDir = join(xdgConfigHome, 'opencode');
+  mkdirSync(opencodeDir, { recursive: true });
+  const agentConfigPath = join(opencodeDir, 'opencode.jsonc');
+  writeFileSync(agentConfigPath, contents);
+  return agentConfigPath;
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
 }
 
 describe('runBootstrap', () => {
@@ -104,7 +197,6 @@ describe('runBootstrap', () => {
   );
 
   it.each([
-    { args: [], stderr: BOOTSTRAP_RESERVED_MESSAGE, code: 2 },
     { args: ['--json'], stderr: '--dry-run', code: 2 },
     { args: ['--bogus'], stderr: 'Unknown flag: --bogus', code: 2 },
   ])(
@@ -242,5 +334,503 @@ describe('runBootstrap', () => {
         }),
       ),
     ).toBe(1);
+  });
+});
+
+describe('D2 interactive', () => {
+  let cleanupDirs: readonly string[] = [];
+  let stdinIsTtyDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    cleanupDirs = [];
+    stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      'isTTY',
+    );
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
+  });
+
+  afterEach(() => {
+    for (const dir of cleanupDirs)
+      rmSync(dir, { recursive: true, force: true });
+    if (stdinIsTtyDescriptor === undefined) {
+      const mutableStdin = process.stdin as { isTTY?: boolean };
+      delete mutableStdin.isTTY;
+    } else {
+      Object.defineProperty(process.stdin, 'isTTY', stdinIsTtyDescriptor);
+    }
+  });
+
+  function useBootstrapEnv(env: {
+    readonly home: string;
+    readonly xdgConfigHome: string;
+    readonly pathDir: string;
+  }): void {
+    process.env.HOME = env.home;
+    process.env.XDG_CONFIG_HOME = env.xdgConfigHome;
+    process.env.PATH = env.pathDir;
+  }
+
+  function queuedPrompt(answers: readonly (string | null)[]) {
+    const queue = [...answers];
+    return vi.fn((_message: string): Promise<string | null> => {
+      return Promise.resolve(queue.length > 0 ? (queue.shift() ?? null) : null);
+    });
+  }
+
+  it('renders a dry-run proposal without prompting when args are empty and no conflicts exist', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    const agentConfigPath = seedBootstrapAgentConfig(xdgConfigHome);
+    const agentBefore = readFileSync(agentConfigPath, 'utf8');
+    const beforeStat = statSync(agentConfigPath);
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(0);
+    expect(stderr.text()).toBe('');
+    expect(prompt).not.toHaveBeenCalled();
+    expect(stdout.text()).toContain('Bootstrap proposal (dry-run)');
+    expect(stdout.text()).toContain('Proposal status: ready');
+    expect(stdout.text()).toContain('Pickable conflicts: 0');
+    expect(stdout.text()).toContain('No files were written.');
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(readFileSync(agentConfigPath, 'utf8')).toBe(agentBefore);
+    expect(statSync(agentConfigPath).size).toBe(beforeStat.size);
+    expect(statSync(agentConfigPath).mtimeMs).toBe(beforeStat.mtimeMs);
+  });
+
+  it('prompts for a pickable conflict and adopts the selected candidate', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    seedFakeClaudeBin(pathDir);
+    const opencodeConfigPath = seedBootstrapAgentConfig(xdgConfigHome);
+    const claudeConfigPath = seedClaudeConfig(
+      home,
+      claudeFilesystemFixtureJson(),
+    );
+    const opencodeBefore = readFileSync(opencodeConfigPath, 'utf8');
+    const claudeBefore = readFileSync(claudeConfigPath, 'utf8');
+    const opencodeStat = statSync(opencodeConfigPath);
+    const claudeStat = statSync(claudeConfigPath);
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(0);
+    expect(stderr.text()).toBe('');
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(prompt).toHaveBeenCalledWith(
+      expect.stringContaining('Pickable conflict: filesystem'),
+    );
+    expect(stdout.text()).toContain('Resolved conflicts: 1');
+    expect(stdout.text()).toContain('Skipped conflicts: 0');
+    expect(stdout.text()).toContain('selected-conflict');
+    expect(stdout.text()).toContain('filesystem: Claude Code (claude-code)');
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
+    expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
+    expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);
+    expect(statSync(claudeConfigPath).size).toBe(claudeStat.size);
+    expect(statSync(opencodeConfigPath).mtimeMs).toBe(opencodeStat.mtimeMs);
+    expect(statSync(claudeConfigPath).mtimeMs).toBe(claudeStat.mtimeMs);
+  });
+
+  it('skips one pickable on empty input and selects the next candidate', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    seedFakeClaudeBin(pathDir);
+    const opencodeConfigPath = seedOpencodeConfig(
+      xdgConfigHome,
+      opencodeTwoPickablesFixtureJsonc(),
+    );
+    const claudeConfigPath = seedClaudeConfig(
+      home,
+      claudeTwoPickablesFixtureJson(),
+    );
+    const opencodeBefore = readFileSync(opencodeConfigPath, 'utf8');
+    const claudeBefore = readFileSync(claudeConfigPath, 'utf8');
+    const opencodeStat = statSync(opencodeConfigPath);
+    const claudeStat = statSync(claudeConfigPath);
+    const prompt = queuedPrompt(['', '1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(0);
+    expect(stderr.text()).toBe('');
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(countOccurrences(stdout.text(), 'Pickable conflict:')).toBe(2);
+    expect(stdout.text()).toContain('Resolved conflicts: 1');
+    expect(stdout.text()).toContain('Skipped conflicts: 1');
+    expect(stdout.text()).toContain('selected-conflict');
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
+    expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
+    expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);
+    expect(statSync(claudeConfigPath).size).toBe(claudeStat.size);
+    expect(statSync(opencodeConfigPath).mtimeMs).toBe(opencodeStat.mtimeMs);
+    expect(statSync(claudeConfigPath).mtimeMs).toBe(claudeStat.mtimeMs);
+  });
+
+  it('re-asks invalid input until the invalid answer limit aborts', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    seedFakeClaudeBin(pathDir);
+    const opencodeConfigPath = seedBootstrapAgentConfig(xdgConfigHome);
+    const claudeConfigPath = seedClaudeConfig(
+      home,
+      claudeFilesystemFixtureJson(),
+    );
+    const opencodeBefore = readFileSync(opencodeConfigPath, 'utf8');
+    const claudeBefore = readFileSync(claudeConfigPath, 'utf8');
+    const opencodeStat = statSync(opencodeConfigPath);
+    const claudeStat = statSync(claudeConfigPath);
+    const prompt = vi.fn((): Promise<string> => Promise.resolve('foo'));
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(2);
+    expect(prompt).toHaveBeenCalledTimes(10);
+    expect(1 + prompt.mock.calls.length).toBe(11);
+    expect(stderr.text()).toBe(
+      'Bootstrap aborted: too many invalid answers for filesystem\n',
+    );
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
+    expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
+    expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);
+    expect(statSync(claudeConfigPath).size).toBe(claudeStat.size);
+    expect(statSync(opencodeConfigPath).mtimeMs).toBe(opencodeStat.mtimeMs);
+    expect(statSync(claudeConfigPath).mtimeMs).toBe(claudeStat.mtimeMs);
+  });
+
+  it('aborts when the user answers q', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    seedFakeClaudeBin(pathDir);
+    const opencodeConfigPath = seedBootstrapAgentConfig(xdgConfigHome);
+    const claudeConfigPath = seedClaudeConfig(
+      home,
+      claudeFilesystemFixtureJson(),
+    );
+    const opencodeBefore = readFileSync(opencodeConfigPath, 'utf8');
+    const claudeBefore = readFileSync(claudeConfigPath, 'utf8');
+    const opencodeStat = statSync(opencodeConfigPath);
+    const claudeStat = statSync(claudeConfigPath);
+    const prompt = queuedPrompt(['q']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(2);
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(stderr.text()).toBe('Bootstrap aborted: filesystem\n');
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
+    expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
+    expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);
+    expect(statSync(claudeConfigPath).size).toBe(claudeStat.size);
+    expect(statSync(opencodeConfigPath).mtimeMs).toBe(opencodeStat.mtimeMs);
+    expect(statSync(claudeConfigPath).mtimeMs).toBe(claudeStat.mtimeMs);
+  });
+
+  it('prints the hard-refuse proposal without prompting', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    seedFakeClaudeBin(pathDir);
+    const opencodeConfigPath = seedBootstrapAgentConfig(xdgConfigHome);
+    const claudeConfigPath = seedClaudeConfig(
+      home,
+      claudeRemoteFilesystemFixtureJson(),
+    );
+    const opencodeBefore = readFileSync(opencodeConfigPath, 'utf8');
+    const claudeBefore = readFileSync(claudeConfigPath, 'utf8');
+    const opencodeStat = statSync(opencodeConfigPath);
+    const claudeStat = statSync(claudeConfigPath);
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(1);
+    expect(stderr.text()).toBe('');
+    expect(prompt).not.toHaveBeenCalled();
+    expect(stdout.text()).toContain('Bootstrap proposal (dry-run)');
+    expect(stdout.text()).toContain('Hard refuses: 1');
+    expect(stdout.text()).toContain('No files were written.');
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
+    expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
+    expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);
+    expect(statSync(claudeConfigPath).size).toBe(claudeStat.size);
+    expect(statSync(opencodeConfigPath).mtimeMs).toBe(opencodeStat.mtimeMs);
+    expect(statSync(claudeConfigPath).mtimeMs).toBe(claudeStat.mtimeMs);
+  });
+
+  it('prints the no-readable-agents blocker proposal without prompting', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(1);
+    expect(stderr.text()).toBe('');
+    expect(prompt).not.toHaveBeenCalled();
+    expect(stdout.text()).toContain('Bootstrap proposal (dry-run)');
+    expect(stdout.text()).toContain('Blockers: 1');
+    expect(stdout.text()).toContain('no-readable-agents');
+    expect(stdout.text()).toContain('No files were written.');
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+  });
+
+  it('requires a TTY before prompting for a pickable conflict', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    seedFakeClaudeBin(pathDir);
+    const opencodeConfigPath = seedBootstrapAgentConfig(xdgConfigHome);
+    const claudeConfigPath = seedClaudeConfig(
+      home,
+      claudeFilesystemFixtureJson(),
+    );
+    const opencodeBefore = readFileSync(opencodeConfigPath, 'utf8');
+    const claudeBefore = readFileSync(claudeConfigPath, 'utf8');
+    const opencodeStat = statSync(opencodeConfigPath);
+    const claudeStat = statSync(claudeConfigPath);
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, { prompt });
+
+    expect(code).toBe(2);
+    expect(stdout.text()).toBe('');
+    expect(stderr.text()).toBe(
+      'Interactive bootstrap requires a TTY. Run "overture bootstrap --dry-run" for a non-interactive preview.\n',
+    );
+    expect(prompt).not.toHaveBeenCalled();
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
+    expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
+    expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);
+    expect(statSync(claudeConfigPath).size).toBe(claudeStat.size);
+    expect(statSync(opencodeConfigPath).mtimeMs).toBe(opencodeStat.mtimeMs);
+    expect(statSync(claudeConfigPath).mtimeMs).toBe(claudeStat.mtimeMs);
+  });
+
+  it('preserves --dry-run as a non-interactive proposal for pickables', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    seedFakeClaudeBin(pathDir);
+    const opencodeConfigPath = seedBootstrapAgentConfig(xdgConfigHome);
+    const claudeConfigPath = seedClaudeConfig(
+      home,
+      claudeFilesystemFixtureJson(),
+    );
+    const opencodeBefore = readFileSync(opencodeConfigPath, 'utf8');
+    const claudeBefore = readFileSync(claudeConfigPath, 'utf8');
+    const opencodeStat = statSync(opencodeConfigPath);
+    const claudeStat = statSync(claudeConfigPath);
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap(['--dry-run'], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(1);
+    expect(stderr.text()).toBe('');
+    expect(prompt).not.toHaveBeenCalled();
+    expect(stdout.text()).toContain('Bootstrap proposal (dry-run)');
+    expect(stdout.text()).toContain('Pickable conflicts: 1');
+    expect(stdout.text()).not.toContain('Resolved conflicts:');
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
+    expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
+    expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);
+    expect(statSync(claudeConfigPath).size).toBe(claudeStat.size);
+    expect(statSync(opencodeConfigPath).mtimeMs).toBe(opencodeStat.mtimeMs);
+    expect(statSync(claudeConfigPath).mtimeMs).toBe(claudeStat.mtimeMs);
+  });
+
+  it('preserves --dry-run --json as a non-interactive envelope for pickables', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    seedFakeClaudeBin(pathDir);
+    const opencodeConfigPath = seedBootstrapAgentConfig(xdgConfigHome);
+    const claudeConfigPath = seedClaudeConfig(
+      home,
+      claudeFilesystemFixtureJson(),
+    );
+    const opencodeBefore = readFileSync(opencodeConfigPath, 'utf8');
+    const claudeBefore = readFileSync(claudeConfigPath, 'utf8');
+    const opencodeStat = statSync(opencodeConfigPath);
+    const claudeStat = statSync(claudeConfigPath);
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap(['--dry-run', '--json'], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(1);
+    expect(stderr.text()).toBe('');
+    expect(prompt).not.toHaveBeenCalled();
+    const parsed = JSON.parse(stdout.text()) as {
+      conflicts: { pickable: unknown[]; hardRefuses: unknown[] };
+      proposal: { status: string };
+    };
+    expect(parsed.proposal.status).toBe('blocked');
+    expect(parsed.conflicts.pickable).toHaveLength(1);
+    expect(parsed.conflicts.hardRefuses).toHaveLength(0);
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
+    expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
+    expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);
+    expect(statSync(claudeConfigPath).size).toBe(claudeStat.size);
+    expect(statSync(opencodeConfigPath).mtimeMs).toBe(opencodeStat.mtimeMs);
+    expect(statSync(claudeConfigPath).mtimeMs).toBe(claudeStat.mtimeMs);
+  });
+
+  it('rejects an existing canonical config before prompting', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    const paths = defaultOverturePaths(env);
+    mkdirSync(paths.configDir, { recursive: true });
+    writeFileSync(paths.configFile, validCanonicalConfigJson());
+    const configBefore = readFileSync(paths.configFile, 'utf8');
+    const beforeStat = statSync(paths.configFile);
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(1);
+    expect(stdout.text()).toBe('');
+    expect(stderr.text()).toContain('Bootstrap is one-time');
+    expect(prompt).not.toHaveBeenCalled();
+    expect(readFileSync(paths.configFile, 'utf8')).toBe(configBefore);
+    expect(statSync(paths.configFile).size).toBe(beforeStat.size);
+    expect(statSync(paths.configFile).mtimeMs).toBe(beforeStat.mtimeMs);
+  });
+
+  it('rejects an unknown flag before prompting', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap(['--bogus'], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(2);
+    expect(stdout.text()).toBe('');
+    expect(stderr.text()).toContain('Unknown flag: --bogus');
+    expect(stderr.text()).toContain(BOOTSTRAP_USAGE);
+    expect(prompt).not.toHaveBeenCalled();
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+  });
+
+  it('rejects --json without --dry-run before prompting', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    const prompt = queuedPrompt(['1']);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap(['--json'], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(2);
+    expect(stdout.text()).toBe('');
+    expect(stderr.text()).toContain('Invalid flag combination');
+    expect(stderr.text()).toContain(BOOTSTRAP_USAGE);
+    expect(prompt).not.toHaveBeenCalled();
+    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
   });
 });

--- a/apps/cli/src/bootstrap-command.ts
+++ b/apps/cli/src/bootstrap-command.ts
@@ -7,12 +7,29 @@ import {
 import { defaultPathResolutionContext } from './platforms/detect.js';
 import { buildScanJsonOutput } from './scan.js';
 import { buildBootstrapPlan, type BootstrapPlan } from './bootstrap.js';
-import { formatHumanBootstrapProposal } from './bootstrap-human.js';
+import {
+  formatHumanBootstrapProposal,
+  formatHumanInteractiveResult,
+} from './bootstrap-human.js';
+import {
+  applyInteractiveResolutions,
+  type InteractiveResolution,
+} from './bootstrap-resolution.js';
+import {
+  createStdinPrompt,
+  formatPickablePrompt,
+  parsePickableAnswer,
+  type PromptQuestion,
+} from './bootstrap-prompt.js';
 export type { StringWriter } from './scan-command.js';
 import type { StringWriter } from './scan-command.js';
 
 export const BOOTSTRAP_USAGE = 'Usage: overture bootstrap --dry-run [--json]\n';
 
+// D2 - the no-flag path is now an interactive read-only dispatch.
+// This constant remains exported so the bootstrap-command spec (which task 5
+// will rewrite) can keep referencing the historical message while it is
+// phased out.
 export const BOOTSTRAP_RESERVED_MESSAGE =
   'Bootstrap writes are not implemented yet. Run "overture bootstrap --dry-run" to preview the proposal.\n';
 
@@ -24,6 +41,21 @@ const BOOTSTRAP_EXISTING_CONFIG_MESSAGE =
 
 const BOOTSTRAP_UNKNOWN_FLAG_PREFIX = 'Unknown flag: ';
 
+const BOOTSTRAP_NON_TTY_MESSAGE =
+  'Interactive bootstrap requires a TTY. Run "overture bootstrap --dry-run" for a non-interactive preview.\n';
+
+const MAX_INVALID_PROMPT_ATTEMPTS = 10;
+
+/**
+ * D2 - injection seam for tests and production. Production callers omit
+ * `options`; tests inject a stubbed prompt + explicit `isTTY` so the
+ * interactive flow can be exercised without a real TTY.
+ */
+export interface RunBootstrapOptions {
+  readonly prompt?: PromptQuestion;
+  readonly isTTY?: boolean;
+}
+
 export function exitCodeForBootstrap(plan: BootstrapPlan): 0 | 1 {
   return plan.proposal.status === 'blocked' ? 1 : 0;
 }
@@ -32,12 +64,8 @@ export async function runBootstrap(
   args: readonly string[],
   stdout: StringWriter,
   stderr: StringWriter,
+  options: RunBootstrapOptions = {},
 ): Promise<number> {
-  if (args.length === 0) {
-    stderr.write(BOOTSTRAP_RESERVED_MESSAGE);
-    return 2;
-  }
-
   if (args.includes('--help') || args.includes('-h')) {
     stdout.write(BOOTSTRAP_USAGE);
     return 0;
@@ -58,11 +86,6 @@ export async function runBootstrap(
 
   if (hasJson && !hasDryRun) {
     stderr.write(`${BOOTSTRAP_INVALID_COMBINATION_MESSAGE}${BOOTSTRAP_USAGE}`);
-    return 2;
-  }
-
-  if (!hasDryRun) {
-    stderr.write(BOOTSTRAP_RESERVED_MESSAGE);
     return 2;
   }
 
@@ -96,6 +119,10 @@ export async function runBootstrap(
     configPath: paths.configFile,
   });
 
+  if (!hasDryRun) {
+    return runBootstrapInteractive(stdout, stderr, plan, options);
+  }
+
   if (!hasJson) {
     return runBootstrapHuman(stdout, plan);
   }
@@ -117,6 +144,97 @@ export async function runBootstrap(
 function runBootstrapHuman(stdout: StringWriter, plan: BootstrapPlan): 0 | 1 {
   stdout.write(formatHumanBootstrapProposal(plan));
   return exitCodeForBootstrap(plan);
+}
+
+/**
+ * D2 - Interactive read-only dispatch for the no-flag path.
+ *
+ * Decision tree (matches the D2 plan exactly):
+ *   1. hard refuses OR blockers -> print proposal and return 1; never prompt.
+ *   2. pickables AND non-TTY -> print TTY hint to stderr and return 2.
+ *   3. pickables AND TTY     -> prompt each conflict in order, collect
+ *      decisions, apply them in-memory, print interactive summary, return
+ *      1 if the resulting plan is still blocked, else 0.
+ *   4. otherwise (no conflicts of any kind) -> print proposal, return 0.
+ *
+ * No filesystem writes happen here.
+ */
+async function runBootstrapInteractive(
+  stdout: StringWriter,
+  stderr: StringWriter,
+  plan: BootstrapPlan,
+  options: RunBootstrapOptions,
+): Promise<number> {
+  if (plan.conflicts.hardRefuses.length > 0 || plan.blockers.length > 0) {
+    stdout.write(formatHumanBootstrapProposal(plan));
+    return 1;
+  }
+
+  if (plan.conflicts.pickable.length === 0) {
+    stdout.write(formatHumanBootstrapProposal(plan));
+    return 0;
+  }
+
+  const isTTY = options.isTTY ?? process.stdin.isTTY ?? false;
+  if (!isTTY) {
+    stderr.write(BOOTSTRAP_NON_TTY_MESSAGE);
+    return 2;
+  }
+
+  const prompt = options.prompt ?? createStdinPrompt();
+  const decisions: InteractiveResolution[] = [];
+
+  for (const conflict of plan.conflicts.pickable) {
+    stdout.write(formatPickablePrompt(conflict));
+    let resolved = false;
+    let invalidAttempts = 0;
+    while (!resolved) {
+      const answer = await prompt(formatPickablePrompt(conflict));
+      if (answer === null) {
+        stderr.write(`Bootstrap aborted: ${conflict.serverName}\n`);
+        return 2;
+      }
+      const parsed = parsePickableAnswer(answer, conflict.candidates.length);
+      if (parsed.kind === 'abort') {
+        stderr.write(`Bootstrap aborted: ${conflict.serverName}\n`);
+        return 2;
+      }
+      if (parsed.kind === 'invalid') {
+        invalidAttempts += 1;
+        if (invalidAttempts >= MAX_INVALID_PROMPT_ATTEMPTS) {
+          stderr.write(
+            `Bootstrap aborted: too many invalid answers for ${conflict.serverName}\n`,
+          );
+          return 2;
+        }
+        stdout.write(formatPickablePrompt(conflict));
+        continue;
+      }
+      if (parsed.kind === 'skipped') {
+        decisions.push({
+          kind: 'skipped',
+          serverName: conflict.serverName,
+        });
+        resolved = true;
+        continue;
+      }
+      decisions.push({
+        kind: 'selected',
+        serverName: conflict.serverName,
+        candidateIndex: parsed.candidateIndex,
+      });
+      resolved = true;
+    }
+  }
+
+  const result = applyInteractiveResolutions(plan, decisions);
+  if (result.aborted) {
+    stderr.write('Bootstrap aborted: user requested abort\n');
+    return 2;
+  }
+
+  stdout.write(formatHumanInteractiveResult(result));
+  return result.plan.proposal.status === 'blocked' ? 1 : 0;
 }
 
 function messageForError(err: unknown): string {

--- a/apps/cli/src/bootstrap-human.interactive.spec.ts
+++ b/apps/cli/src/bootstrap-human.interactive.spec.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from 'vitest';
+import type { PickableConflict } from '@overture/scan-matrix';
+
+import { buildBootstrapPlan } from './bootstrap.js';
+import type { BootstrapPlan } from './bootstrap.js';
+import {
+  formatHumanBootstrapProposal,
+  formatHumanInteractiveResult,
+} from './bootstrap-human.js';
+import {
+  applyInteractiveResolutions,
+  type InteractiveResolution,
+} from './bootstrap-resolution.js';
+import {
+  CONTEXT7_REMOTE,
+  HOME_FILESYSTEM_STDIO,
+  PNPM_FILESYSTEM_STDIO,
+  UPSTASH_CONTEXT7_STDIO,
+  agentSnapshot,
+  remoteServer,
+  row,
+  scanOutput,
+  stdioServer,
+} from '../test-support/bootstrap-test-support.js';
+
+const PICKABLE_FILESYSTEM: PickableConflict = {
+  serverName: 'filesystem',
+  candidates: [
+    {
+      agentId: 'claude-code',
+      displayName: 'claude-code',
+      server: HOME_FILESYSTEM_STDIO,
+    },
+    {
+      agentId: 'opencode',
+      displayName: 'opencode',
+      server: PNPM_FILESYSTEM_STDIO,
+    },
+  ],
+  message: 'Pickable conflict for "filesystem".',
+};
+
+const PICKABLE_CONTEXT7: PickableConflict = {
+  serverName: 'context7',
+  candidates: [
+    {
+      agentId: 'claude-code',
+      displayName: 'claude-code',
+      server: UPSTASH_CONTEXT7_STDIO,
+    },
+    {
+      agentId: 'opencode',
+      displayName: 'opencode',
+      server: CONTEXT7_REMOTE,
+    },
+  ],
+  message: 'Pickable conflict for "context7".',
+};
+
+const PICKABLE_SHARED: PickableConflict = {
+  serverName: 'shared',
+  candidates: [
+    {
+      agentId: 'claude-code',
+      displayName: 'claude-code',
+      server: stdioServer('alpha', ['--shared']),
+    },
+    {
+      agentId: 'opencode',
+      displayName: 'opencode',
+      server: stdioServer('zeta', ['--shared']),
+    },
+  ],
+  message: 'Pickable conflict for "shared".',
+};
+
+function planWithThreePickables(): BootstrapPlan {
+  return buildBootstrapPlan({
+    scanOutput: scanOutput({
+      agents: [
+        agentSnapshot('claude-code', 'read-ok'),
+        agentSnapshot('opencode', 'read-ok'),
+      ],
+      rows: [
+        row({
+          agentId: 'claude-code',
+          serverName: 'filesystem',
+          server: HOME_FILESYSTEM_STDIO,
+        }),
+        row({
+          agentId: 'opencode',
+          serverName: 'filesystem',
+          server: PNPM_FILESYSTEM_STDIO,
+        }),
+        row({
+          agentId: 'claude-code',
+          serverName: 'context7',
+          server: UPSTASH_CONTEXT7_STDIO,
+        }),
+        row({
+          agentId: 'opencode',
+          serverName: 'context7',
+          server: CONTEXT7_REMOTE,
+        }),
+        row({
+          agentId: 'claude-code',
+          serverName: 'shared',
+          server: stdioServer('alpha', ['--shared']),
+        }),
+        row({
+          agentId: 'opencode',
+          serverName: 'shared',
+          server: stdioServer('zeta', ['--shared']),
+        }),
+      ],
+      conflicts: {
+        pickable: [PICKABLE_FILESYSTEM, PICKABLE_CONTEXT7, PICKABLE_SHARED],
+        hardRefuses: [],
+      },
+    }),
+    configPath: '/tmp/overture.jsonc',
+  });
+}
+
+function planWithBearerHeadersRemote(): BootstrapPlan {
+  return buildBootstrapPlan({
+    scanOutput: scanOutput({
+      agents: [
+        agentSnapshot('claude-code', 'read-ok'),
+        agentSnapshot('opencode', 'read-ok'),
+      ],
+      rows: [
+        row({
+          agentId: 'claude-code',
+          serverName: 'filesystem',
+          server: HOME_FILESYSTEM_STDIO,
+        }),
+        row({
+          agentId: 'opencode',
+          serverName: 'filesystem',
+          server: PNPM_FILESYSTEM_STDIO,
+        }),
+      ],
+      conflicts: {
+        pickable: [
+          {
+            serverName: 'remote-secret',
+            candidates: [
+              {
+                agentId: 'claude-code',
+                displayName: 'claude-code',
+                server: remoteServer('https://api.example.com?api_key=secret', {
+                  Authorization: 'Bearer secret',
+                }),
+              },
+              {
+                agentId: 'opencode',
+                displayName: 'opencode',
+                server: remoteServer('https://api.example.com?api_key=other', {
+                  Authorization: 'Bearer other',
+                }),
+              },
+            ],
+            message:
+              'Pick one canonical entry for "remote-secret". See https://api.example.com?api_key=secret.',
+          },
+        ],
+        hardRefuses: [
+          {
+            reason: 'mixed-transport-types',
+            serverName: 'remote-secret',
+            agentId: null,
+            displayName: null,
+            message:
+              'Cannot classify server "remote-secret" because agents disagree on transport type. See https://api.example.com?api_key=secret for the offending entry.',
+          },
+        ],
+      },
+    }),
+    configPath: '/tmp/overture.jsonc',
+  });
+}
+
+function emptyInteractivePlan(): BootstrapPlan {
+  return buildBootstrapPlan({
+    scanOutput: scanOutput({
+      agents: [
+        agentSnapshot('claude-code', 'read-ok'),
+        agentSnapshot('opencode', 'read-ok'),
+      ],
+      rows: [],
+      conflicts: { pickable: [], hardRefuses: [] },
+    }),
+    configPath: '/tmp/overture.jsonc',
+  });
+}
+
+function expectedTwoResolvedOneSkipped(): string {
+  // Deterministic byte-for-byte renderer contract. Adopted servers are
+  // sorted alphabetically; resolved/skipped conflicts come pre-sorted from
+  // the resolver. No blank lines between sections.
+  return [
+    'Bootstrap proposal (interactive)',
+    'Config path: /tmp/overture.jsonc',
+    'Proposal status: ready',
+    'Adopted servers: 2',
+    '  - context7 (selected-conflict) from claude-code',
+    '  - filesystem (selected-conflict) from claude-code',
+    'Pickable conflicts: 0',
+    'Hard refuses: 0',
+    'Blockers: 0',
+    'Resolved conflicts: 2',
+    '  - context7: claude-code (claude-code)',
+    '  - filesystem: claude-code (claude-code)',
+    'Skipped conflicts: 1',
+    '  - shared',
+    'No files were written.',
+    '',
+  ].join('\n');
+}
+
+function expectedEmpty(): string {
+  return [
+    'Bootstrap proposal (interactive)',
+    'Config path: /tmp/overture.jsonc',
+    'Proposal status: ready',
+    'Adopted servers: 0',
+    'Pickable conflicts: 0',
+    'Hard refuses: 0',
+    'Blockers: 0',
+    'Resolved conflicts: 0',
+    'Skipped conflicts: 0',
+    'No files were written.',
+    '',
+  ].join('\n');
+}
+
+describe('formatHumanInteractiveResult', () => {
+  it('matches the exact byte contract for a 2-resolution + 1-skip plan', () => {
+    const plan = planWithThreePickables();
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+      { kind: 'selected', serverName: 'context7', candidateIndex: 0 },
+      { kind: 'skipped', serverName: 'shared' },
+    ];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+    const output = formatHumanInteractiveResult(result);
+
+    expect(output).toBe(expectedTwoResolvedOneSkipped());
+  });
+
+  it('preserves formatHumanBootstrapProposal byte-for-byte against a known fixture', () => {
+    // Baseline regression: the dry-run renderer must not change in D2.
+    const plan = buildBootstrapPlan({
+      scanOutput: scanOutput({
+        agents: [
+          agentSnapshot('claude-code', 'read-ok'),
+          agentSnapshot('opencode', 'read-ok'),
+        ],
+        rows: [
+          row({
+            agentId: 'claude-code',
+            serverName: 'filesystem',
+            server: HOME_FILESYSTEM_STDIO,
+          }),
+          row({
+            agentId: 'opencode',
+            serverName: 'filesystem',
+            server: PNPM_FILESYSTEM_STDIO,
+          }),
+        ],
+        conflicts: { pickable: [], hardRefuses: [] },
+      }),
+      configPath: '/tmp/overture.jsonc',
+    });
+
+    const first = formatHumanBootstrapProposal(plan);
+    const second = formatHumanBootstrapProposal(plan);
+    expect(first).toBe(second);
+    expect(first).toContain('Bootstrap proposal (dry-run)');
+    expect(first).toContain('No files were written.');
+  });
+
+  it('redacts bearer headers, secrets, and full URLs in the interactive output', () => {
+    const plan = planWithBearerHeadersRemote();
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'remote-secret', candidateIndex: 0 },
+    ];
+    const result = applyInteractiveResolutions(plan, decisions);
+    const output = formatHumanInteractiveResult(result);
+
+    const forbiddenFragments = [
+      'api_key=',
+      'Bearer ',
+      '$schema',
+      'matrix',
+      'agentServer',
+      'canonicalServer',
+      'headers: {',
+      'Authorization',
+    ];
+    for (const fragment of forbiddenFragments) {
+      expect(output).not.toContain(fragment);
+    }
+
+    // The full URLs in the pickable and hard-refuse messages must be
+    // redacted to the form `<scheme>://<host><path>?…` by redactMessageUrls.
+    expect(output).toContain('https://api.example.com/?…');
+    expect(output).not.toContain('api_key=secret');
+    expect(output).not.toContain('api_key=other');
+  });
+
+  it('ends with a single trailing newline and prints No files were written. as the last content line', () => {
+    const plan = planWithThreePickables();
+    const result = applyInteractiveResolutions(plan, [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+      { kind: 'selected', serverName: 'context7', candidateIndex: 0 },
+      { kind: 'skipped', serverName: 'shared' },
+    ]);
+
+    const output = formatHumanInteractiveResult(result);
+
+    expect(output.endsWith('\n')).toBe(true);
+    expect(output.endsWith('\n\n')).toBe(false);
+
+    const lines = output.split('\n');
+    // split('\n') on a string that ends with '\n' produces an empty last
+    // element; the content line before it must be the footer.
+    expect(lines.at(-1)).toBe('');
+    expect(lines.at(-2)).toBe('No files were written.');
+  });
+
+  it('renders zero counters for a no-pickable / no-hard-refuse / no-blocker plan', () => {
+    const plan = emptyInteractivePlan();
+    const result = applyInteractiveResolutions(plan, []);
+    const output = formatHumanInteractiveResult(result);
+
+    expect(output).toContain('Pickable conflicts: 0');
+    expect(output).toContain('Hard refuses: 0');
+    expect(output).toContain('Blockers: 0');
+    expect(output).toContain('Resolved conflicts: 0');
+    expect(output).toContain('Skipped conflicts: 0');
+    expect(output).toBe(expectedEmpty());
+  });
+
+  it('does not emit ansi escape codes', () => {
+    const plan = planWithThreePickables();
+    const result = applyInteractiveResolutions(plan, [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+      { kind: 'selected', serverName: 'context7', candidateIndex: 0 },
+      { kind: 'skipped', serverName: 'shared' },
+    ]);
+    const output = formatHumanInteractiveResult(result);
+    expect(/\x1b\[[0-9;]*m/.test(output)).toBe(false);
+  });
+});

--- a/apps/cli/src/bootstrap-human.ts
+++ b/apps/cli/src/bootstrap-human.ts
@@ -1,6 +1,7 @@
 import { renderFingerprint, redactUrl } from './scan-human/fingerprint.js';
 
 import type { BootstrapBlocker, BootstrapPlan } from './bootstrap.js';
+import type { InteractiveResolutionResult } from './bootstrap-resolution.js';
 
 type PickableConflictList = BootstrapPlan['conflicts']['pickable'];
 type HardRefuseConflictList = BootstrapPlan['conflicts']['hardRefuses'];
@@ -51,6 +52,72 @@ export function formatHumanBootstrapProposal(plan: BootstrapPlan): string {
   lines.push(
     'Run "overture bootstrap --dry-run --json" for machine-readable details.',
   );
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * D2 - Render the final read-only interactive summary. A sibling renderer to
+ * `formatHumanBootstrapProposal`: the dry-run path emits the full proposal
+ * (config preview, target agents, pickable candidate fingerprints), while
+ * this interactive path emits a tighter summary that surfaces only the
+ * proposal fields the user needs to verify the resolution plus the
+ * in-memory decisions they made.
+ *
+ * Section ordering (fixed):
+ *   heading, config path, status, adopted servers, pickable conflicts,
+ *   hard refuses, blockers, resolved conflicts, skipped conflicts,
+ *   no-files footer.
+ *
+ * Deterministic, plain-text, no ANSI. URL-bearing messages from hard
+ * refuses are redacted via `redactMessageUrls`. No raw env/headers/full
+ * URLs/`$schema`/`matrix`/`agentServer`/`canonicalServer` is ever emitted.
+ * No files are written; the footer reflects that explicitly.
+ */
+export function formatHumanInteractiveResult(
+  result: InteractiveResolutionResult,
+): string {
+  const lines: string[] = ['Bootstrap proposal (interactive)'];
+
+  lines.push(`Config path: ${result.plan.proposal.configPath}`);
+  lines.push(`Proposal status: ${result.plan.proposal.status}`);
+
+  lines.push(`Adopted servers: ${result.plan.proposal.adoptedServers.length}`);
+  for (const adopted of sortByName(result.plan.proposal.adoptedServers)) {
+    lines.push(
+      `  - ${adopted.name} (${adopted.source}) from ${adopted.agentIds.join(', ')}`,
+    );
+  }
+
+  // Pickable conflicts: count only. After a successful interactive run the
+  // caller has decided every pickable (selected or skipped), so this count
+  // is always 0 here; the boot command exits 1 before reaching this renderer
+  // when pickables remain un-decided.
+  lines.push(`Pickable conflicts: ${result.plan.conflicts.pickable.length}`);
+
+  lines.push(`Hard refuses: ${result.plan.conflicts.hardRefuses.length}`);
+  for (const conflict of sortHardRefuses(result.plan.conflicts.hardRefuses)) {
+    lines.push(`  - ${redactMessageUrls(conflict.message)}`);
+  }
+
+  lines.push(`Blockers: ${result.plan.blockers.length}`);
+  for (const blocker of result.plan.blockers) {
+    lines.push(`  - ${renderBlocker(blocker)}`);
+  }
+
+  lines.push(`Resolved conflicts: ${result.resolvedConflicts.length}`);
+  for (const entry of result.resolvedConflicts) {
+    lines.push(
+      `  - ${entry.serverName}: ${entry.displayName} (${entry.agentId})`,
+    );
+  }
+
+  lines.push(`Skipped conflicts: ${result.skippedConflicts.length}`);
+  for (const name of result.skippedConflicts) {
+    lines.push(`  - ${name}`);
+  }
+
+  lines.push('No files were written.');
+
   return `${lines.join('\n')}\n`;
 }
 

--- a/apps/cli/src/bootstrap-prompt.spec.ts
+++ b/apps/cli/src/bootstrap-prompt.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * D2 - Spec for the interactive bootstrap prompt primitive.
+ *
+ * Covers the pure renderer (`formatPickablePrompt`) and parser
+ * (`parsePickableAnswer`) plus the injectable readline adapter
+ * (`createReadlinePrompt`). `createStdinPrompt` is intentionally not
+ * exercised here because it would attach to the real process stdio.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { OvertureMcpServer } from '@overture/config';
+import type {
+  PickableConflict,
+  PickableConflictCandidate,
+} from '@overture/scan-matrix';
+
+import {
+  createReadlinePrompt,
+  formatPickablePrompt,
+  parsePickableAnswer,
+} from './bootstrap-prompt.js';
+import { renderFingerprint } from './scan-human/fingerprint.js';
+
+function stdioCandidate(
+  agentId: string,
+  displayName: string,
+  server: Extract<OvertureMcpServer, { type: 'stdio' }>,
+): PickableConflictCandidate {
+  return { agentId, displayName, server };
+}
+
+function remoteCandidate(
+  agentId: string,
+  displayName: string,
+  server: Extract<OvertureMcpServer, { type: 'remote' }>,
+): PickableConflictCandidate {
+  return { agentId, displayName, server };
+}
+
+describe('formatPickablePrompt', () => {
+  it('2-candidate: exact-string render with stdio servers (no headers)', () => {
+    const conflict: PickableConflict = {
+      serverName: 'filesystem',
+      message: '',
+      candidates: [
+        stdioCandidate('claude-code', 'claude-code', {
+          type: 'stdio',
+          command: 'npx',
+          args: ['@modelcontextprotocol/server-filesystem'],
+        }),
+        stdioCandidate('opencode', 'opencode', {
+          type: 'stdio',
+          command: 'mcp-fs',
+        }),
+      ],
+    };
+
+    const out = formatPickablePrompt(conflict);
+
+    const expected = [
+      'Pickable conflict: filesystem',
+      `  1) claude-code (claude-code): ${renderFingerprint(conflict.candidates[0].server)}`,
+      `  2) opencode (opencode): ${renderFingerprint(conflict.candidates[1].server)}`,
+      '  s) skip this server (default)',
+      'Choose canonical entry [1-2, s=skip, q=abort]: ',
+    ].join('\n');
+
+    expect(out).toBe(expected);
+  });
+
+  it('3-candidate: exact-string render with one stdio and two remotes (distinct URLs)', () => {
+    const conflict: PickableConflict = {
+      serverName: 'context7',
+      message: '',
+      candidates: [
+        stdioCandidate('claude-code', 'claude-code', {
+          type: 'stdio',
+          command: 'mcp-fs',
+        }),
+        remoteCandidate('opencode', 'opencode', {
+          type: 'remote',
+          url: 'https://mcp.example.com/?api_key=secret&x=1',
+        }),
+        remoteCandidate('openai-codex', 'openai-codex', {
+          type: 'remote',
+          url: 'https://other.example.com/?token=abc',
+        }),
+      ],
+    };
+
+    const out = formatPickablePrompt(conflict);
+
+    const expected = [
+      'Pickable conflict: context7',
+      `  1) claude-code (claude-code): ${renderFingerprint(conflict.candidates[0].server)}`,
+      `  2) opencode (opencode): ${renderFingerprint(conflict.candidates[1].server)}`,
+      `  3) openai-codex (openai-codex): ${renderFingerprint(conflict.candidates[2].server)}`,
+      '  s) skip this server (default)',
+      'Choose canonical entry [1-3, s=skip, q=abort]: ',
+    ].join('\n');
+
+    expect(out).toBe(expected);
+  });
+
+  it('redaction: never leaks api_key / Bearer / schema / matrix / agentServer / canonicalServer / headers / Authorization', () => {
+    const conflict: PickableConflict = {
+      serverName: 'leaky',
+      message: '',
+      candidates: [
+        remoteCandidate('claude-code', 'claude-code', {
+          type: 'remote',
+          url: 'https://mcp.example.com/?api_key=secret&x=1',
+          headers: { Authorization: 'Bearer leaked' },
+        }),
+      ],
+    };
+
+    const out = formatPickablePrompt(conflict);
+
+    for (const banned of [
+      'api_key=',
+      'Bearer ',
+      '$schema',
+      'matrix',
+      'agentServer',
+      'canonicalServer',
+      'headers: {',
+      'Authorization',
+    ]) {
+      expect(out).not.toContain(banned);
+    }
+  });
+
+  it('suffix: prompt line ends with ": " and overall output ends with newline', () => {
+    const conflict: PickableConflict = {
+      serverName: 'filesystem',
+      message: '',
+      candidates: [
+        stdioCandidate('claude-code', 'claude-code', {
+          type: 'stdio',
+          command: 'npx',
+        }),
+        stdioCandidate('opencode', 'opencode', {
+          type: 'stdio',
+          command: 'mcp-fs',
+        }),
+      ],
+    };
+
+    const out = formatPickablePrompt(conflict);
+
+    // Prompt line ends with ': ' (single trailing space), not '\n'; exact-string cases above pin this.
+    expect(out.endsWith('\n')).toBe(false);
+  });
+});
+
+describe('parsePickableAnswer', () => {
+  const cases: readonly (readonly [
+    string,
+    number,
+    ReturnType<typeof parsePickableAnswer>,
+  ])[] = [
+    ['', 2, { kind: 'skipped' }],
+    ['   ', 2, { kind: 'skipped' }],
+    ['s', 2, { kind: 'skipped' }],
+    ['S', 2, { kind: 'skipped' }],
+    ['skip', 2, { kind: 'skipped' }],
+    ['Skip', 2, { kind: 'skipped' }],
+    ['SKIP', 2, { kind: 'skipped' }],
+    ['q', 2, { kind: 'abort' }],
+    ['Q', 2, { kind: 'abort' }],
+    ['quit', 2, { kind: 'abort' }],
+    ['abort', 2, { kind: 'abort' }],
+    ['exit', 2, { kind: 'abort' }],
+    ['  q  ', 2, { kind: 'abort' }],
+    ['1', 2, { kind: 'selected', candidateIndex: 0 }],
+    ['2', 2, { kind: 'selected', candidateIndex: 1 }],
+    ['1', 3, { kind: 'selected', candidateIndex: 0 }],
+    ['3', 3, { kind: 'selected', candidateIndex: 2 }],
+    ['3', 2, { kind: 'invalid' }],
+    ['0', 2, { kind: 'invalid' }],
+    ['-1', 2, { kind: 'invalid' }],
+    ['1.5', 2, { kind: 'invalid' }],
+    ['foo', 2, { kind: 'invalid' }],
+    ['  1  ', 2, { kind: 'selected', candidateIndex: 0 }],
+  ];
+
+  for (const [input, candidateCount, expected] of cases) {
+    it(`maps ${JSON.stringify(input)} (n=${candidateCount}) -> ${expected.kind}`, () => {
+      expect(parsePickableAnswer(input, candidateCount)).toEqual(expected);
+    });
+  }
+});
+describe('createReadlinePrompt', () => {
+  it('returns the trimmed stubbed answer', async () => {
+    const rl = {
+      question: vi.fn((_msg: string) => Promise.resolve('1')),
+      close: vi.fn(),
+    };
+    const ask = createReadlinePrompt(rl);
+
+    expect(await ask('pick: ')).toBe('1');
+    expect(rl.question).toHaveBeenCalledWith('pick: ');
+  });
+
+  it('strips surrounding whitespace from the stubbed answer', async () => {
+    const rl = {
+      question: vi.fn((_msg: string) => Promise.resolve('  q  ')),
+      close: vi.fn(),
+    };
+    const ask = createReadlinePrompt(rl);
+
+    expect(await ask('pick: ')).toBe('q');
+  });
+
+  it('returns null when the underlying reader rejects (EOF)', async () => {
+    const rl = {
+      question: vi.fn(() => {
+        throw new Error('eof');
+      }),
+      close: vi.fn(),
+    };
+
+    const ask = createReadlinePrompt(rl);
+
+    expect(await ask('pick: ')).toBeNull();
+  });
+});
+
+// createStdinPrompt is not unit-tested: would attach to the real process stdio.

--- a/apps/cli/src/bootstrap-prompt.ts
+++ b/apps/cli/src/bootstrap-prompt.ts
@@ -1,0 +1,220 @@
+/**
+ * D2 - Plain-text interactive bootstrap prompt primitive.
+ *
+ * The module exposes a pure renderer/parser plus a thin injectable adapter
+ * over `node:readline/promises`. The renderer is a pure function of a
+ * `PickableConflict`: no I/O, no ANSI, no newlines other than `\n` between
+ * sections. The parser maps a trimmed answer into a discriminated union
+ * (`selected | skipped | invalid | abort`) without touching any global state.
+ *
+ * `createReadlinePrompt` accepts the minimal `question`/`close` shape that
+ * `node:readline/promises.Interface` exposes so unit tests can pass a stub
+ * interface. Production wiring (Wave 2) owns the real `node:readline` import
+ * via `createStdinPrompt`, which is the only place `node:readline/promises`
+ * is imported. Importing that factory in unit tests would pull a real TTY
+ * dependency, so tests cover `createReadlinePrompt` with a stub instead.
+ */
+import type * as readlinePromises from 'node:readline/promises';
+
+import type { PickableConflict } from '@overture/scan-matrix';
+
+import { renderFingerprint } from './scan-human/fingerprint.js';
+
+/**
+ * The discriminated answer returned by `parsePickableAnswer` and the
+ * `createReadlinePrompt` adapter. Callers (the Wave 2 command) decide how to
+ * react: `selected` adopts `candidate[candidateIndex]`, `skipped` omits the
+ * server, `invalid` re-asks the same prompt, `abort` exits with code 2.
+ */
+export type PickableAnswer =
+  | { readonly kind: 'selected'; readonly candidateIndex: number }
+  | { readonly kind: 'skipped' }
+  | { readonly kind: 'invalid' }
+  | { readonly kind: 'abort' };
+
+/**
+ * Adapter shape the Wave 2 command injects for testability. The factory
+ * accepts the minimal readline surface (`question` + `close`) so tests can
+ * pass a stub. The returned string is fed to `parsePickableAnswer` by the
+ * caller; the adapter itself does no parsing.
+ *
+ * Returns `null` when the underlying line reader is closed (EOF), which the
+ * caller maps to `kind: 'abort'` per the D2 plan.
+ */
+export type PromptQuestion = (message: string) => Promise<string | null>;
+
+/**
+ * Render a `PickableConflict` as deterministic plain-text prompt lines. The
+ * exact shape is a public contract — Wave 2 callers and the spec lock the
+ * ordering, indentation, and trailing `: ` (single trailing space on the
+ * final prompt line) byte-for-byte.
+ *
+ * The renderer never mutates the input conflict; the candidate order follows
+ * `PickableConflict.candidates` from `@overture/scan-matrix` (already in
+ * registry order per B3). Fingerprints come from the shared
+ * `renderFingerprint` helper so URLs / env / headers are redacted exactly
+ * the way the C2 dry-run report redacts them.
+ */
+export function formatPickablePrompt(conflict: PickableConflict): string {
+  const lines: string[] = [`Pickable conflict: ${conflict.serverName}`];
+
+  conflict.candidates.forEach((candidate, index) => {
+    const n = index + 1;
+    lines.push(
+      `  ${n}) ${candidate.displayName} (${candidate.agentId}): ${renderFingerprint(candidate.server)}`,
+    );
+  });
+
+  lines.push('  s) skip this server (default)');
+  lines.push(
+    `Choose canonical entry [1-${conflict.candidates.length}, s=skip, q=abort]: `,
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Parse a trimmed answer into a `PickableAnswer`. Pure function: no I/O, no
+ * regex literals, only literal string equality. Whitespace is stripped from
+ * both ends before any check, matching what `node:readline/promises`
+ * `rl.question()` returns for a single-line input.
+ *
+ * Mapping:
+ *   - empty string OR whitespace-only -> `skipped` (per D2 default).
+ *   - `s` / `S` / `skip` -> `skipped`.
+ *   - `q` / `Q` / `quit` / `abort` / `exit` -> `abort`.
+ *   - positive integer in `[1, candidateCount]` -> `selected` with
+ *     `candidateIndex = input - 1`.
+ *   - anything else (negative, zero, decimals, multi-line, embedded
+ *     spaces, non-numeric, out-of-range) -> `invalid`.
+ */
+export function parsePickableAnswer(
+  input: string,
+  candidateCount: number,
+): PickableAnswer {
+  const trimmed = input.trim();
+
+  if (trimmed === '') {
+    return { kind: 'skipped' };
+  }
+
+  if (
+    trimmed === 's' ||
+    trimmed === 'S' ||
+    trimmed === 'skip' ||
+    trimmed === 'Skip' ||
+    trimmed === 'SKIP'
+  ) {
+    return { kind: 'skipped' };
+  }
+
+  if (
+    trimmed === 'q' ||
+    trimmed === 'Q' ||
+    trimmed === 'quit' ||
+    trimmed === 'Quit' ||
+    trimmed === 'QUIT' ||
+    trimmed === 'abort' ||
+    trimmed === 'Abort' ||
+    trimmed === 'ABORT' ||
+    trimmed === 'exit' ||
+    trimmed === 'Exit' ||
+    trimmed === 'EXIT'
+  ) {
+    return { kind: 'abort' };
+  }
+
+  if (!isPositiveInteger(trimmed)) {
+    return { kind: 'invalid' };
+  }
+
+  const numeric = Number.parseInt(trimmed, 10);
+  if (numeric < 1 || numeric > candidateCount) {
+    return { kind: 'invalid' };
+  }
+
+  return { kind: 'selected', candidateIndex: numeric - 1 };
+}
+
+/**
+ * Adapt a `node:readline/promises.Interface`-shaped object into a
+ * `PromptQuestion`. The factory accepts the minimal `question`/`close`
+ * surface so tests can pass a stub without instantiating a real readline
+ * interface. Production wiring is `createStdinPrompt`, which uses
+ * `node:readline/promises.createInterface({ input: process.stdin, ... })`.
+ *
+ * The trimmed string from `rl.question(message)` is returned as-is so the
+ * caller can pass it to `parsePickableAnswer`. When the underlying reader
+ * rejects (EOF, SIGINT, post-`close` call), the adapter returns `null`,
+ * which the caller maps to `kind: 'abort'` per the D2 plan.
+ */
+export function createReadlinePrompt(
+  rl: Pick<readlinePromises.Interface, 'question' | 'close'>,
+): PromptQuestion {
+  return async (message: string): Promise<string | null> => {
+    try {
+      const answer = await rl.question(message);
+      return answer.trim();
+    } catch {
+      return null;
+    }
+  };
+}
+
+/**
+ * Production helper. Builds a real `node:readline/promises` interface bound
+ * to `process.stdin` / `process.stdout` and returns a `PromptQuestion`. This
+ * is the only place `node:readline/promises` is imported — keeping it out of
+ * the module top level lets unit tests exercise the pure parser/renderer
+ * without pulling readline into the test bundle.
+ *
+ * `createStdinPrompt` is intentionally not unit-tested: calling it would
+ * attach to the real process stdio and require a TTY fixture. Wave 2 command
+ * tests inject a stubbed `createReadlinePrompt` adapter and cover the
+ * interactive flow without touching real stdio.
+ */
+export function createStdinPrompt(): PromptQuestion {
+  // Lazy import: keep readline out of the module top level so unit tests
+  // can import the pure helpers without dragging readline into the bundle.
+  const readlinePromises = createReadlinePromises();
+
+  const rl = readlinePromises.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return createReadlinePrompt(rl);
+}
+
+interface ReadlinePromisesLike {
+  createInterface(options: {
+    readonly input: NodeJS.ReadableStream;
+    readonly output: NodeJS.WritableStream;
+  }): Pick<readlinePromises.Interface, 'question' | 'close'>;
+}
+
+function createReadlinePromises(): ReadlinePromisesLike {
+  // `require` here is the lazy-load seam; tests never trigger this code path.
+
+  const required = createReadlineRequire();
+  return required('node:readline/promises') as ReadlinePromisesLike;
+}
+
+import { createRequire } from 'node:module';
+
+function createReadlineRequire(): (specifier: string) => unknown {
+  return createRequire(__filename);
+}
+
+function isPositiveInteger(text: string): boolean {
+  if (text.length === 0) {
+    return false;
+  }
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i);
+    if (code < 48 || code > 57) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/apps/cli/src/bootstrap-resolution.spec.ts
+++ b/apps/cli/src/bootstrap-resolution.spec.ts
@@ -1,0 +1,741 @@
+import { describe, expect, it } from 'vitest';
+import type { OvertureMcpServer } from '@overture/config';
+import type {
+  HardRefuseConflict,
+  PickableConflict,
+} from '@overture/scan-matrix';
+
+import { buildBootstrapPlan } from './bootstrap.js';
+import type {
+  BootstrapBlocker,
+  BootstrapPlan,
+  BootstrapProposal,
+} from './bootstrap.js';
+import {
+  applyInteractiveResolutions,
+  type InteractiveResolution,
+  type InteractiveResolutionResult,
+} from './bootstrap-resolution.js';
+import {
+  CONTEXT7_REMOTE,
+  HOME_FILESYSTEM_STDIO,
+  PNPM_FILESYSTEM_STDIO,
+  SCHEMA_URL,
+  UPSTASH_CONTEXT7_STDIO,
+  agentSnapshot,
+  remoteServer,
+  row,
+  scanOutput,
+} from '../test-support/bootstrap-test-support.js';
+
+const SCHEMA_URL_TEST =
+  'https://raw.githubusercontent.com/jander99/overture/main/schemas/overture.config.schema.json';
+
+const PICKABLE_FILESYSTEM: readonly PickableConflict[] = [
+  {
+    serverName: 'filesystem',
+    candidates: [
+      {
+        agentId: 'claude-code',
+        displayName: 'claude-code',
+        server: HOME_FILESYSTEM_STDIO,
+      },
+      {
+        agentId: 'opencode',
+        displayName: 'opencode',
+        server: PNPM_FILESYSTEM_STDIO,
+      },
+    ],
+    message: 'Pickable conflict for "filesystem".',
+  },
+];
+
+const PICKABLE_CONTEXT7: readonly PickableConflict[] = [
+  {
+    serverName: 'context7',
+    candidates: [
+      {
+        agentId: 'claude-code',
+        displayName: 'claude-code',
+        server: UPSTASH_CONTEXT7_STDIO,
+      },
+      {
+        agentId: 'opencode',
+        displayName: 'opencode',
+        server: CONTEXT7_REMOTE,
+      },
+    ],
+    message: 'Pickable conflict for "context7".',
+  },
+];
+
+const MIXED_HARD_REFUSE: readonly HardRefuseConflict[] = [
+  {
+    reason: 'mixed-transport-types',
+    serverName: 'shared',
+    agentId: null,
+    displayName: null,
+    message:
+      'Cannot classify server "shared" because agents disagree on transport type (remote, stdio).',
+  },
+];
+
+const PARSE_ERROR_REFUSE: readonly HardRefuseConflict[] = [
+  {
+    reason: 'parse-error',
+    serverName: null,
+    agentId: 'claude-code',
+    displayName: 'claude-code',
+    message: 'parse-error from claude-code',
+  },
+];
+
+const NO_READABLE_AGENTS_BLOCKER: readonly BootstrapBlocker[] = [
+  { reason: 'no-readable-agents' },
+];
+
+function planWithFilesystemPickable(): BootstrapPlan {
+  return buildBootstrapPlan({
+    scanOutput: scanOutput({
+      agents: [
+        agentSnapshot('claude-code', 'read-ok'),
+        agentSnapshot('opencode', 'read-ok'),
+      ],
+      rows: [
+        row({
+          agentId: 'claude-code',
+          serverName: 'filesystem',
+          server: HOME_FILESYSTEM_STDIO,
+        }),
+        row({
+          agentId: 'opencode',
+          serverName: 'filesystem',
+          server: PNPM_FILESYSTEM_STDIO,
+        }),
+      ],
+      conflicts: { pickable: PICKABLE_FILESYSTEM, hardRefuses: [] },
+    }),
+    configPath: '/tmp/overture.jsonc',
+  });
+}
+
+function planWithTwoPickables(): BootstrapPlan {
+  return buildBootstrapPlan({
+    scanOutput: scanOutput({
+      agents: [
+        agentSnapshot('claude-code', 'read-ok'),
+        agentSnapshot('opencode', 'read-ok'),
+      ],
+      rows: [
+        row({
+          agentId: 'claude-code',
+          serverName: 'filesystem',
+          server: HOME_FILESYSTEM_STDIO,
+        }),
+        row({
+          agentId: 'opencode',
+          serverName: 'filesystem',
+          server: PNPM_FILESYSTEM_STDIO,
+        }),
+        row({
+          agentId: 'claude-code',
+          serverName: 'context7',
+          server: UPSTASH_CONTEXT7_STDIO,
+        }),
+        row({
+          agentId: 'opencode',
+          serverName: 'context7',
+          server: CONTEXT7_REMOTE,
+        }),
+      ],
+      conflicts: {
+        pickable: [...PICKABLE_FILESYSTEM, ...PICKABLE_CONTEXT7],
+        hardRefuses: [],
+      },
+    }),
+    configPath: '/tmp/overture.jsonc',
+  });
+}
+
+function planWithHardRefuse(): BootstrapPlan {
+  return buildBootstrapPlan({
+    scanOutput: scanOutput({
+      agents: [
+        agentSnapshot('claude-code', 'read-ok'),
+        agentSnapshot('opencode', 'read-ok'),
+      ],
+      rows: [
+        row({
+          agentId: 'claude-code',
+          serverName: 'filesystem',
+          server: HOME_FILESYSTEM_STDIO,
+        }),
+        row({
+          agentId: 'opencode',
+          serverName: 'filesystem',
+          server: PNPM_FILESYSTEM_STDIO,
+        }),
+      ],
+      conflicts: {
+        pickable: PICKABLE_FILESYSTEM,
+        hardRefuses: MIXED_HARD_REFUSE,
+      },
+    }),
+    configPath: '/tmp/overture.jsonc',
+  });
+}
+
+function planWithBlocker(): BootstrapPlan {
+  const baseProposal: BootstrapProposal = {
+    status: 'blocked',
+    configPath: '/tmp/overture.jsonc',
+    config: {
+      $schema: SCHEMA_URL_TEST,
+      version: 1,
+      settings: {
+        defaultProfile: 'default',
+        dryRunByDefault: true,
+        backupBeforeWrite: true,
+        conflictPolicy: 'refuse',
+      },
+      profiles: {
+        default: {
+          mcpServers: {},
+          sync: { targets: [], disabledServers: [] },
+          skills: [],
+        },
+      },
+    },
+    adoptedServers: [],
+    targetAgents: [],
+  };
+  return {
+    proposal: baseProposal,
+    conflicts: { pickable: [], hardRefuses: [] },
+    blockers: NO_READABLE_AGENTS_BLOCKER,
+  };
+}
+
+function snapshotConfig(plan: BootstrapPlan): BootstrapProposal['config'] {
+  return JSON.parse(
+    JSON.stringify(plan.proposal.config),
+  ) as BootstrapProposal['config'];
+}
+
+describe('applyInteractiveResolutions', () => {
+  it('puts the selected candidate server in proposal.config.profiles.default.mcpServers', () => {
+    const plan = planWithFilesystemPickable();
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+    ];
+
+    const result: InteractiveResolutionResult = applyInteractiveResolutions(
+      plan,
+      decisions,
+    );
+
+    const filesystemEntry: OvertureMcpServer | undefined =
+      result.plan.proposal.config.profiles.default.mcpServers.filesystem;
+    expect(filesystemEntry).toEqual(HOME_FILESYSTEM_STDIO);
+    expect(result.plan.proposal.config.profiles.default.mcpServers).toEqual({
+      filesystem: HOME_FILESYSTEM_STDIO,
+    });
+
+    expect(result.resolvedConflicts).toEqual([
+      {
+        serverName: 'filesystem',
+        agentId: 'claude-code',
+        displayName: 'claude-code',
+      },
+    ]);
+    expect(result.skippedConflicts).toEqual([]);
+    expect(result.aborted).toBe(false);
+  });
+
+  it('uses the second candidate when candidateIndex 1 is selected (context7)', () => {
+    const plan = planWithTwoPickables();
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'context7', candidateIndex: 1 },
+    ];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    const context7Entry =
+      result.plan.proposal.config.profiles.default.mcpServers.context7;
+    expect(context7Entry).toBeDefined();
+    expect(context7Entry).toEqual(CONTEXT7_REMOTE);
+    if (context7Entry?.type !== 'remote') {
+      throw new Error('expected remote context7 entry');
+    }
+    expect(context7Entry.url).toBe('https://mcp.context7.com/mcp');
+    expect(context7Entry.headers).toEqual({});
+
+    expect(result.resolvedConflicts).toEqual([
+      {
+        serverName: 'context7',
+        agentId: 'opencode',
+        displayName: 'opencode',
+      },
+    ]);
+
+    const adopted = result.plan.proposal.adoptedServers.find(
+      (entry) => entry.name === 'context7',
+    );
+    expect(adopted).toEqual({
+      name: 'context7',
+      source: 'selected-conflict',
+      agentIds: ['opencode'],
+    });
+  });
+
+  it('uses the second candidate for filesystem (selected-conflict + stdio shape)', () => {
+    const plan = planWithFilesystemPickable();
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 1 },
+    ];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    const filesystemEntry =
+      result.plan.proposal.config.profiles.default.mcpServers.filesystem;
+    expect(filesystemEntry).toEqual(PNPM_FILESYSTEM_STDIO);
+    if (filesystemEntry?.type !== 'stdio') {
+      throw new Error('expected stdio filesystem entry');
+    }
+    expect(filesystemEntry.command).toBe('pnpm');
+    expect(filesystemEntry.args).toEqual([
+      'dlx',
+      '@modelcontextprotocol/server-filesystem',
+      '/home',
+    ]);
+    expect(filesystemEntry.env).toEqual({});
+  });
+
+  it('records adopted server with source: selected-conflict and agentIds = [candidate.agentId]', () => {
+    const plan = planWithFilesystemPickable();
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+    ];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    const adopted = result.plan.proposal.adoptedServers.find(
+      (entry) => entry.name === 'filesystem',
+    );
+    expect(adopted).toEqual({
+      name: 'filesystem',
+      source: 'selected-conflict',
+      agentIds: ['claude-code'],
+    });
+  });
+
+  it('skipped pickable is absent from mcpServers, adoptedServers, and recorded in skippedConflicts', () => {
+    const plan = planWithFilesystemPickable();
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'skipped', serverName: 'filesystem' },
+    ];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    expect(
+      result.plan.proposal.config.profiles.default.mcpServers,
+    ).not.toHaveProperty('filesystem');
+    expect(
+      result.plan.proposal.adoptedServers.find(
+        (entry) => entry.name === 'filesystem',
+      ),
+    ).toBeUndefined();
+    expect(result.skippedConflicts).toEqual(['filesystem']);
+    expect(result.resolvedConflicts).toEqual([]);
+  });
+
+  it('all-decisions-given plan with no hard refuses/blockers becomes status: ready', () => {
+    const plan = planWithTwoPickables();
+    expect(plan.proposal.status).toBe('blocked');
+
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+      { kind: 'selected', serverName: 'context7', candidateIndex: 0 },
+    ];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    expect(result.plan.proposal.status).toBe('ready');
+    expect(result.plan.conflicts.pickable).toEqual([]);
+    expect(result.plan.conflicts.hardRefuses).toEqual([]);
+    expect(result.plan.blockers).toEqual([]);
+  });
+
+  it('all-skipped plan with no hard refuses/blockers also becomes status: ready', () => {
+    const plan = planWithTwoPickables();
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'skipped', serverName: 'filesystem' },
+      { kind: 'skipped', serverName: 'context7' },
+    ];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    expect(result.plan.proposal.status).toBe('ready');
+    expect(result.skippedConflicts).toEqual(['context7', 'filesystem']);
+    expect(result.resolvedConflicts).toEqual([]);
+  });
+
+  it('hard refuses pass through unchanged and keep status: blocked even when decisions are supplied', () => {
+    const plan = planWithHardRefuse();
+    expect(plan.proposal.status).toBe('blocked');
+
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+    ];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    expect(result.plan.conflicts.hardRefuses).toEqual(MIXED_HARD_REFUSE);
+    expect(result.plan.proposal.status).toBe('blocked');
+
+    const filesystemEntry =
+      result.plan.proposal.config.profiles.default.mcpServers.filesystem;
+    expect(filesystemEntry).toEqual(HOME_FILESYSTEM_STDIO);
+  });
+
+  it('blockers pass through unchanged', () => {
+    const plan = planWithBlocker();
+    const decisions: readonly InteractiveResolution[] = [];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    expect(result.plan.blockers).toEqual(NO_READABLE_AGENTS_BLOCKER);
+    expect(result.plan.proposal.status).toBe('blocked');
+  });
+
+  it('parse-error hard refuses pass through even when no pickable decisions are given', () => {
+    const plan = buildBootstrapPlan({
+      scanOutput: scanOutput({
+        agents: [agentSnapshot('claude-code', 'parse-error')],
+        rows: [],
+        conflicts: { pickable: [], hardRefuses: PARSE_ERROR_REFUSE },
+      }),
+      configPath: '/tmp/overture.jsonc',
+    });
+
+    const result = applyInteractiveResolutions(plan, []);
+
+    expect(result.plan.conflicts.hardRefuses).toEqual(PARSE_ERROR_REFUSE);
+    expect(result.plan.proposal.status).toBe('blocked');
+  });
+
+  it("kind: 'abort' returns the original plan with aborted: true and no config mutation", () => {
+    const plan = planWithFilesystemPickable();
+    const planConfigBefore = snapshotConfig(plan);
+    const planAdoptedBefore = JSON.parse(
+      JSON.stringify(plan.proposal.adoptedServers),
+    );
+    const planConflictsBefore = JSON.parse(JSON.stringify(plan.conflicts));
+
+    const decisions: readonly InteractiveResolution[] = [{ kind: 'abort' }];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    expect(result.aborted).toBe(true);
+    expect(result.resolvedConflicts).toEqual([]);
+    expect(result.skippedConflicts).toEqual([]);
+    expect(result.plan).toBe(plan);
+    expect(snapshotConfig(result.plan)).toEqual(planConfigBefore);
+    expect(
+      JSON.parse(JSON.stringify(result.plan.proposal.adoptedServers)),
+    ).toEqual(planAdoptedBefore);
+    expect(JSON.parse(JSON.stringify(result.plan.conflicts))).toEqual(
+      planConflictsBefore,
+    );
+  });
+
+  it("kind: 'abort' short-circuits even when other decisions are supplied", () => {
+    const plan = planWithTwoPickables();
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+      { kind: 'abort' },
+      { kind: 'selected', serverName: 'context7', candidateIndex: 0 },
+    ];
+
+    const result = applyInteractiveResolutions(plan, decisions);
+
+    expect(result.aborted).toBe(true);
+    expect(result.plan).toBe(plan);
+  });
+
+  it('out-of-range candidateIndex throws', () => {
+    const plan = planWithFilesystemPickable();
+
+    expect(() =>
+      applyInteractiveResolutions(plan, [
+        { kind: 'selected', serverName: 'filesystem', candidateIndex: 2 },
+      ]),
+    ).toThrow(/candidateIndex 2 is out of range/);
+
+    expect(() =>
+      applyInteractiveResolutions(plan, [
+        { kind: 'selected', serverName: 'filesystem', candidateIndex: -1 },
+      ]),
+    ).toThrow(/candidateIndex -1 is out of range/);
+  });
+
+  it('unknown serverName throws', () => {
+    const plan = planWithFilesystemPickable();
+
+    expect(() =>
+      applyInteractiveResolutions(plan, [
+        { kind: 'selected', serverName: 'does-not-exist', candidateIndex: 0 },
+      ]),
+    ).toThrow(/unknown serverName "does-not-exist"/);
+
+    expect(() =>
+      applyInteractiveResolutions(plan, [
+        { kind: 'skipped', serverName: 'does-not-exist' },
+      ]),
+    ).toThrow(/unknown serverName "does-not-exist"/);
+  });
+
+  it('duplicate serverName decisions throw deterministically (first duplicate wins)', () => {
+    const plan = planWithTwoPickables();
+
+    expect(() =>
+      applyInteractiveResolutions(plan, [
+        { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+        { kind: 'skipped', serverName: 'filesystem' },
+      ]),
+    ).toThrow(/duplicate decision for pickable serverName "filesystem"/);
+
+    expect(() =>
+      applyInteractiveResolutions(plan, [
+        { kind: 'skipped', serverName: 'context7' },
+        { kind: 'selected', serverName: 'context7', candidateIndex: 0 },
+      ]),
+    ).toThrow(/duplicate decision for pickable serverName "context7"/);
+  });
+
+  it('does not mutate the input plan or its proposal config', () => {
+    const plan = planWithTwoPickables();
+    const inputSnapshot = {
+      config: snapshotConfig(plan),
+      adoptedServers: JSON.parse(JSON.stringify(plan.proposal.adoptedServers)),
+      pickable: JSON.parse(JSON.stringify(plan.conflicts.pickable)),
+      hardRefuses: JSON.parse(JSON.stringify(plan.conflicts.hardRefuses)),
+      blockers: JSON.parse(JSON.stringify(plan.blockers)),
+      status: plan.proposal.status,
+    };
+
+    const decisions: readonly InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+      { kind: 'skipped', serverName: 'context7' },
+    ];
+
+    applyInteractiveResolutions(plan, decisions);
+
+    expect(snapshotConfig(plan)).toEqual(inputSnapshot.config);
+    expect(JSON.parse(JSON.stringify(plan.proposal.adoptedServers))).toEqual(
+      inputSnapshot.adoptedServers,
+    );
+    expect(JSON.parse(JSON.stringify(plan.conflicts.pickable))).toEqual(
+      inputSnapshot.pickable,
+    );
+    expect(JSON.parse(JSON.stringify(plan.conflicts.hardRefuses))).toEqual(
+      inputSnapshot.hardRefuses,
+    );
+    expect(JSON.parse(JSON.stringify(plan.blockers))).toEqual(
+      inputSnapshot.blockers,
+    );
+    expect(plan.proposal.status).toBe(inputSnapshot.status);
+  });
+
+  it('does not mutate the input decisions array', () => {
+    const plan = planWithTwoPickables();
+    const decisions: InteractiveResolution[] = [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+      { kind: 'skipped', serverName: 'context7' },
+    ];
+    const originalDecisionsJson = JSON.parse(JSON.stringify(decisions));
+
+    applyInteractiveResolutions(plan, decisions);
+
+    expect(JSON.parse(JSON.stringify(decisions))).toEqual(
+      originalDecisionsJson,
+    );
+  });
+
+  it('selected conflict does not overwrite a non-pickable adopted server with the same name', () => {
+    const plan = planWithFilesystemPickable();
+
+    // Sanity: filesystem is NOT in adoptedServers initially (it's a pickable).
+    const initialAdopted = plan.proposal.adoptedServers.find(
+      (entry) => entry.name === 'filesystem',
+    );
+    expect(initialAdopted).toBeUndefined();
+
+    const result = applyInteractiveResolutions(plan, [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+    ]);
+
+    const adopted = result.plan.proposal.adoptedServers.find(
+      (entry) => entry.name === 'filesystem',
+    );
+    expect(adopted).toEqual({
+      name: 'filesystem',
+      source: 'selected-conflict',
+      agentIds: ['claude-code'],
+    });
+  });
+
+  it('preserves existing adopted servers when adding a selected conflict', () => {
+    const plan = buildBootstrapPlan({
+      scanOutput: scanOutput({
+        agents: [
+          agentSnapshot('claude-code', 'read-ok'),
+          agentSnapshot('opencode', 'read-ok'),
+        ],
+        rows: [
+          row({
+            agentId: 'claude-code',
+            serverName: 'alpha',
+            server: { type: 'stdio', command: 'alpha-cli', args: [] },
+          }),
+          row({
+            agentId: 'claude-code',
+            serverName: 'filesystem',
+            server: HOME_FILESYSTEM_STDIO,
+          }),
+          row({
+            agentId: 'opencode',
+            serverName: 'filesystem',
+            server: PNPM_FILESYSTEM_STDIO,
+          }),
+        ],
+        conflicts: { pickable: PICKABLE_FILESYSTEM, hardRefuses: [] },
+      }),
+      configPath: '/tmp/overture.jsonc',
+    });
+
+    expect(plan.proposal.adoptedServers.map((entry) => entry.name)).toEqual([
+      'alpha',
+    ]);
+
+    const result = applyInteractiveResolutions(plan, [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 0 },
+    ]);
+
+    expect(
+      result.plan.proposal.adoptedServers.map((entry) => entry.name),
+    ).toEqual(['alpha', 'filesystem']);
+    expect(
+      result.plan.proposal.adoptedServers.find(
+        (entry) => entry.name === 'alpha',
+      )?.source,
+    ).toBe('single-agent');
+    expect(
+      result.plan.proposal.adoptedServers.find(
+        (entry) => entry.name === 'filesystem',
+      )?.source,
+    ).toBe('selected-conflict');
+  });
+
+  it('selected conflict uses the chosen candidate headers (remote shape preserved)', () => {
+    const bearerRemote: OvertureMcpServer = remoteServer(
+      'https://api.example.com/v1',
+      { Authorization: 'Bearer secret' },
+    );
+    const plan = buildBootstrapPlan({
+      scanOutput: scanOutput({
+        agents: [
+          agentSnapshot('claude-code', 'read-ok'),
+          agentSnapshot('opencode', 'read-ok'),
+        ],
+        rows: [
+          row({
+            agentId: 'claude-code',
+            serverName: 'remote-server',
+            server: bearerRemote,
+          }),
+          row({
+            agentId: 'opencode',
+            serverName: 'remote-server',
+            server: remoteServer('https://api.example.com/v1'),
+          }),
+        ],
+        conflicts: {
+          pickable: [
+            {
+              serverName: 'remote-server',
+              candidates: [
+                {
+                  agentId: 'claude-code',
+                  displayName: 'claude-code',
+                  server: bearerRemote,
+                },
+                {
+                  agentId: 'opencode',
+                  displayName: 'opencode',
+                  server: remoteServer('https://api.example.com/v1'),
+                },
+              ],
+              message: 'Pickable conflict for "remote-server".',
+            },
+          ],
+          hardRefuses: [],
+        },
+      }),
+      configPath: '/tmp/overture.jsonc',
+    });
+
+    const result = applyInteractiveResolutions(plan, [
+      { kind: 'selected', serverName: 'remote-server', candidateIndex: 0 },
+    ]);
+
+    const entry =
+      result.plan.proposal.config.profiles.default.mcpServers['remote-server'];
+    expect(entry).toBeDefined();
+    if (entry?.type !== 'remote') {
+      throw new Error('expected remote entry');
+    }
+    expect(entry.url).toBe('https://api.example.com/v1');
+    expect(entry.headers).toEqual({ Authorization: 'Bearer secret' });
+  });
+
+  it('selected conflict stores the candidate server (not the conflict fingerprint)', () => {
+    const plan = planWithFilesystemPickable();
+
+    const result = applyInteractiveResolutions(plan, [
+      { kind: 'selected', serverName: 'filesystem', candidateIndex: 1 },
+    ]);
+
+    const entry =
+      result.plan.proposal.config.profiles.default.mcpServers.filesystem;
+    expect(entry).toEqual(PNPM_FILESYSTEM_STDIO);
+    if (entry?.type !== 'stdio') {
+      throw new Error('expected stdio entry');
+    }
+    // Verify the FULL normalized server (not redacted) is stored.
+    expect(entry.command).toBe('pnpm');
+    expect(entry.args).toEqual([
+      'dlx',
+      '@modelcontextprotocol/server-filesystem',
+      '/home',
+    ]);
+  });
+});
+
+describe('buildBootstrapPlan (D2 baseline characterization)', () => {
+  it('pickables block proposal status without any resolution applied', () => {
+    const plan = planWithFilesystemPickable();
+
+    expect(plan.proposal.status).toBe('blocked');
+    expect(plan.proposal.config.profiles.default.mcpServers).not.toHaveProperty(
+      'filesystem',
+    );
+    expect(
+      plan.proposal.adoptedServers.find((entry) => entry.name === 'filesystem'),
+    ).toBeUndefined();
+  });
+
+  it('SCHEMA_URL matches the bootstrap module constant (consistency check)', () => {
+    expect(SCHEMA_URL).toBe(SCHEMA_URL_TEST);
+  });
+});

--- a/apps/cli/src/bootstrap-resolution.ts
+++ b/apps/cli/src/bootstrap-resolution.ts
@@ -1,0 +1,243 @@
+import type { OvertureMcpServer } from '@overture/config';
+
+import type {
+  BootstrapAdoptedServer,
+  BootstrapPlan,
+  BootstrapProposal,
+} from './bootstrap.js';
+
+/**
+ * D2 Wave 1 - One interactive resolution decision supplied by the prompt
+ * adapter (Wave 2). Decisions are passed in as a readonly array; this module
+ * never reads from stdin or any other I/O source.
+ *
+ * - `selected`: pick candidate N (0-based) of the pickable conflict named
+ *   `serverName`.
+ * - `skipped`: drop the pickable conflict named `serverName` from the
+ *   proposal.
+ * - `abort`: short-circuit. The original plan is returned unchanged with
+ *   `aborted: true`.
+ */
+export type InteractiveResolution =
+  | {
+      readonly kind: 'selected';
+      readonly serverName: string;
+      readonly candidateIndex: number;
+    }
+  | { readonly kind: 'skipped'; readonly serverName: string }
+  | { readonly kind: 'abort' };
+
+/**
+ * Per-server summary of a selected pickable. The `agentId` and `displayName`
+ * reflect the candidate the user picked, not the union of candidates.
+ */
+export interface ResolvedConflictSummary {
+  readonly serverName: string;
+  readonly agentId: string;
+  readonly displayName: string;
+}
+
+/**
+ * D2 Wave 1 - Pure resolution result. `plan` is a deep clone of the input
+ * plan with the decisions applied: selected pickables are folded into the
+ * proposal config and adopted servers, skipped pickables are removed from
+ * the proposal and recorded in `skippedConflicts`. `aborted: true` means
+ * the caller supplied a `kind: 'abort'` decision and the input plan is
+ * returned unchanged (no clone is required).
+ */
+export interface InteractiveResolutionResult {
+  readonly plan: BootstrapPlan;
+  readonly resolvedConflicts: readonly ResolvedConflictSummary[];
+  readonly skippedConflicts: readonly string[];
+  readonly aborted: boolean;
+}
+
+/**
+ * D2 Wave 1 - Apply a list of per-conflict decisions to a `BootstrapPlan`.
+ *
+ * Pure: no I/O, no fs, no readline, no `process.exit`, no `process.stdin`.
+ *
+ * Mutation: the input `plan`, the input `decisions`, and any nested object
+ * reachable from them are not modified. The returned `plan` is a fresh
+ * object graph constructed from cloned input slices.
+ *
+ * Status semantics:
+ *   - `kind: 'abort'` short-circuits and returns the input plan with
+ *     `aborted: true` and no other state mutated.
+ *   - Otherwise, the new `proposal.status` is `'ready'` iff there are no
+ *     hard refuses, no blockers, and no remaining (un-decided) pickables.
+ *   - Hard refuses and blockers are passed through untouched.
+ *
+ * Validation (throws `Error` with a descriptive message):
+ *   - Unknown `serverName` (not in `plan.conflicts.pickable`).
+ *   - Out-of-range `candidateIndex` for a `selected` decision.
+ *   - Duplicate `serverName` across decisions (the first duplicate
+ *     encountered in `decisions` order throws).
+ */
+export function applyInteractiveResolutions(
+  plan: BootstrapPlan,
+  decisions: readonly InteractiveResolution[],
+): InteractiveResolutionResult {
+  if (decisions.some((decision) => decision.kind === 'abort')) {
+    return {
+      plan,
+      resolvedConflicts: [],
+      skippedConflicts: [],
+      aborted: true,
+    };
+  }
+
+  const pickableByServer = new Map<
+    string,
+    BootstrapPlan['conflicts']['pickable'][number]
+  >();
+  for (const conflict of plan.conflicts.pickable) {
+    pickableByServer.set(conflict.serverName, conflict);
+  }
+
+  const seenServerNames = new Set<string>();
+  const appliedSelections: {
+    readonly serverName: string;
+    readonly candidateIndex: number;
+    readonly candidate: BootstrapPlan['conflicts']['pickable'][number]['candidates'][number];
+  }[] = [];
+  const appliedSkips: string[] = [];
+
+  for (const decision of decisions) {
+    if (decision.kind === 'abort') {
+      // unreachable: handled above, but satisfies the discriminated narrowing.
+      continue;
+    }
+    if (seenServerNames.has(decision.serverName)) {
+      throw new Error(
+        `applyInteractiveResolutions: duplicate decision for pickable serverName "${decision.serverName}". Each pickable may be resolved at most once.`,
+      );
+    }
+    const conflict = pickableByServer.get(decision.serverName);
+    if (conflict === undefined) {
+      throw new Error(
+        `applyInteractiveResolutions: unknown serverName "${decision.serverName}". Decisions may only reference names listed in plan.conflicts.pickable.`,
+      );
+    }
+    if (decision.kind === 'skipped') {
+      seenServerNames.add(decision.serverName);
+      appliedSkips.push(decision.serverName);
+      continue;
+    }
+    const { candidateIndex, serverName } = decision;
+    if (
+      !Number.isInteger(candidateIndex) ||
+      candidateIndex < 0 ||
+      candidateIndex >= conflict.candidates.length
+    ) {
+      throw new Error(
+        `applyInteractiveResolutions: candidateIndex ${candidateIndex} is out of range for serverName "${serverName}" (candidates: ${conflict.candidates.length}).`,
+      );
+    }
+    const candidate = conflict.candidates[candidateIndex];
+    if (candidate === undefined) {
+      // Defensive: the bounds check above guarantees this is unreachable.
+      throw new Error(
+        `applyInteractiveResolutions: candidate at index ${candidateIndex} is missing for serverName "${serverName}".`,
+      );
+    }
+    seenServerNames.add(serverName);
+    appliedSelections.push({ serverName, candidateIndex, candidate });
+  }
+
+  const resolvedConflicts: ResolvedConflictSummary[] = appliedSelections
+    .map(({ serverName, candidate }) => ({
+      serverName,
+      agentId: candidate.agentId,
+      displayName: candidate.displayName,
+    }))
+    .sort((left, right) => left.serverName.localeCompare(right.serverName));
+
+  const skippedConflicts: string[] = [...appliedSkips].sort((left, right) =>
+    left.localeCompare(right),
+  );
+
+  const existingMcpServers: Record<string, OvertureMcpServer> = {
+    ...plan.proposal.config.profiles.default.mcpServers,
+  };
+  const newMcpServers: Record<string, OvertureMcpServer> = {
+    ...existingMcpServers,
+  };
+  for (const selection of appliedSelections) {
+    newMcpServers[selection.serverName] = cloneMcpServer(
+      selection.candidate.server,
+    );
+  }
+
+  const selectedAdoptions: BootstrapAdoptedServer[] = appliedSelections
+    .map(
+      ({ serverName, candidate }): BootstrapAdoptedServer => ({
+        name: serverName,
+        source: 'selected-conflict',
+        agentIds: [candidate.agentId],
+      }),
+    )
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const existingAdopted = [...plan.proposal.adoptedServers];
+  const mergedAdopted = [...existingAdopted, ...selectedAdoptions].sort(
+    (left, right) => left.name.localeCompare(right.name),
+  );
+
+  const remainingPickable = plan.conflicts.pickable.filter(
+    (conflict) => !seenServerNames.has(conflict.serverName),
+  );
+
+  const newStatus: BootstrapProposal['status'] =
+    plan.conflicts.hardRefuses.length === 0 &&
+    plan.blockers.length === 0 &&
+    remainingPickable.length === 0
+      ? 'ready'
+      : 'blocked';
+
+  const newPlan: BootstrapPlan = {
+    proposal: {
+      ...plan.proposal,
+      status: newStatus,
+      config: {
+        ...plan.proposal.config,
+        profiles: {
+          ...plan.proposal.config.profiles,
+          default: {
+            ...plan.proposal.config.profiles.default,
+            mcpServers: newMcpServers,
+          },
+        },
+      },
+      adoptedServers: mergedAdopted,
+    },
+    conflicts: {
+      pickable: remainingPickable,
+      hardRefuses: plan.conflicts.hardRefuses,
+    },
+    blockers: plan.blockers,
+  };
+
+  return {
+    plan: newPlan,
+    resolvedConflicts,
+    skippedConflicts,
+    aborted: false,
+  };
+}
+
+function cloneMcpServer(server: OvertureMcpServer): OvertureMcpServer {
+  if (server.type === 'stdio') {
+    return {
+      type: 'stdio',
+      command: server.command,
+      args: server.args === undefined ? undefined : [...server.args],
+      env: server.env === undefined ? undefined : { ...server.env },
+    };
+  }
+  return {
+    type: 'remote',
+    url: server.url,
+    headers: server.headers === undefined ? undefined : { ...server.headers },
+  };
+}

--- a/apps/cli/src/bootstrap.ts
+++ b/apps/cli/src/bootstrap.ts
@@ -22,7 +22,7 @@ const DEFAULT_SETTINGS = {
 
 export interface BootstrapAdoptedServer {
   readonly name: string;
-  readonly source: 'single-agent' | 'all-agents-equal';
+  readonly source: 'single-agent' | 'all-agents-equal' | 'selected-conflict';
   readonly agentIds: readonly string[];
 }
 

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -277,6 +277,9 @@ Approval gate: prompt UX and skip semantics.
 
 Expected result: interactive selection behavior covered by tests.
 
+D2 implementation merged in this PR (2026-06-23).
+QY|
+
 ### D3. Bootstrap write
 
 Write the canonical `overture.jsonc` after the plan is conflict-free or all


### PR DESCRIPTION
## D2: Interactive bootstrap conflict prompt

D2 of the bootstrap pipeline. The no-flag `overture bootstrap` path now
walks pickable MCP conflicts one at a time and applies the chosen
candidate or `skip` in memory, then prints a read-only summary.

Hard refuses, blockers, and existing canonical config still short-circuit
the prompt loop and emit the dry-run proposal / one-time message.

Non-TTY invocations with pickables exit 2 with a hint to re-run with
`--dry-run`. Aborts (`q` / EOF / SIGINT / too many invalid answers) also
exit 2.

**No filesystem writes happen during D2.** D3 will own the actual write step.

### What this PR adds

- `apps/cli/src/bootstrap-resolution.ts` — pure `applyInteractiveResolutions`
  helper. Returns a structural clone of the plan with selected pickables
  folded into the proposal config + adopted servers; skipped pickables
  removed from the proposal and recorded in `skippedConflicts`. Aborts
  return the input plan unchanged.
- `apps/cli/src/bootstrap-prompt.ts` — pure `formatPickablePrompt` +
  `parsePickableAnswer` + injectable readline adapter. `createStdinPrompt`
  lazy-loads `node:readline/promises` via `createRequire` so the readline
  bundle stays out of unit tests. No third-party prompt dependency.
- `apps/cli/src/bootstrap-command.ts` — D2 interactive dispatcher with
  TTY / existing-config / blocker / no-write guards. The D1 reserved
  no-flag path is removed.
- `apps/cli/src/bootstrap-human.ts` — `formatHumanInteractiveResult`
  sibling renderer for the final read-only summary.
- `apps/cli/src/bootstrap-command.spec.ts` + `bootstrap-human.interactive.spec.ts` +
  `bootstrap-prompt.spec.ts` + `bootstrap-resolution.spec.ts` — full UX
  coverage (select / skip / re-ask invalid / abort / non-TTY / hard refuses
  / blockers / existing config / no-flag ready).
- `apps/cli/scripts/verify-package.mjs` — no-flag bootstrap smoke check
  (exit 1, proposal heading present, no reserved message, no leaks,
  no write).
- `README.md` + `apps/cli/README.md` + `docs/overture-implementation-slices.md`
  updated for D2.

### Exit code matrix

| Exit | Meaning |
| ---- | ------- |
| `0`  | `--help`; `--dry-run [--json]` proposal status `ready`; no-flag interactive run with no hard refuses/blockers remaining. |
| `1`  | Dry-run proposal emitted but status `blocked` (pickables / hard refuses / no readable agents / existing valid config); OR no-flag interactive run whose plan is still blocked. |
| `2`  | Usage error (unknown flag); invalid flag combination (`--json` without `--dry-run`); invalid/parse-error existing canonical config; non-TTY no-flag run with pickables; user abort during the interactive prompt; unexpected pre-model failure. |

### Scope fidelity guarantees

- No write to `~/.config/overture/overture.jsonc`, agent config files,
  state cache (`~/.local/state/overture/`), or proposal cache.
- No `conflictPolicy` flag. No `--yes` / `--force` / `--no-input` flag.
- No `inquirer` / `prompts` / `enquirer` dependency.
- No `any`, `@ts-ignore`, or `@ts-expect-error`.
- No raw `env` / `headers` / full URLs / `$schema` / `matrix` / `agentServer`
  / `canonicalServer` in human output (asserted in tests and in
  `verify-package.mjs`).
- No `.codegraph/` or evidence files staged.

### Quality gates

- `yarn nx test @jander99/overture --skip-nx-cache` → 211/211 PASS
- `yarn nx build @jander99/overture --skip-nx-cache` → PASS
- `yarn prettier --check` (all D2 paths) → PASS
- `node apps/cli/scripts/verify-package.mjs` → PASS
  (`bootstrap (no flags): exit=1 proposalHeading=PASS noReserved=PASS noLeak=PASS noWrite=PASS`)

### Next slice

D3 will add the actual write step that consumes the resolved plan from D2
and produces the canonical `~/.config/overture/overture.jsonc`.
