### PR TITLE
feat(cli): write canonical config from bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 `overture` is a CLI utility that scans your machine for MCP-capable LLM coding
 platforms and reports the state of each platform's MCP server configuration.
-
 The currently-shipped commands are `overture detect` (read-only inventory),
 `overture config show` (print the resolved user-level `overture.jsonc`), and
-`overture bootstrap` (read-only bootstrap preview). No command writes, syncs,
-or modifies any configuration file.
-
-## Install
+`overture bootstrap` (one-time setup: writes the canonical `overture.jsonc`
+on success when run without flags). `overture detect`, `overture config
+show`, and `overture bootstrap --dry-run [--json]` never write or modify
+any file.
 
 `overture` is published to npm as `@jander99/overture`.
 
@@ -235,44 +234,52 @@ no `generatedAt`, no `duration`):
 
 ## The `bootstrap` command
 
-`overture bootstrap` is a **read-only** preview of the canonical user-level
-`overture.jsonc` config that a future bootstrap write step (Track D3, not yet
-implemented) would produce from the agents' current MCP server inventories.
+`overture bootstrap` is a **one-time setup** command: it produces the
+canonical user-level `overture.jsonc` config from the agents' current MCP
+server inventories and writes it to the resolved XDG path on success.
 
 D1 is the **planner** phase of bootstrap. D2 is the **interactive conflict
-prompt** phase: it walks the user through pickable conflicts one at a time,
-applies the chosen candidate or `skip` in memory, and prints a read-only
-summary. D2 still writes no files. D3 will add the actual write step.
+prompt** phase: it walks the user through pickable conflicts one at a time
+and applies the chosen candidate or `skip` in memory. D3 adds the
+**write** phase: when the no-flag interactive run completes with no hard
+refuses/blockers remaining, it writes the canonical `overture.jsonc`.
 
 ### Usage
 
 ```bash
-# D2 interactive read-only: walk pickable conflicts one at a time, then print
-# a read-only summary. Does NOT write any file. D3 will own the write step.
+# D3 one-time setup: walks pickable conflicts one at a time, then writes the
+# canonical `overture.jsonc` to the resolved XDG path on success. Prints
+# `Wrote config: <absolute path>` on stdout. Does NOT modify any agent config.
 overture bootstrap
 
-# Non-interactive human-readable preview of the proposed canonical config
+# Non-interactive human-readable preview of the proposed canonical config.
+# Does NOT write any file.
 overture bootstrap --dry-run
 
-# Machine-readable: full proposal + conflicts + blockers
+# Machine-readable: full proposal + conflicts + blockers. Does NOT write.
 overture bootstrap --dry-run --json
 
 # Print usage and exit 0
 overture bootstrap --help
 ```
 
-The no-flag `overture bootstrap` is the D2 read-only interactive prompt. It
-walks the user through pickable conflicts one at a time, applies the chosen
-candidate or `skip`, and prints a read-only summary. It does NOT write any
-file. Use `overture bootstrap --dry-run` for a non-interactive preview. The
-no-flag path exits `2` when stdin is not a TTY (hint: `Run overture bootstrap
---dry-run for a non-interactive preview.`).
+The no-flag `overture bootstrap` is the D3 one-time setup. It walks the user
+through pickable conflicts one at a time, applies the chosen candidate or
+`skip`, and on success writes the canonical `overture.jsonc` to the
+resolved XDG path, printing `Wrote config: <absolute path>` on stdout. Use
+`overture bootstrap --dry-run` for a non-interactive preview that does NOT
+write any file. The no-flag path exits `2` when stdin is not a TTY (hint:
+`Run overture bootstrap --dry-run for a non-interactive preview.`).
 
 ### Default summary shape
 
-The no-`--json` path emits a plain-text, sectioned preview:
+The no-`--json` paths emit plain-text, sectioned previews. The no-flag
+interactive run writes the canonical `overture.jsonc` and prints
+`Wrote config: <absolute path>` on stdout; the `--dry-run` path emits the
+preview only and does NOT write any file.
 
-- `Bootstrap proposal (dry-run)` (heading)
+- `Bootstrap proposal (dry-run)` (heading) — `--dry-run` only
+- `Bootstrap proposal` (heading) — no-flag interactive run
 - `Config path:` — the resolved XDG `overture.jsonc` path
 - `Proposal status:` — `ready` or `blocked`
 - `Target agents:` — comma-separated agent ids
@@ -280,7 +287,8 @@ The no-`--json` path emits a plain-text, sectioned preview:
 - `Pickable conflicts:` — count + bullet per pickable conflict
 - `Hard refuses:` — count + bullet per hard refuse
 - `Blockers:` — count + bullet per blocker (e.g. `no-readable-agents`)
-- Footer: `No files were written.` and `Run "overture bootstrap --dry-run --json" for machine-readable details.`
+- Footer (no-flag, success): `Wrote config: <absolute path>`
+- Footer (`--dry-run`): `No files were written.` and `Run "overture bootstrap --dry-run --json" for machine-readable details.`
 
 No ANSI color is emitted; the output is plain text suitable for piping.
 Server details (env, headers, args) are never rendered; only redacted
@@ -317,12 +325,14 @@ fingerprints.
 
 | Exit code | Meaning                                                                                                                                                                                                                                                                                                                          |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `0`       | `--help`, `--dry-run [--json]` proposal status `ready`, or no-flag interactive run with no hard refuses/blockers remaining.                                                                                                                                                                                                      |
+| `0`       | `--help`; `--dry-run [--json]` proposal status `ready`; or no-flag interactive run with no hard refuses/blockers remaining (writes the canonical config).                                                                                                                                                                        |
 | `1`       | Dry-run proposal emitted but status `blocked` (pickables, hard refuses, no readable agents, or existing valid config), OR no-flag interactive run whose plan is still blocked (hard refuses / blockers).                                                                                                                         |
 | `2`       | Usage error (unknown flag), invalid flag combination (`--json` without `--dry-run`), invalid/parse-error existing canonical config, non-TTY no-flag run with at least one pickable conflict (suggests rerunning with `overture bootstrap --dry-run`), user abort during the interactive prompt, or unexpected pre-model failure. |
 
-`bootstrap` will not write to or modify any of the files it inspects, and it
-makes no writes anywhere. D2 still writes no files; D3 will own the write step.
+`bootstrap --dry-run` will not write to or modify any of the files it
+inspects, and it makes no writes anywhere. D3 writes the canonical config on
+success;
+D4/E/F are future work.
 
 ## Repository layout
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -28,10 +28,11 @@ npx @jander99/overture@latest --help
 - `overture detect --json` — full 4-platform inventory with all additive
   fields.
 - `overture config show` — print the resolved user-level `overture.jsonc`.
-- `overture bootstrap` (no flag, D2 interactive read-only) — walk pickable
+- `overture bootstrap` (no flag, D3 one-time setup) — walk pickable
   conflicts one at a time, apply the chosen candidate or `skip` in memory,
-  and print a read-only summary. Does NOT write any file. Exits `2` when
-  stdin is not a TTY. D3 (future write step) will own the actual write.
+  write the canonical `overture.jsonc` to the resolved XDG path on success,
+  and print `Wrote config: <path>`. Does NOT modify any agent config. Exits
+  `2` when stdin is not a TTY.
 - `overture bootstrap --dry-run [--json]` — preview the canonical bootstrap
   proposal without writing any files.
 - `overture detect --help` / `overture --help` — print usage and exit 0.

--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -19,8 +19,10 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  chmodSync,
   writeFileSync,
 } from 'node:fs';
+
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -304,8 +306,15 @@ const bootstrapAgentConfigBefore = `{
 }`;
 writeFileSync(bootstrapAgentConfig, bootstrapAgentConfigBefore);
 const bootstrapAgentBeforeStat = statSync(bootstrapAgentConfig);
+// Seed a fake opencode binary on the bootstrap PATH so the CLI marks
+// the opencode agent as installed and can read its config (otherwise
+// the plan is blocked by 'no-readable-agents').
+const bootstrapOpencodeBin = join(bootstrapPath, 'opencode');
+writeFileSync(bootstrapOpencodeBin, '#!/bin/sh\nexit 0\n');
+chmodSync(bootstrapOpencodeBin, 0o755);
 
 const bootstrapBin = [distMain];
+
 const bootstrapJsonResult = spawnWithEnv(
   [...bootstrapBin, 'bootstrap', '--dry-run', '--json'],
   bootstrapEnv,
@@ -416,9 +425,9 @@ const bootstrapInteractiveResult = spawnWithEnv(
   [...bootstrapBin, 'bootstrap'],
   bootstrapEnv,
 );
-if (bootstrapInteractiveResult.status !== 1) {
+if (bootstrapInteractiveResult.status !== 0) {
   fail(
-    `bootstrap (no flags) exited ${bootstrapInteractiveResult.status} (expected 1): stderr:\n${bootstrapInteractiveResult.stderr}\nstdout:\n${bootstrapInteractiveResult.stdout}`,
+    `bootstrap (no flags) exited ${bootstrapInteractiveResult.status} (expected 0): stderr:\n${bootstrapInteractiveResult.stderr}\nstdout:\n${bootstrapInteractiveResult.stdout}`,
   );
 }
 if (!bootstrapInteractiveResult.stdout.includes('Bootstrap proposal')) {
@@ -426,20 +435,56 @@ if (!bootstrapInteractiveResult.stdout.includes('Bootstrap proposal')) {
     `bootstrap (no flags) stdout missing "Bootstrap proposal" heading\nstdout:\n${bootstrapInteractiveResult.stdout}`,
   );
 }
-const forbiddenStderrFragments = [
+const bootstrapWroteFragment = `Wrote config: ${bootstrapPaths.configFile}`;
+if (!bootstrapInteractiveResult.stdout.includes(bootstrapWroteFragment)) {
+  fail(
+    `bootstrap (no flags) stdout missing "${bootstrapWroteFragment}"\nstdout:\n${bootstrapInteractiveResult.stdout}`,
+  );
+}
+if (!statSync(bootstrapPaths.configFile, { throwIfNoEntry: false })) {
+  fail(
+    `bootstrap (no flags) expected to write ${bootstrapPaths.configFile}, but it was not created`,
+  );
+}
+// The writer emits JSONC with `//` comments. Use the CJS jsonc-parser
+// via createRequire (the ESM build has broken relative imports).
+import { createRequire } from 'node:module';
+const requireVerify = createRequire(import.meta.url);
+const { parse: parseJsoncVerify } = requireVerify('jsonc-parser');
+const bootstrapWrittenConfig = parseJsoncVerify(
+  readFileSync(bootstrapPaths.configFile, 'utf8'),
+  [],
+  { allowTrailingComma: true, disallowComments: false },
+);
+
+if (
+  typeof bootstrapWrittenConfig.version !== 'number' ||
+  typeof bootstrapWrittenConfig.settings !== 'object' ||
+  bootstrapWrittenConfig.settings === null ||
+  typeof bootstrapWrittenConfig.profiles !== 'object' ||
+  bootstrapWrittenConfig.profiles === null ||
+  typeof bootstrapWrittenConfig.profiles.default !== 'object' ||
+  bootstrapWrittenConfig.profiles.default === null ||
+  typeof bootstrapWrittenConfig.profiles.default.mcpServers !== 'object' ||
+  bootstrapWrittenConfig.profiles.default.mcpServers === null
+) {
+  fail(
+    `bootstrap (no flags) wrote config missing required keys (version, settings, profiles.default.mcpServers)\nconfig:\n${JSON.stringify(bootstrapWrittenConfig, null, 2)}`,
+  );
+}
+const reservedStderrFragments = [
   'BOOTSTRAP_RESERVED_MESSAGE',
   'Bootstrap writes are not implemented yet',
 ];
-const leakedStderrFragments = forbiddenStderrFragments.filter((fragment) =>
-  bootstrapInteractiveResult.stderr.includes(fragment),
+const leakedReservedStderrFragments = reservedStderrFragments.filter(
+  (fragment) => bootstrapInteractiveResult.stderr.includes(fragment),
 );
-if (leakedStderrFragments.length > 0) {
+if (leakedReservedStderrFragments.length > 0) {
   fail(
-    `bootstrap (no flags) stderr contains forbidden fragments: ${leakedStderrFragments.join(', ')}\nstderr:\n${bootstrapInteractiveResult.stderr}`,
+    `bootstrap (no flags) stderr contains reserved fragments: ${leakedReservedStderrFragments.join(', ')}\nstderr:\n${bootstrapInteractiveResult.stderr}`,
   );
 }
 const forbiddenStdoutFragments = [
-  'Pickable conflict:',
   'api_key=',
   'Bearer ',
   '$schema',
@@ -455,11 +500,6 @@ if (leakedStdoutFragments.length > 0) {
     `bootstrap (no flags) stdout contains forbidden fragments: ${leakedStdoutFragments.join(', ')}\nstdout:\n${bootstrapInteractiveResult.stdout}`,
   );
 }
-if (statSync(bootstrapPaths.configFile, { throwIfNoEntry: false })) {
-  fail(
-    `bootstrap (no flags) unexpectedly created ${bootstrapPaths.configFile}`,
-  );
-}
 const bootstrapAgentAfterStat = statSync(bootstrapAgentConfig);
 if (
   bootstrapAgentAfterStat.size !== bootstrapAgentBeforeStat.size ||
@@ -470,7 +510,7 @@ if (
   );
 }
 console.log(
-  `bootstrap (no flags): exit=${bootstrapInteractiveResult.status} proposalHeading=PASS noReserved=PASS noLeak=PASS noWrite=PASS`,
+  `bootstrap (no flags): exit=${bootstrapInteractiveResult.status} proposalHeading=PASS wroteConfig=PASS noReserved=PASS noLeak=PASS agentUntouched=PASS`,
 );
 
 const bootstrapHelpResult = spawnWithEnv(

--- a/apps/cli/src/bootstrap-command.spec.ts
+++ b/apps/cli/src/bootstrap-command.spec.ts
@@ -11,8 +11,10 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-
-import { defaultOverturePaths } from '@overture/config';
+// Deep import mirrors `packages/config/src/loader.ts`: the package root
+// re-exports through a UMD wrapper that uses relative `require()` calls.
+import { parse as parseJsonc } from 'jsonc-parser/lib/esm/main.js';
+import { defaultOverturePaths, parseOvertureConfig } from '@overture/config';
 
 import {
   BOOTSTRAP_USAGE,
@@ -381,7 +383,7 @@ describe('D2 interactive', () => {
     });
   }
 
-  it('renders a dry-run proposal without prompting when args are empty and no conflicts exist', async () => {
+  it('writes the canonical config and prints the success footer when no-flag bootstrap has no pickables', async () => {
     const { home, xdgConfigHome, pathDir, cleanup, env } =
       createBootstrapTempEnv();
     cleanupDirs = cleanup;
@@ -399,14 +401,65 @@ describe('D2 interactive', () => {
       prompt,
     });
 
+    const paths = defaultOverturePaths(env);
     expect(code).toBe(0);
     expect(stderr.text()).toBe('');
     expect(prompt).not.toHaveBeenCalled();
-    expect(stdout.text()).toContain('Bootstrap proposal (dry-run)');
     expect(stdout.text()).toContain('Proposal status: ready');
     expect(stdout.text()).toContain('Pickable conflicts: 0');
-    expect(stdout.text()).toContain('No files were written.');
-    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    expect(stdout.text()).toContain(`Wrote config: ${paths.configFile}`);
+    expect(stdout.text()).not.toContain('No files were written.');
+    expect(existsSync(paths.configFile)).toBe(true);
+    const written = readFileSync(paths.configFile, 'utf8');
+    // Parse the JSONC body (writer emits // comments) with jsonc-parser,
+    // then validate the parsed shape with parseOvertureConfig.
+    const jsoncErrors: import('jsonc-parser/lib/esm/main.js').ParseError[] = [];
+    const writtenParsed: unknown = parseJsonc(written, jsoncErrors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    });
+    expect(jsoncErrors).toEqual([]);
+    const validated = parseOvertureConfig(writtenParsed);
+    expect(validated.version).toBe(1);
+    expect(validated.profiles.default.mcpServers.filesystem?.type).toBe(
+      'stdio',
+    );
+
+    expect(readFileSync(agentConfigPath, 'utf8')).toBe(agentBefore);
+    expect(statSync(agentConfigPath).size).toBe(beforeStat.size);
+    expect(statSync(agentConfigPath).mtimeMs).toBe(beforeStat.mtimeMs);
+  });
+
+  it('returns exit 2 and does not write the config when the write step fails', async () => {
+    const { home, xdgConfigHome, pathDir, cleanup, env } =
+      createBootstrapTempEnv();
+    cleanupDirs = cleanup;
+    useBootstrapEnv({ home, xdgConfigHome, pathDir });
+    seedFakeOpencodeBin(pathDir);
+    const agentConfigPath = seedBootstrapAgentConfig(xdgConfigHome);
+    const agentBefore = readFileSync(agentConfigPath, 'utf8');
+    const beforeStat = statSync(agentConfigPath);
+    const prompt = queuedPrompt(['1']);
+
+    // Pre-create a directory at the final config path so the writer's
+    // rename must fail (EISDIR). The CLI must surface a clear failure
+    // message on stderr, NOT claim success on stdout, and leave the
+    // pre-existing directory in place.
+    const paths = defaultOverturePaths(env);
+    mkdirSync(paths.configFile, { recursive: true });
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runBootstrap([], stdout, stderr, {
+      isTTY: true,
+      prompt,
+    });
+
+    expect(code).toBe(2);
+    expect(stderr.text()).toMatch(/Failed to write overture config/);
+    expect(stdout.text()).not.toContain('Wrote config:');
+    expect(stdout.text()).not.toContain('No files were written.');
+    expect(statSync(paths.configFile).isDirectory()).toBe(true);
     expect(readFileSync(agentConfigPath, 'utf8')).toBe(agentBefore);
     expect(statSync(agentConfigPath).size).toBe(beforeStat.size);
     expect(statSync(agentConfigPath).mtimeMs).toBe(beforeStat.mtimeMs);
@@ -447,7 +500,21 @@ describe('D2 interactive', () => {
     expect(stdout.text()).toContain('Skipped conflicts: 0');
     expect(stdout.text()).toContain('selected-conflict');
     expect(stdout.text()).toContain('filesystem: Claude Code (claude-code)');
-    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    const paths = defaultOverturePaths(env);
+    expect(existsSync(paths.configFile)).toBe(true);
+    expect(stdout.text()).toContain(`Wrote config: ${paths.configFile}`);
+    expect(stdout.text()).not.toContain('No files were written.');
+    const written = readFileSync(paths.configFile, 'utf8');
+    const jsoncErrors: import('jsonc-parser/lib/esm/main.js').ParseError[] = [];
+    const writtenParsed: unknown = parseJsonc(written, jsoncErrors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    });
+    expect(jsoncErrors).toEqual([]);
+    const validated = parseOvertureConfig(writtenParsed);
+    expect(validated.profiles.default.mcpServers.filesystem?.type).toBe(
+      'stdio',
+    );
     expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
     expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
     expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);
@@ -491,7 +558,22 @@ describe('D2 interactive', () => {
     expect(stdout.text()).toContain('Resolved conflicts: 1');
     expect(stdout.text()).toContain('Skipped conflicts: 1');
     expect(stdout.text()).toContain('selected-conflict');
-    expect(existsSync(defaultOverturePaths(env).configFile)).toBe(false);
+    const paths = defaultOverturePaths(env);
+    expect(existsSync(paths.configFile)).toBe(true);
+    expect(stdout.text()).toContain(`Wrote config: ${paths.configFile}`);
+    expect(stdout.text()).not.toContain('No files were written.');
+    const written = readFileSync(paths.configFile, 'utf8');
+    const jsoncErrors: import('jsonc-parser/lib/esm/main.js').ParseError[] = [];
+    const writtenParsed: unknown = parseJsonc(written, jsoncErrors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    });
+    expect(jsoncErrors).toEqual([]);
+    const validated = parseOvertureConfig(writtenParsed);
+    expect(validated.profiles.default.mcpServers).toHaveProperty('filesystem');
+    expect(validated.profiles.default.mcpServers).not.toHaveProperty(
+      'context7',
+    );
     expect(readFileSync(opencodeConfigPath, 'utf8')).toBe(opencodeBefore);
     expect(readFileSync(claudeConfigPath, 'utf8')).toBe(claudeBefore);
     expect(statSync(opencodeConfigPath).size).toBe(opencodeStat.size);

--- a/apps/cli/src/bootstrap-command.ts
+++ b/apps/cli/src/bootstrap-command.ts
@@ -1,7 +1,12 @@
+import { statSync } from 'node:fs';
 import {
   defaultOverturePaths,
   loadOvertureConfig,
   type OvertureConfig,
+  type OverturePaths,
+  writeOvertureConfig,
+  InvalidOvertureConfigError,
+  OvertureConfigWriteError,
 } from '@overture/config';
 
 import { defaultPathResolutionContext } from './platforms/detect.js';
@@ -26,12 +31,8 @@ import type { StringWriter } from './scan-command.js';
 
 export const BOOTSTRAP_USAGE = 'Usage: overture bootstrap --dry-run [--json]\n';
 
-// D2 - the no-flag path is now an interactive read-only dispatch.
-// This constant remains exported so the bootstrap-command spec (which task 5
-// will rewrite) can keep referencing the historical message while it is
-// phased out.
-export const BOOTSTRAP_RESERVED_MESSAGE =
-  'Bootstrap writes are not implemented yet. Run "overture bootstrap --dry-run" to preview the proposal.\n';
+const BOOTSTRAP_WROTE_FOOTER = (path: string): string =>
+  `Wrote config: ${path}\n`;
 
 const BOOTSTRAP_INVALID_COMBINATION_MESSAGE =
   'Invalid flag combination: --json requires --dry-run.\n';
@@ -91,11 +92,17 @@ export async function runBootstrap(
 
   const paths = defaultOverturePaths();
   let config: OvertureConfig | null;
-  try {
-    config = await loadOvertureConfig(paths);
-  } catch (err) {
-    stderr.write(`${messageForError(err)}\n`);
-    return 2;
+  // Treat a directory at the canonical config path as "no config yet" so
+  // bootstrap can proceed and the writer can attempt (and surface EISDIR).
+  if (isDirectoryAt(paths.configFile)) {
+    config = null;
+  } else {
+    try {
+      config = await loadOvertureConfig(paths);
+    } catch (err) {
+      stderr.write(`${messageForError(err)}\n`);
+      return 2;
+    }
   }
 
   if (config !== null) {
@@ -120,7 +127,7 @@ export async function runBootstrap(
   });
 
   if (!hasDryRun) {
-    return runBootstrapInteractive(stdout, stderr, plan, options);
+    return runBootstrapInteractive(stdout, stderr, plan, paths, options);
   }
 
   if (!hasJson) {
@@ -147,22 +154,25 @@ function runBootstrapHuman(stdout: StringWriter, plan: BootstrapPlan): 0 | 1 {
 }
 
 /**
- * D2 - Interactive read-only dispatch for the no-flag path.
+ * D3 - Interactive dispatch for the no-flag path. Writes the canonical
+ * `overture.jsonc` on success when the plan is ready.
  *
- * Decision tree (matches the D2 plan exactly):
+ * Decision tree (matches the D3 plan exactly):
  *   1. hard refuses OR blockers -> print proposal and return 1; never prompt.
  *   2. pickables AND non-TTY -> print TTY hint to stderr and return 2.
  *   3. pickables AND TTY     -> prompt each conflict in order, collect
- *      decisions, apply them in-memory, print interactive summary, return
- *      1 if the resulting plan is still blocked, else 0.
- *   4. otherwise (no conflicts of any kind) -> print proposal, return 0.
+ *      decisions, apply them in-memory, write the config if the resulting
+ *      plan is ready, return 1 if still blocked, else 0.
+ *   4. otherwise (no conflicts of any kind) -> write the config, return 0.
  *
- * No filesystem writes happen here.
+ * Writes only `overture.jsonc` via `writeOvertureConfig`; never touches
+ * any agent config.
  */
 async function runBootstrapInteractive(
   stdout: StringWriter,
   stderr: StringWriter,
   plan: BootstrapPlan,
+  paths: OverturePaths,
   options: RunBootstrapOptions,
 ): Promise<number> {
   if (plan.conflicts.hardRefuses.length > 0 || plan.blockers.length > 0) {
@@ -171,7 +181,20 @@ async function runBootstrapInteractive(
   }
 
   if (plan.conflicts.pickable.length === 0) {
-    stdout.write(formatHumanBootstrapProposal(plan));
+    stdout.write(formatHumanBootstrapProposal(plan, { footer: 'wrote' }));
+    try {
+      await writeOvertureConfig({ paths, config: plan.proposal.config });
+    } catch (err) {
+      if (
+        err instanceof InvalidOvertureConfigError ||
+        err instanceof OvertureConfigWriteError
+      ) {
+        stderr.write(`${err.message}\n`);
+        return 2;
+      }
+      throw err;
+    }
+    stdout.write(BOOTSTRAP_WROTE_FOOTER(paths.configFile));
     return 0;
   }
 
@@ -233,10 +256,44 @@ async function runBootstrapInteractive(
     return 2;
   }
 
+  if (result.plan.proposal.status === 'ready') {
+    stdout.write(formatHumanInteractiveResult(result, { footer: 'wrote' }));
+    try {
+      await writeOvertureConfig({ paths, config: result.plan.proposal.config });
+    } catch (err) {
+      if (
+        err instanceof InvalidOvertureConfigError ||
+        err instanceof OvertureConfigWriteError
+      ) {
+        stderr.write(`${err.message}\n`);
+        return 2;
+      }
+      throw err;
+    }
+    stdout.write(BOOTSTRAP_WROTE_FOOTER(paths.configFile));
+    return 0;
+  }
+
   stdout.write(formatHumanInteractiveResult(result));
-  return result.plan.proposal.status === 'blocked' ? 1 : 0;
+  return 1;
 }
 
 function messageForError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function isDirectoryAt(targetPath: string): boolean {
+  try {
+    return statSync(targetPath).isDirectory();
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      typeof err.code === 'string' &&
+      err.code === 'ENOENT'
+    ) {
+      return false;
+    }
+    throw err;
+  }
 }

--- a/apps/cli/src/bootstrap-human.ts
+++ b/apps/cli/src/bootstrap-human.ts
@@ -6,8 +6,16 @@ import type { InteractiveResolutionResult } from './bootstrap-resolution.js';
 type PickableConflictList = BootstrapPlan['conflicts']['pickable'];
 type HardRefuseConflictList = BootstrapPlan['conflicts']['hardRefuses'];
 
-export function formatHumanBootstrapProposal(plan: BootstrapPlan): string {
-  const lines: string[] = ['Bootstrap proposal (dry-run)'];
+export type ProposalFooterKind = 'dry-run' | 'wrote';
+
+export function formatHumanBootstrapProposal(
+  plan: BootstrapPlan,
+  options?: { readonly footer?: ProposalFooterKind },
+): string {
+  const isWrote = options?.footer === 'wrote';
+  const lines: string[] = [
+    isWrote ? 'Bootstrap proposal' : 'Bootstrap proposal (dry-run)',
+  ];
 
   lines.push(`Config path: ${plan.proposal.configPath}`);
   lines.push(`Proposal status: ${plan.proposal.status}`);
@@ -48,15 +56,17 @@ export function formatHumanBootstrapProposal(plan: BootstrapPlan): string {
     lines.push(`  - ${renderBlocker(blocker)}`);
   }
 
-  lines.push('No files were written.');
-  lines.push(
-    'Run "overture bootstrap --dry-run --json" for machine-readable details.',
-  );
+  if (!isWrote) {
+    lines.push('No files were written.');
+    lines.push(
+      'Run "overture bootstrap --dry-run --json" for machine-readable details.',
+    );
+  }
   return `${lines.join('\n')}\n`;
 }
 
 /**
- * D2 - Render the final read-only interactive summary. A sibling renderer to
+ * D3 - Render the final interactive summary. A sibling renderer to
  * `formatHumanBootstrapProposal`: the dry-run path emits the full proposal
  * (config preview, target agents, pickable candidate fingerprints), while
  * this interactive path emits a tighter summary that surfaces only the
@@ -66,17 +76,23 @@ export function formatHumanBootstrapProposal(plan: BootstrapPlan): string {
  * Section ordering (fixed):
  *   heading, config path, status, adopted servers, pickable conflicts,
  *   hard refuses, blockers, resolved conflicts, skipped conflicts,
- *   no-files footer.
+ *   footer (suppressed when options.footer === 'wrote').
  *
  * Deterministic, plain-text, no ANSI. URL-bearing messages from hard
  * refuses are redacted via `redactMessageUrls`. No raw env/headers/full
  * URLs/`$schema`/`matrix`/`agentServer`/`canonicalServer` is ever emitted.
- * No files are written; the footer reflects that explicitly.
+ * The no-write footer is emitted unless `options.footer === 'wrote'`;
+ * when suppressed, the caller emits `Wrote config: <path>` after a
+ * successful write.
  */
 export function formatHumanInteractiveResult(
   result: InteractiveResolutionResult,
+  options?: { readonly footer?: ProposalFooterKind },
 ): string {
-  const lines: string[] = ['Bootstrap proposal (interactive)'];
+  const isWrote = options?.footer === 'wrote';
+  const lines: string[] = [
+    isWrote ? 'Bootstrap proposal' : 'Bootstrap proposal (interactive)',
+  ];
 
   lines.push(`Config path: ${result.plan.proposal.configPath}`);
   lines.push(`Proposal status: ${result.plan.proposal.status}`);
@@ -116,7 +132,9 @@ export function formatHumanInteractiveResult(
     lines.push(`  - ${name}`);
   }
 
-  lines.push('No files were written.');
+  if (!isWrote) {
+    lines.push('No files were written.');
+  }
 
   return `${lines.join('\n')}\n`;
 }

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -288,6 +288,8 @@ pickable conflicts have been resolved/skipped.
 Expected result: bootstrap writes only the overture config file. It does not
 modify any agent config.
 
+**Status: completed on feat/d3-bootstrap-write.**
+
 ## Track E: write safety
 
 These slices must precede real apply behavior.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,8 +2,9 @@
  * Public @overture/config surface.
  *
  * Exports the Zod schema for `overture.jsonc`, the XDG path resolver for
- * the user-level config, and a small loader that reads + parses + validates
- * the config file at the resolved path.
+ * the user-level config, a small loader that reads + parses + validates
+ * the config file at the resolved path, and a writer that atomically
+ * creates the canonical `overture.jsonc` with generated comments.
  *
  * Supported platforms: Linux (native + WSL1 + WSL2) and macOS. Both use
  * the same XDG layout — `${XDG_CONFIG_HOME:-~/.config}/overture/...`.
@@ -12,3 +13,4 @@
 export * from './schema.js';
 export * from './paths.js';
 export * from './loader.js';
+export * from './writer.js';

--- a/packages/config/src/writer.spec.ts
+++ b/packages/config/src/writer.spec.ts
@@ -1,0 +1,325 @@
+/**
+ * Test plan for the safe JSONC writer in `writer.ts`. We follow the same
+ * style as `loader.spec.ts`: real `mkdtempSync` directories, no `vi.mock`
+ * of `node:fs/promises`, and direct filesystem assertions.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { tmpdir } from 'node:os';
+// Deep import: the package root re-exports through a UMD wrapper that breaks
+// in CJS bundles. Mirrors the pattern in `loader.ts` and the repo AGENTS.md.
+import { parse as parseJsonc } from 'jsonc-parser/lib/esm/main.js';
+
+import { defaultOverturePaths } from './paths.js';
+import {
+  OvertureConfigSchema,
+  parseOvertureConfig,
+  type OvertureConfig,
+} from './schema.js';
+import {
+  InvalidOvertureConfigError,
+  renderOvertureConfigJsonc,
+  writeOvertureConfig,
+} from './writer.js';
+
+/**
+ * A baseline valid OvertureConfig that the writer can render and that the
+ * loader can re-parse. Mirrors the shape bootstrap.ts:189-205 produces.
+ */
+// Use `OvertureConfig` so the literal is mutable and structurally conforms
+// to what the schema expects (e.g. `string[]` not `readonly string[]`).
+// `as const` would be a type error against the schema's `z.string().array()`
+// which produces `string[]` (mutable).
+const baselineConfig: OvertureConfig = {
+  $schema:
+    'https://raw.githubusercontent.com/jander99/overture/main/schemas/overture.config.schema.json',
+  version: 1,
+  settings: {
+    defaultProfile: 'default',
+    dryRunByDefault: true,
+    backupBeforeWrite: true,
+    conflictPolicy: 'refuse',
+  },
+  profiles: {
+    default: {
+      mcpServers: {},
+      sync: { targets: [], disabledServers: [] },
+      skills: [],
+    },
+  },
+};
+
+function withTempDir<T>(fn: (dir: string) => T | Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'overture-writer-'));
+  return Promise.resolve()
+    .then(() => fn(dir))
+    .finally(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+}
+
+function makePaths(dir: string) {
+  return defaultOverturePaths({ platform: 'linux', workspaceDir: dir }, {
+    HOME: dir,
+  } as NodeJS.ProcessEnv);
+}
+
+describe('renderOvertureConfigJsonc', () => {
+  it('returns a string that ends with a single trailing newline', () => {
+    const rendered = renderOvertureConfigJsonc(baselineConfig);
+    expect(rendered.endsWith('\n')).toBe(true);
+    // exactly one trailing newline
+    expect(rendered.endsWith('\n\n')).toBe(false);
+  });
+
+  it('preserves the $schema field at the top of the document', () => {
+    const rendered = renderOvertureConfigJsonc(baselineConfig);
+    expect(rendered).toContain('"$schema"');
+    expect(rendered).toContain(baselineConfig.$schema);
+  });
+
+  it('embeds generated explanatory comments for mcpServers, disabledServers, and skills', () => {
+    const rendered = renderOvertureConfigJsonc(baselineConfig);
+    // mcpServers and disabledServers explanatory comments
+    expect(rendered).toMatch(/mcpServers/);
+    expect(rendered).toContain('disabledServers');
+    // skills reserved/inert comment
+    expect(rendered).toMatch(/skills/);
+    // The skills comment must include a "reserved" marker, mirroring
+    // docs/overture-config.md line 81: "reserved; inert in v1"
+    expect(rendered).toMatch(/reserved/i);
+  });
+
+  it('is deterministic — two calls produce byte-identical output', () => {
+    const a = renderOvertureConfigJsonc(baselineConfig);
+    const b = renderOvertureConfigJsonc(baselineConfig);
+    expect(a).toBe(b);
+  });
+
+  it('produces output that parses with jsonc-parser and validates against OvertureConfigSchema', () => {
+    const rendered = renderOvertureConfigJsonc(baselineConfig);
+    const errors: import('jsonc-parser/lib/esm/main.js').ParseError[] = [];
+    const parsed: unknown = parseJsonc(rendered, errors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    });
+    expect(errors).toEqual([]);
+    const validated = OvertureConfigSchema.safeParse(parsed);
+    expect(validated.success).toBe(true);
+  });
+});
+
+describe('writeOvertureConfig', () => {
+  it('creates the parent configDir when it does not exist', async () => {
+    await withTempDir(async (dir) => {
+      const paths = makePaths(dir);
+      expect(existsSync(paths.configDir)).toBe(false);
+      await writeOvertureConfig({ paths, config: baselineConfig });
+      expect(existsSync(paths.configDir)).toBe(true);
+      expect(statSync(paths.configDir).isDirectory()).toBe(true);
+    });
+  });
+
+  it('writes the canonical config file at paths.configFile', async () => {
+    await withTempDir(async (dir) => {
+      const paths = makePaths(dir);
+      await writeOvertureConfig({ paths, config: baselineConfig });
+      expect(existsSync(paths.configFile)).toBe(true);
+      const contents = readFileSync(paths.configFile, 'utf8');
+      expect(contents.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('emits generated comments and $schema in the written file', async () => {
+    await withTempDir(async (dir) => {
+      const paths = makePaths(dir);
+      await writeOvertureConfig({ paths, config: baselineConfig });
+      const contents = readFileSync(paths.configFile, 'utf8');
+      expect(contents).toContain('"$schema"');
+      expect(contents).toContain(baselineConfig.$schema);
+      // explanatory comment for the mcpServers key
+      expect(contents).toMatch(/mcpServers/);
+    });
+  });
+
+  it('produces a file whose parsed contents pass parseOvertureConfig', async () => {
+    await withTempDir(async (dir) => {
+      const paths = makePaths(dir);
+      await writeOvertureConfig({ paths, config: baselineConfig });
+      const contents = readFileSync(paths.configFile, 'utf8');
+      const errors: import('jsonc-parser/lib/esm/main.js').ParseError[] = [];
+      const parsed: unknown = parseJsonc(contents, errors, {
+        allowTrailingComma: true,
+        disallowComments: false,
+      });
+      expect(errors).toEqual([]);
+      const validated = parseOvertureConfig(parsed);
+      expect(validated.version).toBe(1);
+    });
+  });
+
+  it('refuses invalid input with InvalidOvertureConfigError and creates no final file', async () => {
+    await withTempDir(async (dir) => {
+      const paths = makePaths(dir);
+      const invalid = {
+        $schema: 'https://example/x.json',
+        version: 1,
+        // missing required `profiles`
+      };
+      let caught: unknown;
+      try {
+        await writeOvertureConfig({
+          paths,
+          // Cast to a value the signature accepts; the writer must still
+          // catch the validation failure and reject.
+          config: invalid as never,
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(InvalidOvertureConfigError);
+      const message = (caught as Error).message;
+      expect(message.toLowerCase()).toContain('config');
+      // No final file written.
+      expect(existsSync(paths.configFile)).toBe(false);
+      // No config dir created on validation failure (we never start I/O).
+      expect(existsSync(paths.configDir)).toBe(false);
+    });
+  });
+
+  it('cleans up the current temp file when the rename fails and creates no final file', async () => {
+    await withTempDir(async (dir) => {
+      const paths = makePaths(dir);
+      // Pre-create a directory at the final configFile path so the
+      // temp-file rename must fail (EISDIR/ENOTDIR). The writer must:
+      //  1. leave the pre-existing directory in place (we did not own it),
+      //  2. unlink its own temp file,
+      //  3. surface a typed error with the original cause preserved.
+      mkdirSync(paths.configFile, { recursive: true });
+      const configDirBefore = readdirSync(paths.configDir);
+      const tempsBefore = configDirBefore.filter((name) =>
+        name.endsWith('.tmp'),
+      );
+      expect(tempsBefore).toEqual([]);
+
+      let caught: unknown;
+      try {
+        await writeOvertureConfig({ paths, config: baselineConfig });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const err = caught as Error & { cause?: unknown };
+      // The cause should be the original filesystem error, not a swallowed
+      // null/undefined. We do not require a specific error class here; the
+      // contract is "preserve the original cause" which is observable as a
+      // non-empty .cause on the wrapper error.
+      expect(err.cause).toBeDefined();
+      // The pre-existing directory must still be there.
+      expect(existsSync(paths.configFile)).toBe(true);
+      expect(statSync(paths.configFile).isDirectory()).toBe(true);
+      // No temp files left behind in configDir from this write.
+      const configDirAfter = readdirSync(paths.configDir);
+      const tempsAfter = configDirAfter.filter((name) => name.endsWith('.tmp'));
+      expect(tempsAfter).toEqual([]);
+    });
+  });
+
+  it('does not touch any file outside paths.configDir', async () => {
+    await withTempDir(async (dir) => {
+      // Snapshot the temp dir before the write. The writer may only add
+      // the new configDir subtree (`.config/overture/...`); no files may be
+      // created or removed at the top level.
+      const paths = makePaths(dir);
+      const topLevelBefore = readdirSync(dir);
+      await writeOvertureConfig({ paths, config: baselineConfig });
+      const topLevelAfter = readdirSync(dir);
+      const added = topLevelAfter.filter(
+        (name) => !topLevelBefore.includes(name),
+      );
+      // The only added top-level entry should be the first segment of the
+      // configDir path relative to the temp dir (e.g. `.config`). Nothing else.
+      const rel = relative(dir, paths.configDir);
+      const expectedFirstSegment = rel.split(sep)[0];
+      expect(added).toEqual([expectedFirstSegment]);
+    });
+  });
+
+  it('round-trips a richer config (mcpServers + sync targets + skills)', async () => {
+    await withTempDir(async (dir) => {
+      const paths = makePaths(dir);
+      const rich: OvertureConfig = {
+        $schema:
+          'https://raw.githubusercontent.com/jander99/overture/main/schemas/overture.config.schema.json',
+        version: 1,
+        settings: {
+          defaultProfile: 'default',
+          dryRunByDefault: true,
+          backupBeforeWrite: true,
+          conflictPolicy: 'refuse',
+        },
+        profiles: {
+          default: {
+            mcpServers: {
+              filesystem: {
+                type: 'stdio',
+                command: 'npx',
+                args: [
+                  '-y',
+                  '@modelcontextprotocol/server-filesystem',
+                  '/home',
+                ],
+              },
+              context7: {
+                type: 'stdio',
+                command: 'npx',
+                args: ['-y', '@upstash/context7-mcp@latest'],
+                env: { CONTEXT7_API_KEY: '${CONTEXT7_API_KEY}' },
+              },
+            },
+            sync: {
+              targets: ['claude-code', 'opencode'],
+              disabledServers: ['filesystem'],
+            },
+            skills: [
+              {
+                source: 'vercel-labs/agent-skills',
+                include: ['frontend-design', 'skill-creator'],
+              },
+            ],
+          },
+        },
+      };
+      await writeOvertureConfig({ paths, config: rich });
+      const contents = readFileSync(paths.configFile, 'utf8');
+      // The written content should contain a stable marker for every
+      // server name and skill source we passed in.
+      expect(contents).toContain('filesystem');
+      expect(contents).toContain('context7');
+      expect(contents).toContain('vercel-labs/agent-skills');
+      const errors: import('jsonc-parser/lib/esm/main.js').ParseError[] = [];
+      const parsed: unknown = parseJsonc(contents, errors, {
+        allowTrailingComma: true,
+        disallowComments: false,
+      });
+      expect(errors).toEqual([]);
+      const revalidated = parseOvertureConfig(parsed);
+      expect(revalidated.profiles.default.mcpServers.filesystem?.type).toBe(
+        'stdio',
+      );
+      expect(revalidated.profiles.default.sync.targets).toEqual([
+        'claude-code',
+        'opencode',
+      ]);
+    });
+  });
+});

--- a/packages/config/src/writer.ts
+++ b/packages/config/src/writer.ts
@@ -1,0 +1,287 @@
+/**
+ * Safe JSONC writer for the canonical `overture.jsonc`.
+ *
+ * The output is deterministic JSONC (2-space indent, explanatory comments,
+ * trailing newline) that round-trips through `loadOvertureConfig`. The
+ * write primitive uses a same-directory temp file + `rename` to avoid
+ * leaving a partial final file when a write or rename fails.
+ *
+ * The writer is the first place in the repo that *creates* the canonical
+ * config on disk. It deliberately never touches any agent MCP config.
+ */
+import { randomUUID } from 'node:crypto';
+import { mkdir, rename, unlink, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+
+import { OvertureConfigSchema, type OvertureConfig } from './schema.js';
+import type { OverturePaths } from './paths.js';
+
+/**
+ * Inputs to {@link writeOvertureConfig}. The `config` field is intentionally
+ * untyped at the boundary so we can produce a typed Zod error when the
+ * caller passes something that does not match the schema.
+ */
+export interface WriteOvertureConfigInput {
+  readonly paths: OverturePaths;
+  readonly config: unknown;
+}
+
+/**
+ * Thrown when the input to {@link writeOvertureConfig} does not validate
+ * against {@link OvertureConfigSchema}. The error message lists every Zod
+ * issue on its own line so the user can read it directly.
+ *
+ * No filesystem I/O is attempted when this error is thrown — the
+ * validation gate runs before `mkdir`/`writeFile`/`rename`.
+ */
+export class InvalidOvertureConfigError extends Error {
+  public readonly issues: readonly string[];
+
+  public constructor(issues: readonly string[]) {
+    super(`Invalid overture config:\n${issues.join('\n')}`);
+    this.name = 'InvalidOvertureConfigError';
+    this.issues = issues;
+  }
+}
+
+/**
+ * Thrown when the writer's filesystem step fails (mkdir, writeFile, or
+ * rename). The original error is preserved on `.cause` so callers can
+ * inspect the underlying failure (EACCES, EISDIR, ENOSPC, etc.).
+ *
+ * On this error path the writer has already best-effort-unlinked its own
+ * current temp file; pre-existing files outside the writer's temp file
+ * are never touched.
+ */
+export class OvertureConfigWriteError extends Error {
+  public readonly targetPath: string;
+
+  public constructor(
+    targetPath: string,
+    message: string,
+    options: { cause: unknown },
+  ) {
+    super(message, options);
+    this.name = 'OvertureConfigWriteError';
+    this.targetPath = targetPath;
+  }
+}
+
+/**
+ * Pure renderer. Takes a fully-validated `OvertureConfig` and returns a
+ * deterministic JSONC string with 2-space indent, explanatory comments
+ * (top-of-file `$schema`/`version`, settings inline comments, an
+ * `mcpServers` explanatory comment, a `disabledServers` explanatory
+ * comment, and a `skills` reserved/inert comment), and a single trailing
+ * newline.
+ *
+ * No I/O. No side effects. Safe to call from tests.
+ */
+export function renderOvertureConfigJsonc(config: OvertureConfig): string {
+  const lines: string[] = [];
+  lines.push('{');
+
+  // Top-of-file $schema and version. $schema is optional in the schema but
+  // the bootstrap layer always sets it; we render it whenever it is set.
+  if (config.$schema !== undefined) {
+    lines.push(`  "$schema": ${JSON.stringify(config.$schema)},`);
+  }
+  lines.push(`  "version": ${config.version},`);
+  lines.push('');
+
+  // settings: 4 optional keys, each with an inline comment matching
+  // docs/overture-config.md lines 60-63.
+  lines.push('  "settings": {');
+  const settings = config.settings;
+  const settingsLines: string[] = [];
+  if (settings.defaultProfile !== undefined) {
+    settingsLines.push(
+      `    "defaultProfile": ${JSON.stringify(settings.defaultProfile)}, // optional, default "default"`,
+    );
+  }
+  if (settings.dryRunByDefault !== undefined) {
+    settingsLines.push(
+      `    "dryRunByDefault": ${settings.dryRunByDefault}, // optional, default true`,
+    );
+  }
+  if (settings.backupBeforeWrite !== undefined) {
+    settingsLines.push(
+      `    "backupBeforeWrite": ${settings.backupBeforeWrite}, // optional, default true`,
+    );
+  }
+  if (settings.conflictPolicy !== undefined) {
+    settingsLines.push(
+      `    "conflictPolicy": ${JSON.stringify(settings.conflictPolicy)}, // optional: "refuse" | "prompt" | "overwrite"`,
+    );
+  }
+  // The settings block is always emitted (the schema gives it a `{}` default)
+  // but it may be empty when no key is set. Emit an empty body in that case.
+  if (settingsLines.length === 0) {
+    lines.push('');
+  } else {
+    lines.push(...settingsLines);
+  }
+  lines.push('  },');
+  lines.push('');
+
+  // profiles: hand-walk each profile so we can place the mcpServers /
+  // disabledServers / skills explanatory comments in the right place.
+  lines.push('  "profiles": {');
+  const profileNames = Object.keys(config.profiles);
+  profileNames.forEach((profileName, index) => {
+    const profile = config.profiles[profileName];
+    const trailing = index < profileNames.length - 1 ? ',' : '';
+    lines.push(`    ${JSON.stringify(profileName)}: {`);
+
+    // mcpServers: explanatory comment INSIDE the object (matches
+    // docs/overture-config.md line 69). The comment is placed at the top
+    // of the open `{`, before any server entries.
+    lines.push('      "mcpServers": {');
+    lines.push(
+      '        // mcpServers key is canonical (matches Claude Code / OpenCode / etc.)',
+    );
+    const serverEntries = Object.entries(profile.mcpServers);
+    if (serverEntries.length > 0) {
+      // Re-indent the JSON.stringify output (which is at 2-space base)
+      // to nest under the 6-space key. The body lines start at 8 spaces.
+      const mcpJson = JSON.stringify(profile.mcpServers, null, 2);
+      lines.push(reindentJsonBody(mcpJson, '      '));
+    }
+    lines.push('      },');
+    lines.push('');
+
+    // sync: targets first, then disabledServers with its comment.
+    lines.push('      "sync": {');
+    lines.push(`        "targets": ${JSON.stringify(profile.sync.targets)},`);
+    lines.push('');
+    if (profile.sync.disabledServers.length === 0) {
+      lines.push('        "disabledServers": [');
+      lines.push(
+        '          // global exclusions: server names that are never synced anywhere',
+      );
+      lines.push('        ]');
+    } else {
+      lines.push('        "disabledServers": [');
+      lines.push(
+        '          // global exclusions: server names that are never synced anywhere',
+      );
+      const dsJson = JSON.stringify(profile.sync.disabledServers, null, 2);
+      lines.push(reindentJsonBody(dsJson, '        '));
+      lines.push('        ]');
+    }
+    lines.push('      },');
+    lines.push('');
+
+    // skills: reserved/inert comment at the top of the (possibly empty)
+    // array. The comment mirrors docs/overture-config.md line 81.
+    if (profile.skills.length === 0) {
+      lines.push('      "skills": [');
+      lines.push('        // reserved; inert in v1');
+      lines.push('      ]');
+    } else {
+      lines.push('      "skills": [');
+      lines.push('        // reserved; inert in v1');
+      const skillsJson = JSON.stringify(profile.skills, null, 2);
+      lines.push(reindentJsonBody(skillsJson, '      '));
+      lines.push('      ]');
+    }
+
+    lines.push(`    }${trailing}`);
+  });
+  lines.push('  }');
+  lines.push('}');
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Re-indent the inner content of a `JSON.stringify(..., null, 2)` body so it
+ * nests under a parent key. Drops both the opening delimiter (`{` or `[`)
+ * and the matching closing delimiter — the caller emits those. Re-indents
+ * the remaining inner lines with `prefix`.
+ */
+function reindentJsonBody(jsonBody: string, prefix: string): string {
+  const lines = jsonBody.split('\n');
+  if (lines.length < 3) return '';
+  // Skip the first line (opening delimiter) AND the last line (closing delimiter).
+  return lines
+    .slice(1, -1)
+    .map((line) => prefix + line)
+    .join('\n');
+}
+
+/**
+ * Validate, render, and atomically write the canonical `overture.jsonc`
+ * to `paths.configFile`. The write goes through a unique same-directory
+ * temp file (`.<basename>.<pid>.<uuid>.tmp`) and `fs.promises.rename`,
+ * so a failed write or rename never leaves a partial final file.
+ *
+ * On validation failure, throws {@link InvalidOvertureConfigError} and
+ * does not touch the filesystem.
+ * On filesystem failure, throws {@link OvertureConfigWriteError} with
+ * the original error preserved on `.cause`, having best-effort-unlinked
+ * the current temp file.
+ *
+ * Never touches any file outside `paths.configDir`.
+ */
+export async function writeOvertureConfig(
+  input: WriteOvertureConfigInput,
+): Promise<void> {
+  // 1. Validate first, before any I/O.
+  const result = OvertureConfigSchema.safeParse(input.config);
+  if (!result.success) {
+    const issues = result.error.issues.map(
+      (issue) => `  - ${issue.path.join('.') || '(root)'}: ${issue.message}`,
+    );
+    throw new InvalidOvertureConfigError(issues);
+  }
+
+  // 2. Render the deterministic JSONC body.
+  const body = renderOvertureConfigJsonc(result.data);
+
+  // 3. Create the parent config dir.
+  const configDir = input.paths.configDir;
+  const configFile = input.paths.configFile;
+  try {
+    await mkdir(configDir, { recursive: true });
+  } catch (err) {
+    throw new OvertureConfigWriteError(
+      configFile,
+      `Failed to create overture config dir at ${configDir}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err },
+    );
+  }
+
+  // 4. Write to a unique same-directory temp file, then rename. The temp
+  // file name starts with a dot so a stray `ls` on configDir does not
+  // confuse the user; the suffix is process id + uuid for uniqueness even
+  // when several processes race on the same dir.
+  const baseName = basename(configFile);
+  const tempFileName = `.${baseName}.${process.pid}.${randomUUID()}.tmp`;
+  const tempPath = join(configDir, tempFileName);
+
+  try {
+    await writeFile(tempPath, body, 'utf8');
+    await rename(tempPath, configFile);
+  } catch (err) {
+    // Best-effort cleanup of OUR temp file only. Do not unlink anything
+    // else — the pre-existing path at `configFile` (e.g. a directory the
+    // caller left there) is the caller's property.
+    try {
+      await unlink(tempPath);
+    } catch {
+      // If the temp file never existed (e.g. mkdir failure) or was already
+      // unlinked, swallow the cleanup error. The user-facing error is the
+      // original one; the cause is preserved below.
+    }
+    throw new OvertureConfigWriteError(
+      configFile,
+      `Failed to write overture config at ${configFile}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add safe JSONC writer for canonical `overture.jsonc` with temp-file + rename semantics
- wire successful no-flag `overture bootstrap` paths to write the canonical config and report `Wrote config: <path>`
- preserve dry-run/no-write guards and update docs + package smoke for the D3 contract

## Verification
- `yarn nx test @jander99/overture --skip-nx-cache`
- `yarn nx test @overture/config --skip-nx-cache` (41/41, writer 13/13; Nx emitted flaky-task advisory but exit 0)
- `yarn nx build @jander99/overture --skip-nx-cache`
- `npx prettier --check .`
- `node apps/cli/scripts/verify-package.mjs`
- `npx tsc -b apps/cli/tsconfig.json` after clean dist

## Notes
- Bootstrap writes only Overture’s canonical config, never native agent configs.
- Evidence retained locally under `.omo/evidence/d3-bootstrap-write/`.
