### PR TITLE
feat(agents): E1 writer preservation harness

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -76,6 +76,23 @@ export {
 
 export { asRegistryNormalizeHandler } from './normalize-mcp-config.js';
 
+/**
+ * Writer preservation harness — the E1 safety gate every future per-agent
+ * MCP writer (E2 OpenCode, E3 Claude Code + Copilot CLI, E4 remaining) must
+ * pass before it is considered safe. See
+ * `packages/agents/src/writer-preservation/README` (in the doc comment) and
+ * `docs/overture-implementation-slices.md` for the full contract.
+ */
+export {
+  runPreservationChecks,
+  checksForFormat,
+  type PreservationCheckInput,
+  type PreservationCheckName,
+  type PreservationCheckResult,
+  type PreservationReport,
+  type TargetPath,
+} from './writer-preservation/index.js';
+
 import { claudeCode } from './claude-code.js';
 import { opencode } from './opencode.js';
 import { githubCopilotCli } from './github-copilot-cli.js';

--- a/packages/agents/src/writer-preservation/__reference-writers__.ts
+++ b/packages/agents/src/writer-preservation/__reference-writers__.ts
@@ -1,0 +1,124 @@
+/**
+ * Intentionally-broken reference writers used only by
+ * `contract.spec.ts` to prove the harness catches real writer-shaped
+ * regressions. These are NOT production writers — they exist solely
+ * to exercise the harness's individual preservation checks against
+ * code that looks like a real per-agent writer (input → output
+ * transforms) rather than raw byte-mutator outputs.
+ *
+ * File naming uses `__reference-writers__.ts` (double underscore) so
+ * `index.ts` does not re-export these as part of the public surface.
+ */
+import {
+  appendString,
+  deleteMcpServer,
+  deleteTopLevelKey,
+  deleteTrailingNewline,
+  driftIndentation,
+  stripComments,
+  swapTopLevelKeys,
+} from './byte-mutators.js';
+import type { McpLocationFormat } from '../types.js';
+
+/**
+ * Reference writer signature. Takes the original bytes plus the
+ * targetPath the writer is "allowed" to mutate, returns the output
+ * bytes. Matches the shape a future real per-agent writer will have.
+ */
+export type ReferenceWriter = (
+  original: string,
+  format: McpLocationFormat,
+  targetPath: readonly string[],
+) => string;
+
+/**
+ * A perfectly-preserving reference writer — returns the input
+ * unchanged. The harness must report allPassed=true for this writer
+ * on every format.
+ */
+export const preservingWriter: ReferenceWriter = (original) => original;
+
+/**
+ * A comment-stripping reference writer. Strips every JSONC/TOML/YAML
+ * comment from the input. The harness must fire the `comments` check.
+ */
+export const commentStrippingWriter: ReferenceWriter = (original, format) =>
+  stripComments(original, format);
+
+/**
+ * A key-reordering reference writer. Swaps the two top-level keys
+ * listed in targetPath (or the first two unrelated top-level keys if
+ * targetPath is empty). The harness must fire the `keyOrder` check.
+ */
+export const keyReorderingWriter: ReferenceWriter = (original, format) => {
+  // Pick two unrelated top-level keys based on format.
+  if (format === 'json' || format === 'jsonc') {
+    return swapTopLevelKeys(
+      original,
+      format,
+      'numStartups',
+      'autoUpdaterStatus',
+    );
+  }
+  if (format === 'toml') {
+    return swapTopLevelKeys(original, format, 'model', 'approval_mode');
+  }
+  return original;
+};
+
+/**
+ * A reference writer that deletes an unrelated top-level key. The
+ * harness must fire the `topLevelKeys` check.
+ */
+export const unrelatedKeyDeletingWriter: ReferenceWriter = (
+  original,
+  format,
+) => {
+  if (format === 'json' || format === 'jsonc') {
+    return deleteTopLevelKey(original, format, 'numStartups');
+  }
+  if (format === 'toml') {
+    return deleteTopLevelKey(original, format, 'model');
+  }
+  return original;
+};
+
+/**
+ * A reference writer that deletes an unrelated MCP server. The
+ * harness must fire the `mcpServers` check.
+ */
+export const unrelatedServerDeletingWriter: ReferenceWriter = (
+  original,
+  format,
+  targetPath,
+) => {
+  if (targetPath.length === 0) return original;
+  const mcpKey = targetPath[0]!;
+  const touched = targetPath.length > 1 ? targetPath[1]! : '';
+  // Pick an unrelated server name based on format.
+  const unrelated = format === 'toml' ? 'context7' : 'context7';
+  if (unrelated === touched) return original;
+  return deleteMcpServer(original, format, mcpKey, unrelated);
+};
+
+/**
+ * A reference writer that drifts indentation by +2 spaces. The
+ * harness must fire the `formatting` check.
+ */
+export const whitespaceDriftingWriter: ReferenceWriter = (original) =>
+  driftIndentation(original, 2);
+
+/**
+ * A non-idempotent reference writer that appends a trailing newline
+ * on every apply. Applied twice, the second output has a double
+ * trailing newline. The harness must fire the `idempotency` check.
+ */
+export const nonIdempotentWriter: ReferenceWriter = (original) =>
+  appendString(original, '\n');
+
+/**
+ * A reference writer that deletes the trailing newline. The harness
+ * must fire the `formatting` check.
+ */
+export const trailingNewlineDeletingWriter: ReferenceWriter = (original) =>
+  deleteTrailingNewline(original);

--- a/packages/agents/src/writer-preservation/byte-mutators.spec.ts
+++ b/packages/agents/src/writer-preservation/byte-mutators.spec.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for the byte-mutator test helpers in `byte-mutators.ts`.
+ *
+ * These tests are the RED→GREEN contract for the mutators themselves.
+ * The harness self-tests then use the mutators to produce known-broken
+ * outputs and prove each individual preservation check fires.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendString,
+  deleteMcpServer,
+  deleteTopLevelKey,
+  deleteTrailingNewline,
+  driftIndentation,
+  stripComments,
+  swapMcpServers,
+  swapTopLevelKeys,
+} from './byte-mutators.js';
+
+const claudeCodeFixture = `{
+  // user-global Claude Code state
+  "numStartups": 42,
+  "autoUpdaterStatus": "enabled",
+  /* MCP server inventory */
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "fs"]
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "c7"]
+    }
+  }
+}
+`;
+
+const codexFixture = `# top-level settings
+model = "gpt-5"
+approval_mode = "on-request"
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "fs"]
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "c7"]
+`;
+
+describe('stripComments', () => {
+  it('returns JSON input unchanged', () => {
+    const text = '{"a": 1, "b": 2}';
+    expect(stripComments(text, 'json')).toBe(text);
+  });
+
+  it('removes // line comments from JSONC', () => {
+    const text = `{
+  // a comment
+  "a": 1,
+  "b": 2 // trailing
+}
+`;
+    const result = stripComments(text, 'jsonc');
+    expect(result).not.toContain('// a comment');
+    expect(result).not.toContain('// trailing');
+    expect(result).toContain('"a": 1');
+    expect(result).toContain('"b": 2');
+  });
+
+  it('removes /* block */ comments from JSONC', () => {
+    const text = `{
+  /* block
+     comment */
+  "a": 1
+}
+`;
+    const result = stripComments(text, 'jsonc');
+    expect(result).not.toContain('/*');
+    expect(result).not.toContain('block');
+    expect(result).toContain('"a": 1');
+  });
+
+  it('preserves // inside JSON string literals', () => {
+    const text = `{"url": "https://example.com//path"}`;
+    expect(stripComments(text, 'jsonc')).toBe(text);
+  });
+
+  it('removes # comments from TOML', () => {
+    const text = `# top comment
+key = "value" # trailing
+`;
+    const result = stripComments(text, 'toml');
+    expect(result).not.toContain('# top comment');
+    expect(result).not.toContain('# trailing');
+    expect(result).toContain('key = "value"');
+  });
+
+  it('preserves # inside TOML string literals', () => {
+    const text = `key = "value # not a comment"
+`;
+    expect(stripComments(text, 'toml')).toBe(text);
+  });
+});
+
+describe('deleteTopLevelKey', () => {
+  it('removes a JSON top-level key and its value', () => {
+    const result = deleteTopLevelKey(claudeCodeFixture, 'jsonc', 'numStartups');
+    expect(result).not.toContain('numStartups');
+    expect(result).not.toContain('42');
+    expect(result).toContain('autoUpdaterStatus');
+    expect(result).toContain('mcpServers');
+    expect(result).toContain('filesystem');
+  });
+
+  it('returns input unchanged when the JSON key is absent', () => {
+    expect(deleteTopLevelKey(claudeCodeFixture, 'jsonc', 'nonexistent')).toBe(
+      claudeCodeFixture,
+    );
+  });
+
+  it('removes a JSON top-level key whose value is an object', () => {
+    const result = deleteTopLevelKey(claudeCodeFixture, 'jsonc', 'mcpServers');
+    expect(result).not.toContain('mcpServers');
+    expect(result).not.toContain('filesystem');
+    expect(result).not.toContain('context7');
+    expect(result).toContain('numStartups');
+    expect(result).toContain('autoUpdaterStatus');
+  });
+
+  it('removes a TOML top-level scalar', () => {
+    const result = deleteTopLevelKey(codexFixture, 'toml', 'model');
+    expect(result).not.toContain('model');
+    expect(result).not.toContain('gpt-5');
+    expect(result).toContain('approval_mode');
+    expect(result).toContain('mcp_servers');
+  });
+
+  it('removes a TOML top-level table', () => {
+    const result = deleteTopLevelKey(codexFixture, 'toml', 'mcp_servers');
+    expect(result).not.toContain('mcp_servers');
+    expect(result).not.toContain('filesystem');
+    expect(result).not.toContain('context7');
+    expect(result).toContain('model');
+  });
+});
+
+describe('deleteMcpServer', () => {
+  it('removes a JSON MCP server by name', () => {
+    const result = deleteMcpServer(
+      claudeCodeFixture,
+      'jsonc',
+      'mcpServers',
+      'context7',
+    );
+    expect(result).not.toContain('context7');
+    expect(result).toContain('filesystem');
+    expect(result).toContain('mcpServers');
+    expect(result).toContain('numStartups');
+  });
+
+  it('returns input unchanged when the JSON server is absent', () => {
+    expect(
+      deleteMcpServer(claudeCodeFixture, 'jsonc', 'mcpServers', 'nonexistent'),
+    ).toBe(claudeCodeFixture);
+  });
+
+  it('removes a TOML MCP server by subtable name', () => {
+    const result = deleteMcpServer(
+      codexFixture,
+      'toml',
+      'mcp_servers',
+      'context7',
+    );
+    expect(result).not.toContain('mcp_servers.context7');
+    expect(result).not.toContain('context7');
+    expect(result).toContain('mcp_servers.filesystem');
+    expect(result).toContain('filesystem');
+  });
+});
+
+describe('swapTopLevelKeys', () => {
+  it('swaps two JSON top-level keys and their values', () => {
+    const result = swapTopLevelKeys(
+      claudeCodeFixture,
+      'jsonc',
+      'numStartups',
+      'autoUpdaterStatus',
+    );
+    // The block that contained numStartups now contains autoUpdaterStatus,
+    // and vice versa. We assert by checking that both substrings still
+    // appear exactly once each (they were each present once before).
+    expect(result.match(/numStartups/g)?.length ?? 0).toBe(1);
+    expect(result.match(/autoUpdaterStatus/g)?.length ?? 0).toBe(1);
+    // The swapped positions: numStartups's old position now holds
+    // autoUpdaterStatus's old content ("enabled"), and vice versa (42).
+    // We verify by checking that "42" is still in the file but no longer
+    // adjacent to "numStartups".
+    expect(result).toContain('42');
+    expect(result).toContain('enabled');
+  });
+
+  it('returns input unchanged when either JSON key is absent', () => {
+    expect(
+      swapTopLevelKeys(
+        claudeCodeFixture,
+        'jsonc',
+        'numStartups',
+        'nonexistent',
+      ),
+    ).toBe(claudeCodeFixture);
+  });
+});
+
+describe('swapMcpServers', () => {
+  it('swaps two JSON MCP servers within the subtree', () => {
+    const result = swapMcpServers(
+      claudeCodeFixture,
+      'jsonc',
+      'mcpServers',
+      'filesystem',
+      'context7',
+    );
+    expect(result).toContain('filesystem');
+    expect(result).toContain('context7');
+    expect(result).toContain('mcpServers');
+    // The filesystem block (containing "fs") is now where context7 was,
+    // and vice versa. We verify by checking that "fs" still appears once.
+    expect(result.match(/"fs"/g)?.length ?? 0).toBe(1);
+    expect(result.match(/"c7"/g)?.length ?? 0).toBe(1);
+  });
+
+  it('returns input unchanged when either JSON server is absent', () => {
+    expect(
+      swapMcpServers(
+        claudeCodeFixture,
+        'jsonc',
+        'mcpServers',
+        'filesystem',
+        'nonexistent',
+      ),
+    ).toBe(claudeCodeFixture);
+  });
+});
+
+describe('driftIndentation', () => {
+  it('adds leading whitespace to every line', () => {
+    const text = 'a\nb\nc';
+    expect(driftIndentation(text, 2)).toBe('  a\n  b\n  c');
+  });
+
+  it('removes leading whitespace from every line', () => {
+    const text = '  a\n  b\n  c';
+    expect(driftIndentation(text, -2)).toBe('a\nb\nc');
+  });
+
+  it('is a no-op when delta is 0', () => {
+    const text = 'a\n  b';
+    expect(driftIndentation(text, 0)).toBe(text);
+  });
+
+  it('leaves lines with no leading whitespace unchanged on negative delta', () => {
+    const text = 'a\n  b\nc';
+    expect(driftIndentation(text, -2)).toBe('a\nb\nc');
+  });
+});
+
+describe('deleteTrailingNewline', () => {
+  it('removes a single trailing newline', () => {
+    expect(deleteTrailingNewline('hello\n')).toBe('hello');
+  });
+
+  it('returns input unchanged when there is no trailing newline', () => {
+    expect(deleteTrailingNewline('hello')).toBe('hello');
+  });
+});
+
+describe('appendString', () => {
+  it('appends the suffix verbatim', () => {
+    expect(appendString('hello', ' world')).toBe('hello world');
+  });
+
+  it('appends an empty suffix unchanged', () => {
+    expect(appendString('hello', '')).toBe('hello');
+  });
+});

--- a/packages/agents/src/writer-preservation/byte-mutators.ts
+++ b/packages/agents/src/writer-preservation/byte-mutators.ts
@@ -1,0 +1,649 @@
+/**
+ * Byte-level test helpers for the writer preservation harness.
+ *
+ * These mutators take a config file's raw bytes and produce a
+ * deliberately-broken copy: comments stripped, keys swapped, top-level
+ * keys deleted, MCP servers removed, indentation drifted, trailing
+ * newlines removed, or arbitrary suffixes appended. The harness
+ * self-tests use these to prove each individual preservation check
+ * fires when a future writer regresses.
+ *
+ * All mutators preserve parseability of the resulting bytes — a
+ * regression check that fails with a parse error is a different bug
+ * than a preservation check that fails with a byte diff.
+ *
+ * JSON/JSONC mutators use a JSON-aware byte scanner that locates
+ * top-level key ranges by pattern-matching `"key":` and walking braces
+ * to find the value's end. This preserves comments and formatting
+ * outside the modified region, so each mutator only breaks the
+ * intended property.
+ *
+ * TOML mutators use line-based manipulation because `smol-toml` does
+ * not expose a serializer (we cannot round-trip through
+ * parse+stringify without losing comments and formatting).
+ */
+import type { McpLocationFormat } from '../types.js';
+
+/**
+ * Strip every comment run from the input. JSONC supports both
+ * `// line` and `/* block *​/` comments; TOML and YAML support
+ * `# line` comments. JSON has no comments and the input is returned
+ * unchanged.
+ *
+ * Comment runs are removed entirely (not replaced with whitespace),
+ * so the resulting string may be shorter than the input. String
+ * literals are preserved verbatim — a `//`, `/*`, or `#` inside a
+ * JSON string is NOT a comment.
+ */
+export function stripComments(text: string, format: McpLocationFormat): string {
+  if (format === 'json') return text;
+  if (format === 'jsonc') return stripJsoncComments(text);
+  if (format === 'toml' || format === 'yaml') return stripHashComments(text);
+  return text;
+}
+
+/**
+ * Remove a top-level key (and its value, including any nested object/
+ * array/scalar) from the document. For JSON/JSONC, the key is a JSON
+ * object property; for TOML, the key is either a top-level scalar
+ * (`key = value`), an explicit table header (`[key]`), or implicit
+ * parent table defined by subtables (`[key.child]`).
+ *
+ * Returns the input unchanged if the key is not present.
+ */
+export function deleteTopLevelKey(
+  text: string,
+  format: McpLocationFormat,
+  key: string,
+): string {
+  if (format === 'json' || format === 'jsonc') {
+    return deleteJsonTopLevelKey(text, key);
+  }
+  if (format === 'toml') {
+    return deleteTomlTopLevelKey(text, key);
+  }
+  return text;
+}
+
+/**
+ * Remove a named MCP server from the `mcpKey` subtree (e.g. `mcp`,
+ * `mcpServers`, `mcp_servers`). Returns the input unchanged if the
+ * server is not present.
+ */
+export function deleteMcpServer(
+  text: string,
+  format: McpLocationFormat,
+  mcpKey: string,
+  serverName: string,
+): string {
+  if (format === 'json' || format === 'jsonc') {
+    return deleteJsonMcpServer(text, mcpKey, serverName);
+  }
+  if (format === 'toml') {
+    return deleteTomlMcpServer(text, mcpKey, serverName);
+  }
+  return text;
+}
+
+/**
+ * Swap two top-level keys (and their values). Returns the input
+ * unchanged if either key is not present.
+ */
+export function swapTopLevelKeys(
+  text: string,
+  format: McpLocationFormat,
+  keyA: string,
+  keyB: string,
+): string {
+  if (format === 'json' || format === 'jsonc') {
+    return swapJsonTopLevelKeys(text, keyA, keyB);
+  }
+  if (format === 'toml') {
+    return swapTomlTopLevelKeys(text, keyA, keyB);
+  }
+  return text;
+}
+
+/**
+ * Swap two named MCP servers within the `mcpKey` subtree. Returns
+ * the input unchanged if either server is not present.
+ */
+export function swapMcpServers(
+  text: string,
+  format: McpLocationFormat,
+  mcpKey: string,
+  serverA: string,
+  serverB: string,
+): string {
+  if (format === 'json' || format === 'jsonc') {
+    return swapJsonMcpServers(text, mcpKey, serverA, serverB);
+  }
+  if (format === 'toml') {
+    return swapTomlMcpServers(text, mcpKey, serverA, serverB);
+  }
+  return text;
+}
+
+/**
+ * Shift every line's leading whitespace by `delta` spaces (positive
+ * or negative). Lines with no leading whitespace are left unchanged.
+ * Trailing whitespace is preserved.
+ */
+export function driftIndentation(text: string, delta: number): string {
+  if (delta === 0) return text;
+  const lines = text.split('\n');
+  const shifted = lines.map((line) => {
+    if (delta > 0) {
+      return ' '.repeat(delta) + line;
+    }
+    let removed = 0;
+    while (removed < -delta && removed < line.length && line[removed] === ' ') {
+      removed++;
+    }
+    return line.slice(removed);
+  });
+  return shifted.join('\n');
+}
+
+/**
+ * Remove the trailing newline from the input. No-op if the input
+ * already has no trailing newline.
+ */
+export function deleteTrailingNewline(text: string): string {
+  if (text.endsWith('\n')) return text.slice(0, -1);
+  return text;
+}
+
+/**
+ * Append `suffix` to the input verbatim. Used to break idempotency:
+ * if a future writer appends a trailing newline or signature on every
+ * apply, this mutator simulates the second apply's output.
+ */
+export function appendString(text: string, suffix: string): string {
+  return text + suffix;
+}
+
+// ---------------------------------------------------------------------------
+// JSONC helpers (used for both `json` and `jsonc` formats — JSON is a
+// strict subset of JSONC so the same parser and edit primitives work).
+// ---------------------------------------------------------------------------
+
+function stripJsoncComments(text: string): string {
+  let result = '';
+  let i = 0;
+  let inString = false;
+  let stringChar = '';
+  while (i < text.length) {
+    const c = text[i];
+    if (inString) {
+      result += c;
+      if (c === '\\' && i + 1 < text.length) {
+        result += text[i + 1];
+        i += 2;
+        continue;
+      }
+      if (c === stringChar) {
+        inString = false;
+      }
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      inString = true;
+      stringChar = c;
+      result += c;
+      i++;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '/') {
+      while (i < text.length && text[i] !== '\n') i++;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '*') {
+      i += 2;
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) {
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    result += c;
+    i++;
+  }
+  return result;
+}
+
+function stripHashComments(text: string): string {
+  let result = '';
+  let i = 0;
+  let inString = false;
+  let stringChar = '';
+  while (i < text.length) {
+    const c = text[i];
+    if (inString) {
+      result += c;
+      if (c === '\\' && i + 1 < text.length) {
+        result += text[i + 1];
+        i += 2;
+        continue;
+      }
+      if (c === stringChar) {
+        inString = false;
+      }
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      inString = true;
+      stringChar = c;
+      result += c;
+      i++;
+      continue;
+    }
+    if (c === '#') {
+      while (i < text.length && text[i] !== '\n') i++;
+      continue;
+    }
+    result += c;
+    i++;
+  }
+  return result;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Given a position pointing at the start of a JSON value, return the
+ * exclusive end offset of that value. Returns -1 on malformed input.
+ */
+function scanJsonValueEnd(text: string, start: number): number {
+  if (start >= text.length) return -1;
+  const c = text[start];
+  if (c === '"' || c === "'") {
+    let i = start + 1;
+    while (i < text.length) {
+      if (text[i] === '\\') {
+        i += 2;
+        continue;
+      }
+      if (text[i] === c) {
+        return i + 1;
+      }
+      i++;
+    }
+    return -1;
+  }
+  if (c === '{' || c === '[') {
+    const open = c;
+    const close = c === '{' ? '}' : ']';
+    let depth = 1;
+    let i = start + 1;
+    let inString = false;
+    let stringChar = '';
+    while (i < text.length && depth > 0) {
+      const ch = text[i];
+      if (inString) {
+        if (ch === '\\') {
+          i += 2;
+          continue;
+        }
+        if (ch === stringChar) inString = false;
+        i++;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        inString = true;
+        stringChar = ch;
+        i++;
+        continue;
+      }
+      if (ch === open) depth++;
+      else if (ch === close) depth--;
+      i++;
+    }
+    return depth === 0 ? i : -1;
+  }
+  let i = start;
+  while (i < text.length) {
+    const ch = text[i];
+    if (
+      ch === ' ' ||
+      ch === '\t' ||
+      ch === '\n' ||
+      ch === '\r' ||
+      ch === ',' ||
+      ch === '}' ||
+      ch === ']'
+    ) {
+      return i;
+    }
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Find a top-level JSON/JSONC property's byte range. Returns
+ * `[startOffset, endOffset]` where `endOffset` is exclusive. The range
+ * covers the property's key (including opening quote) and its value.
+ * If the property is followed by a comma, the comma is included.
+ * Returns `null` if the property is not present.
+ */
+function findJsonTopLevelRange(
+  text: string,
+  key: string,
+): readonly [number, number] | null {
+  // We intentionally do NOT call parseJsonc() here for validation:
+  // jsonc-parser raises `InvalidCommentNoLine` on fragments whose
+  // string literals contain `${...}` sequences (e.g. shell-style env
+  // forwarders like "${CONTEXT7_API_KEY}"), even though those are
+  // valid JSONC. The byte-mutator's job is to splice text ranges, not
+  // to validate the document, so we rely on the regex-based key
+  // search alone. Callers are expected to pass text that already
+  // round-trips through jsonc-parser's `parse` (see checks.ts).
+  const keyPattern = new RegExp(`"${escapeRegExp(key)}"\\s*:`, 'g');
+  const match = keyPattern.exec(text);
+  if (match === null) return null;
+  const keyStart = match.index;
+  let i = match.index + match[0].length;
+  while (i < text.length && (text[i] === ' ' || text[i] === '\t')) {
+    i++;
+  }
+  if (i >= text.length) return null;
+  const valueStart = i;
+  const valueEnd = scanJsonValueEnd(text, valueStart);
+  if (valueEnd === -1) return null;
+  let j = valueEnd;
+  while (
+    j < text.length &&
+    (text[j] === ' ' ||
+      text[j] === '\t' ||
+      text[j] === '\n' ||
+      text[j] === '\r')
+  ) {
+    j++;
+  }
+  let endOffset = valueEnd;
+  if (text[j] === ',') {
+    endOffset = j + 1;
+  }
+  return [keyStart, endOffset] as const;
+}
+
+function deleteJsonTopLevelKey(text: string, key: string): string {
+  const range = findJsonTopLevelRange(text, key);
+  if (range === null) return text;
+  const [start, end] = range;
+  let result = text.slice(0, start) + text.slice(end);
+  result = result.replace(/\n[ \t]*\n/g, '\n');
+  return result;
+}
+
+function findJsonTopLevelRangeNoComma(
+  text: string,
+  key: string,
+): readonly [number, number] | null {
+  const range = findJsonTopLevelRange(text, key);
+  if (range === null) return null;
+  const [start, end] = range;
+  if (text[end - 1] === ',') {
+    return [start, end - 1] as const;
+  }
+  return range;
+}
+
+function swapJsonTopLevelKeys(
+  text: string,
+  keyA: string,
+  keyB: string,
+): string {
+  // For swap, we must NOT include the trailing comma in either range,
+  // otherwise the comma ends up in the wrong position and the swap
+  // either no-ops or produces malformed JSON. `findJsonTopLevelRange`
+  // includes the trailing comma for delete; here we strip it. The
+  // comma at `aEnd` and `bEnd` is preserved naturally because
+  // `text.slice(aEnd)` and `afterA.slice(newBEnd)` both start with the
+  // original separator (comma + whitespace).
+  const rangeA = findJsonTopLevelRangeNoComma(text, keyA);
+  const rangeB = findJsonTopLevelRangeNoComma(text, keyB);
+  if (rangeA === null || rangeB === null) return text;
+  const [aStart, aEnd] = rangeA;
+  const [bStart, bEnd] = rangeB;
+  const blockA = text.slice(aStart, aEnd);
+  const blockB = text.slice(bStart, bEnd);
+  const afterA = text.slice(0, aStart) + blockB + text.slice(aEnd);
+  const delta = blockB.length - (aEnd - aStart);
+  const newBStart = bStart + delta;
+  const newBEnd = bEnd + delta;
+  return afterA.slice(0, newBStart) + blockA + afterA.slice(newBEnd);
+}
+
+function deleteJsonMcpServer(
+  text: string,
+  mcpKey: string,
+  serverName: string,
+): string {
+  const mcpRange = findJsonTopLevelRange(text, mcpKey);
+  if (mcpRange === null) return text;
+  const [mcpStart, mcpEnd] = mcpRange;
+  const mcpBlock = text.slice(mcpStart, mcpEnd);
+  const braceIdx = mcpBlock.indexOf('{');
+  if (braceIdx === -1) return text;
+  const inner = mcpBlock.slice(braceIdx);
+  const modifiedInner = deleteJsonTopLevelKey(inner, serverName);
+  if (modifiedInner === inner) return text;
+  const newMcpBlock = mcpBlock.slice(0, braceIdx) + modifiedInner;
+  return text.slice(0, mcpStart) + newMcpBlock + text.slice(mcpEnd);
+}
+
+function swapJsonMcpServers(
+  text: string,
+  mcpKey: string,
+  serverA: string,
+  serverB: string,
+): string {
+  const mcpRange = findJsonTopLevelRange(text, mcpKey);
+  if (mcpRange === null) return text;
+  const [mcpStart, mcpEnd] = mcpRange;
+  const mcpBlock = text.slice(mcpStart, mcpEnd);
+  const braceIdx = mcpBlock.indexOf('{');
+  if (braceIdx === -1) return text;
+  const inner = mcpBlock.slice(braceIdx);
+  const modifiedInner = swapJsonTopLevelKeys(inner, serverA, serverB);
+  if (modifiedInner === inner) return text;
+  const newMcpBlock = mcpBlock.slice(0, braceIdx) + modifiedInner;
+  return text.slice(0, mcpStart) + newMcpBlock + text.slice(mcpEnd);
+}
+
+// ---------------------------------------------------------------------------
+// TOML helpers (line-based; smol-toml does not expose a serializer).
+// ---------------------------------------------------------------------------
+
+function deleteTomlTopLevelKey(text: string, key: string): string {
+  const lines = text.split('\n');
+  const out: string[] = [];
+  let i = 0;
+  let removed = false;
+  // In TOML, `[parent]` declares an explicit table. `[parent.child]`
+  // declares a subtable that implicitly defines `parent`. Deleting
+  // `parent` must remove both the explicit header and every subtable.
+  const explicitTableRe = new RegExp(`^\\[${escapeRegExp(key)}\\]$`);
+  const subtableRe = new RegExp(`^\\[${escapeRegExp(key)}\\.[^\\]]+\\]$`);
+  while (i < lines.length) {
+    const line = lines[i] ?? '';
+    const scalarMatch = new RegExp(`^${escapeRegExp(key)}\\s*=`).exec(line);
+    if (scalarMatch !== null) {
+      removed = true;
+      i++;
+      while (i < lines.length) {
+        const next = lines[i] ?? '';
+        if (next.trim() === '') {
+          i++;
+          continue;
+        }
+        if (next.trim().startsWith('[')) break;
+        if (/^[A-Za-z_]/.test(next)) break;
+        i++;
+      }
+      continue;
+    }
+    if (explicitTableRe.exec(line) !== null || subtableRe.exec(line) !== null) {
+      removed = true;
+      i++;
+      while (i < lines.length) {
+        const next = lines[i] ?? '';
+        if (next.trim().startsWith('[')) break;
+        i++;
+      }
+      continue;
+    }
+    out.push(line);
+    i++;
+  }
+  if (!removed) return text;
+  return out.join('\n');
+}
+
+function deleteTomlMcpServer(
+  text: string,
+  mcpKey: string,
+  serverName: string,
+): string {
+  const lines = text.split('\n');
+  const headerRe = new RegExp(
+    `^\\[${escapeRegExp(mcpKey)}\\.${escapeRegExp(serverName)}\\]$`,
+  );
+  const out: string[] = [];
+  let i = 0;
+  let removed = false;
+  while (i < lines.length) {
+    const line = lines[i] ?? '';
+    if (headerRe.exec(line) !== null) {
+      removed = true;
+      i++;
+      while (i < lines.length) {
+        const next = lines[i] ?? '';
+        if (next.trim().startsWith('[')) break;
+        i++;
+      }
+      continue;
+    }
+    out.push(line);
+    i++;
+  }
+  if (!removed) return text;
+  return out.join('\n');
+}
+
+function swapTomlTopLevelKeys(
+  text: string,
+  keyA: string,
+  keyB: string,
+): string {
+  const rangeA = findTomlTopLevelRange(text, keyA);
+  const rangeB = findTomlTopLevelRange(text, keyB);
+  if (rangeA === null || rangeB === null) return text;
+  const [aStart, aEnd] = rangeA;
+  const [bStart, bEnd] = rangeB;
+  const blockA = text.slice(aStart, aEnd);
+  const blockB = text.slice(bStart, bEnd);
+  const afterA = text.slice(0, aStart) + blockB + text.slice(aEnd);
+  const delta = blockB.length - (aEnd - aStart);
+  const newBStart = bStart + delta;
+  const newBEnd = bEnd + delta;
+  return afterA.slice(0, newBStart) + blockA + afterA.slice(newBEnd);
+}
+
+function swapTomlMcpServers(
+  text: string,
+  mcpKey: string,
+  serverA: string,
+  serverB: string,
+): string {
+  const rangeA = findTomlSubtableRange(text, mcpKey, serverA);
+  const rangeB = findTomlSubtableRange(text, mcpKey, serverB);
+  if (rangeA === null || rangeB === null) return text;
+  const [aStart, aEnd] = rangeA;
+  const [bStart, bEnd] = rangeB;
+  const blockA = text.slice(aStart, aEnd);
+  const blockB = text.slice(bStart, bEnd);
+  const afterA = text.slice(0, aStart) + blockB + text.slice(aEnd);
+  const delta = blockB.length - (aEnd - aStart);
+  const newBStart = bStart + delta;
+  const newBEnd = bEnd + delta;
+  return afterA.slice(0, newBStart) + blockA + afterA.slice(newBEnd);
+}
+
+function findTomlTopLevelRange(
+  text: string,
+  key: string,
+): readonly [number, number] | null {
+  const lines = text.split('\n');
+  let offset = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const lineStart = offset;
+    const lineEnd = offset + line.length + 1;
+    offset = lineEnd;
+    const scalarMatch = new RegExp(`^${escapeRegExp(key)}\\s*=`).exec(line);
+    if (scalarMatch !== null) {
+      let end = lineEnd;
+      let j = i + 1;
+      while (j < lines.length) {
+        const next = lines[j] ?? '';
+        if (next.trim() === '') {
+          end += next.length + 1;
+          j++;
+          continue;
+        }
+        break;
+      }
+      return [lineStart, end] as const;
+    }
+    const tableMatch = new RegExp(`^\\[${escapeRegExp(key)}\\]$`).exec(line);
+    if (tableMatch !== null) {
+      let end = lineEnd;
+      let j = i + 1;
+      while (j < lines.length) {
+        const next = lines[j] ?? '';
+        if (next.trim().startsWith('[')) break;
+        end += next.length + 1;
+        j++;
+      }
+      return [lineStart, end] as const;
+    }
+  }
+  return null;
+}
+
+function findTomlSubtableRange(
+  text: string,
+  parentKey: string,
+  subKey: string,
+): readonly [number, number] | null {
+  const lines = text.split('\n');
+  const headerRe = new RegExp(
+    `^\\[${escapeRegExp(parentKey)}\\.${escapeRegExp(subKey)}\\]$`,
+  );
+  let offset = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const lineStart = offset;
+    const lineEnd = offset + line.length + 1;
+    offset = lineEnd;
+    if (headerRe.exec(line) !== null) {
+      let end = lineEnd;
+      let j = i + 1;
+      while (j < lines.length) {
+        const next = lines[j] ?? '';
+        if (next.trim().startsWith('[')) break;
+        end += next.length + 1;
+        j++;
+      }
+      return [lineStart, end] as const;
+    }
+  }
+  return null;
+}

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -57,9 +57,9 @@ export function checksForFormat(
 
 /**
  * Build the result of a skipped check — the check was not applicable
- * for this format, or the optional input was not supplied. The
- * `details` field is empty and `pass` is true (skipping is not a
- * failure).
+ * for this format (e.g. `comments` for JSON, or the target is the
+ * whole document). The `details` field is empty and `pass` is true
+ * (skipping is not a failure).
  */
 export function skippedCheck(
   name: PreservationCheckName,

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -2,7 +2,7 @@
  * Individual preservation checks for the writer preservation harness.
  *
  * Each check is a pure function: it takes the original bytes, the
- * written bytes, the optional rewritten bytes (for idempotency), and
+ * written bytes, the required rewritten bytes (for idempotency), and
  * the targetPath the writer was allowed to mutate. It returns a
  * {@link PreservationCheckResult} with pass/fail and diagnostic details.
  *

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -31,10 +31,13 @@ const smolTomlCjsModule = createRequire(__filename)('smol-toml') as unknown as {
 };
 
 /**
- * Determines which checks apply for a given format. JSONC adds the
- * `comments` check; JSON skips it (JSON has no comments); TOML and YAML
- * add the `comments` check; every supported format runs the other
- * four checks.
+ * Determines which checks apply for a given format. JSONC and TOML add
+ * the `comments` check; JSON skips it (JSON has no comments). YAML is
+ * not yet supported by any E1 agent (opencode, claude-code,
+ * copilot-cli, codex are JSON/JSONC/TOML only) and returns no
+ * advertised checks. Every supported format runs the base set
+ * (topLevelKeys, keyOrder, mcpServers, formatting) plus `rawBytes`
+ * and `idempotency` (which are always invoked from `runPreservationChecks`).
  */
 export function checksForFormat(
   format: McpLocationFormat,
@@ -578,26 +581,26 @@ function jsonFormattingCheck(
   written: string,
   targetPath: TargetPath,
 ): PreservationCheckResult {
-  const targetRange = findJsonTargetPathRange(original, targetPath);
-  const origLines = original.split('\n');
-  const writtenLines = written.split('\n');
-  // Determine which lines of `original` are inside targetPath.
-  const insideTarget = new Set<number>();
-  if (targetRange !== null) {
-    const [start, end] = targetRange;
-    let pos = 0;
-    for (let i = 0; i < origLines.length; i++) {
-      const lineStart = pos;
-      const lineEnd = pos + origLines[i]!.length + 1;
-      pos = lineEnd;
-      const lineMid = Math.floor((lineStart + lineEnd) / 2);
-      if (lineMid >= start && lineMid < end) insideTarget.add(i);
-    }
+  // Compute target ranges INDEPENDENTLY in original and written. A
+  // length-changing inside-target mutation (e.g. adding a field to
+  // the target server) shifts line indices; using only the original
+  // range would mark the wrong lines as "inside target" and compare
+  // outside lines at shifted indices, falsely firing.
+  const origRange = findJsonTargetPathRange(original, targetPath);
+  const writtenRange = findJsonTargetPathRange(written, targetPath);
+  if (origRange === null || writtenRange === null) {
+    return skippedCheck('formatting');
   }
+  const [origStart, origEnd] = origRange;
+  const [writtenStart, writtenEnd] = writtenRange;
+  const origOutside = original.slice(0, origStart) + original.slice(origEnd);
+  const writtenOutside =
+    written.slice(0, writtenStart) + written.slice(writtenEnd);
+  const origLines = origOutside.split('\n');
+  const writtenLines = writtenOutside.split('\n');
   const diffs: string[] = [];
   const maxLines = Math.min(origLines.length, writtenLines.length);
   for (let i = 0; i < maxLines; i++) {
-    if (insideTarget.has(i)) continue;
     const origLeading = origLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
     const writtenLeading = writtenLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
     if (origLeading !== writtenLeading) {
@@ -606,7 +609,6 @@ function jsonFormattingCheck(
       );
     }
   }
-  // Trailing newline check.
   if (original.endsWith('\n') !== written.endsWith('\n')) {
     diffs.push(
       `trailing newline: original=${original.endsWith('\n')}, written=${written.endsWith('\n')}`,
@@ -1090,17 +1092,36 @@ function tomlFormattingCheck(
   written: string,
   targetPath: TargetPath,
 ): PreservationCheckResult {
+  // Compute target line ranges INDEPENDENTLY in original and written.
+  // A length-changing inside-target mutation shifts line indices; using
+  // only the original range would mark the wrong lines as inside.
   const origLineRange = findTomlTargetPathLineRange(original, targetPath);
+  const writtenLineRange = findTomlTargetPathLineRange(written, targetPath);
+  if (origLineRange === null || writtenLineRange === null) {
+    return skippedCheck('formatting');
+  }
+  const [origStart, origEnd] = origLineRange;
+  const [writtenStart, writtenEnd] = writtenLineRange;
   const origLines = original.split('\n');
   const writtenLines = written.split('\n');
+  const origOutside = [
+    ...origLines.slice(0, origStart),
+    ...origLines.slice(origEnd),
+  ].join('\n');
+  const writtenOutside = [
+    ...writtenLines.slice(0, writtenStart),
+    ...writtenLines.slice(writtenEnd),
+  ].join('\n');
+  const origOutsideLines = origOutside.split('\n');
+  const writtenOutsideLines = writtenOutside.split('\n');
   const diffs: string[] = [];
-  for (let i = 0; i < Math.min(origLines.length, writtenLines.length); i++) {
-    if (origLineRange !== null) {
-      const [s, e] = origLineRange;
-      if (i >= s && i < e) continue;
-    }
-    const origLeading = origLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
-    const writtenLeading = writtenLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
+  for (
+    let i = 0;
+    i < Math.min(origOutsideLines.length, writtenOutsideLines.length);
+    i++
+  ) {
+    const origLeading = origOutsideLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
+    const writtenLeading = writtenOutsideLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
     if (origLeading !== writtenLeading) {
       diffs.push(
         `line ${i + 1}: leading whitespace ${JSON.stringify(origLeading)} vs ${JSON.stringify(writtenLeading)}`,
@@ -1173,8 +1194,8 @@ function findTomlTargetPathLineRange(
     // Find [parent] or [parent.*] headers
     let startLine = -1;
     let endLine = lines.length;
-    const explicitRe = new RegExp(`^\\[${escapeRegExp(parent)}\\]$`);
-    const subRe = new RegExp(`^\\[${escapeRegExp(parent)}\\.[^\\]]+\\]$`);
+    const explicitRe = new RegExp(`^\\s*\\[${escapeRegExp(parent)}\\]$`);
+    const subRe = new RegExp(`^\\s*\\[${escapeRegExp(parent)}\\.[^\\]]+\\]$`);
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
       if (startLine === -1 && (explicitRe.test(line) || subRe.test(line))) {
@@ -1198,7 +1219,7 @@ function findTomlTargetPathLineRange(
     const parent = targetPath[0]!;
     const child = targetPath[1]!;
     const headerRe = new RegExp(
-      `^\\[${escapeRegExp(parent)}\\.${escapeRegExp(child)}\\]$`,
+      `^\\s*\\[${escapeRegExp(parent)}\\.${escapeRegExp(child)}\\]$`,
     );
     let startLine = -1;
     let endLine = lines.length;

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -45,8 +45,12 @@ export function checksForFormat(
   ];
   if (format === 'json') return base;
   if (format === 'jsonc') return ['comments', ...base];
-  if (format === 'toml' || format === 'yaml') return ['comments', ...base];
-  return base;
+  if (format === 'toml') return ['comments', ...base];
+  // YAML: no supported agent uses YAML yet (E1 scope = opencode, claude-code,
+  // copilot-cli, codex). When a YAML agent is added (E4) this branch must
+  // gain real checks. Until then, no checks are advertised so callers cannot
+  // assume coverage they don't have.
+  return [];
 }
 
 /**
@@ -155,17 +159,140 @@ export function formattingCheck(
 }
 
 export function idempotencyCheck(
-  written: string | undefined,
-  rewritten: string | undefined,
+  written: string,
+  rewritten: string,
 ): PreservationCheckResult {
-  if (rewritten === undefined) return skippedCheck('idempotency');
   if (rewritten === written) {
     return { name: 'idempotency', pass: true, details: '', skipped: false };
   }
   return {
     name: 'idempotency',
     pass: false,
-    details: `Second apply produced different bytes than first apply (length: ${written?.length ?? 0} vs ${rewritten.length})`,
+    details: `Second apply produced different bytes than first apply (length: ${written.length} vs ${rewritten.length})`,
+    skipped: false,
+  };
+}
+
+/**
+ * Strongest preservation guarantee: every byte outside the targetPath
+ * subtree must be byte-identical between `original` and `written`.
+ *
+ * This is the primary E1 contract. The structured checks (comments,
+ * topLevelKeys, keyOrder, mcpServers, formatting) are diagnostic
+ * aids that name *which* property regressed; this check is the
+ * catch-all that fires on any out-of-scope byte change those
+ * structural checks might miss (e.g. a comment text change that keeps
+ * the same set, or a value-type swap in a non-target top-level key
+ * that keeps structural equality).
+ *
+ * For JSON/JSONC: extract the targetPath subtree's byte range, then
+ * compare `original[0..start] + original[end..]` byte-for-byte against
+ * the same concatenation from `written`.
+ *
+ * For TOML: same approach but the targetPath range is a line range,
+ * converted to a byte range.
+ *
+ * For empty targetPath: skipped (whole document was allowed).
+ *
+ * For YAML: skipped (no supported agent uses YAML yet).
+ */
+export function rawBytesCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+  format: McpLocationFormat,
+): PreservationCheckResult {
+  if (targetPath.length === 0) return skippedCheck('rawBytes');
+  if (format === 'json' || format === 'jsonc') {
+    const range = findJsonTargetPathRange(original, targetPath);
+    if (range === null) {
+      return {
+        name: 'rawBytes',
+        pass: false,
+        details: `targetPath ${JSON.stringify(targetPath)} not found in original document`,
+        skipped: false,
+      };
+    }
+    const [start, end] = range;
+    const origOutside = original.slice(0, start) + original.slice(end);
+    const writtenOutside = written.slice(0, start) + written.slice(end);
+    if (origOutside === writtenOutside) {
+      return { name: 'rawBytes', pass: true, details: '', skipped: false };
+    }
+    return diffResult(
+      'rawBytes',
+      origOutside,
+      writtenOutside,
+      start,
+      end,
+      format,
+    );
+  }
+  if (format === 'toml') {
+    const lineRange = findTomlTargetPathLineRange(original, targetPath);
+    if (lineRange === null) {
+      return {
+        name: 'rawBytes',
+        pass: false,
+        details: `targetPath ${JSON.stringify(targetPath)} not found in original TOML document`,
+        skipped: false,
+      };
+    }
+    const [startLine, endLine] = lineRange;
+    const origLines = original.split('\n');
+    const writtenLines = written.split('\n');
+    const origOutside = [
+      ...origLines.slice(0, startLine),
+      ...origLines.slice(endLine),
+    ].join('\n');
+    const writtenOutside = [
+      ...writtenLines.slice(0, startLine),
+      ...writtenLines.slice(endLine),
+    ].join('\n');
+    if (origOutside === writtenOutside) {
+      return { name: 'rawBytes', pass: true, details: '', skipped: false };
+    }
+    return diffResult(
+      'rawBytes',
+      origOutside,
+      writtenOutside,
+      startLine,
+      endLine,
+      format,
+    );
+  }
+  return skippedCheck('rawBytes');
+}
+
+function diffResult(
+  name: PreservationCheckName,
+  origOutside: string,
+  writtenOutside: string,
+  start: number,
+  end: number,
+  format: McpLocationFormat,
+): PreservationCheckResult {
+  // Find the first divergent byte to give a useful diagnostic.
+  let divergeAt = 0;
+  const minLen = Math.min(origOutside.length, writtenOutside.length);
+  while (
+    divergeAt < minLen &&
+    origOutside[divergeAt] === writtenOutside[divergeAt]
+  ) {
+    divergeAt++;
+  }
+  const lenDelta = writtenOutside.length - origOutside.length;
+  const snippet = origOutside.slice(
+    Math.max(0, divergeAt - 20),
+    divergeAt + 20,
+  );
+  return {
+    name,
+    pass: false,
+    details:
+      `Bytes outside targetPath[${format === 'toml' ? 'line' : 'byte'} ${start}\u2013${end}] differ: ` +
+      `first divergence at offset ${divergeAt} (len delta: ${lenDelta}), ` +
+      `snippet: ${JSON.stringify(snippet)}`,
     skipped: false,
   };
 }

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -1,0 +1,1133 @@
+/**
+ * Individual preservation checks for the writer preservation harness.
+ *
+ * Each check is a pure function: it takes the original bytes, the
+ * written bytes, the optional rewritten bytes (for idempotency), and
+ * the targetPath the writer was allowed to mutate. It returns a
+ * {@link PreservationCheckResult} with pass/fail and diagnostic details.
+ *
+ * The checks are format-aware. JSON/JSONC uses jsonc-parser for
+ * structural comparisons; TOML uses smol-toml for structural parsing
+ * and line-based manipulation for byte-level checks (because smol-toml
+ * does not preserve comments or key order through parse).
+ */
+import {
+  parse as parseJsonc,
+  type ParseError,
+} from 'jsonc-parser/lib/esm/main.js';
+import { createRequire } from 'node:module';
+
+import type { McpLocationFormat } from '../types.js';
+import type {
+  PreservationCheckName,
+  PreservationCheckResult,
+  TargetPath,
+} from './types.js';
+
+const smolTomlCjsModule = createRequire(__filename)('smol-toml') as unknown as {
+  parse: (text: string) => Record<string, unknown>;
+};
+
+/**
+ * Determines which checks apply for a given format. JSONC adds the
+ * `comments` check; JSON skips it (JSON has no comments); TOML and YAML
+ * add the `comments` check; every supported format runs the other
+ * four checks.
+ */
+export function checksForFormat(
+  format: McpLocationFormat,
+): readonly PreservationCheckName[] {
+  const base: PreservationCheckName[] = [
+    'topLevelKeys',
+    'keyOrder',
+    'mcpServers',
+    'formatting',
+  ];
+  if (format === 'json') return base;
+  if (format === 'jsonc') return ['comments', ...base];
+  if (format === 'toml' || format === 'yaml') return ['comments', ...base];
+  return base;
+}
+
+/**
+ * Build the result of a skipped check — the check was not applicable
+ * for this format, or the optional input was not supplied. The
+ * `details` field is empty and `pass` is true (skipping is not a
+ * failure).
+ */
+export function skippedCheck(
+  name: PreservationCheckName,
+): PreservationCheckResult {
+  return { name, pass: true, details: '', skipped: true };
+}
+
+export function commentsCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+  format: McpLocationFormat,
+): PreservationCheckResult {
+  if (format === 'json') return skippedCheck('comments');
+  const extract =
+    format === 'jsonc' ? extractJsoncComments : extractHashComments;
+  const outsideOriginal = extractOutside(original, targetPath, format);
+  const allWritten = extract(written);
+  const missing = outsideOriginal.filter((c) => !allWritten.includes(c));
+  if (missing.length === 0) {
+    return { name: 'comments', pass: true, details: '', skipped: false };
+  }
+  const preview = missing
+    .slice(0, 3)
+    .map((m) => `  - ${JSON.stringify(m)}`)
+    .join('\n');
+  const more =
+    missing.length > 3 ? `\n  ...and ${missing.length - 3} more` : '';
+  return {
+    name: 'comments',
+    pass: false,
+    details: `Missing ${missing.length} comment(s) from output:\n${preview}${more}`,
+    skipped: false,
+  };
+}
+
+export function topLevelKeysCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+  format: McpLocationFormat,
+): PreservationCheckResult {
+  const allowedTopLevel = targetPath[0];
+  if (format === 'json' || format === 'jsonc') {
+    return jsonTopLevelKeysCheck(original, written, allowedTopLevel);
+  }
+  if (format === 'toml') {
+    return tomlTopLevelKeysCheck(original, written, allowedTopLevel);
+  }
+  return skippedCheck('topLevelKeys');
+}
+
+export function keyOrderCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+  format: McpLocationFormat,
+): PreservationCheckResult {
+  if (format === 'json' || format === 'jsonc') {
+    return jsonKeyOrderCheck(original, written, targetPath);
+  }
+  if (format === 'toml') {
+    return tomlKeyOrderCheck(original, written, targetPath);
+  }
+  return skippedCheck('keyOrder');
+}
+
+export function mcpServersCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+  format: McpLocationFormat,
+): PreservationCheckResult {
+  if (targetPath.length === 0) return skippedCheck('mcpServers');
+  const mcpKey = targetPath[0];
+  const touchedServer = targetPath.length > 1 ? targetPath[1] : undefined;
+  if (format === 'json' || format === 'jsonc') {
+    return jsonMcpServersCheck(original, written, mcpKey, touchedServer);
+  }
+  if (format === 'toml') {
+    return tomlMcpServersCheck(original, written, mcpKey, touchedServer);
+  }
+  return skippedCheck('mcpServers');
+}
+
+export function formattingCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+  format: McpLocationFormat,
+): PreservationCheckResult {
+  if (format === 'json' || format === 'jsonc') {
+    return jsonFormattingCheck(original, written, targetPath);
+  }
+  if (format === 'toml') {
+    return tomlFormattingCheck(original, written, targetPath);
+  }
+  return skippedCheck('formatting');
+}
+
+export function idempotencyCheck(
+  written: string | undefined,
+  rewritten: string | undefined,
+): PreservationCheckResult {
+  if (rewritten === undefined) return skippedCheck('idempotency');
+  if (rewritten === written) {
+    return { name: 'idempotency', pass: true, details: '', skipped: false };
+  }
+  return {
+    name: 'idempotency',
+    pass: false,
+    details: `Second apply produced different bytes than first apply (length: ${written?.length ?? 0} vs ${rewritten.length})`,
+    skipped: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// JSON / JSONC helpers
+// ---------------------------------------------------------------------------
+
+function parseJsoncStrict(text: string): unknown {
+  const errors: ParseError[] = [];
+  const result = parseJsonc(text, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  if (errors.length > 0) {
+    const first = errors[0];
+    throw new Error(
+      `jsonc parse error: ${first?.error ?? 'unknown'} at offset ${first?.offset ?? 0}`,
+    );
+  }
+  return result;
+}
+
+/**
+ * Find a top-level JSON/JSONC property's byte range `[start, end)`.
+ * The range covers the property's key (including opening quote) and
+ * its value. If the property is followed by a comma, the comma is
+ * included. Returns `null` if the property is not present.
+ */
+function findJsonTopLevelRange(
+  text: string,
+  key: string,
+): readonly [number, number] | null {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const keyPattern = new RegExp(`"${escaped}"\\s*:`, 'g');
+  const match = keyPattern.exec(text);
+  if (match === null) return null;
+  const keyStart = match.index;
+  let i = match.index + match[0].length;
+  while (i < text.length && (text[i] === ' ' || text[i] === '\t')) i++;
+  if (i >= text.length) return null;
+  const valueEnd = scanJsonValueEnd(text, i);
+  if (valueEnd === -1) return null;
+  let j = valueEnd;
+  while (
+    j < text.length &&
+    (text[j] === ' ' ||
+      text[j] === '\t' ||
+      text[j] === '\n' ||
+      text[j] === '\r')
+  ) {
+    j++;
+  }
+  let endOffset = valueEnd;
+  if (text[j] === ',') endOffset = j + 1;
+  return [keyStart, endOffset] as const;
+}
+
+function scanJsonValueEnd(text: string, start: number): number {
+  if (start >= text.length) return -1;
+  const c = text[start];
+  if (c === '"' || c === "'") {
+    let i = start + 1;
+    while (i < text.length) {
+      if (text[i] === '\\') {
+        i += 2;
+        continue;
+      }
+      if (text[i] === c) return i + 1;
+      i++;
+    }
+    return -1;
+  }
+  if (c === '{' || c === '[') {
+    const open = c;
+    const close = c === '{' ? '}' : ']';
+    let depth = 1;
+    let i = start + 1;
+    let inString = false;
+    let stringChar = '';
+    while (i < text.length && depth > 0) {
+      const ch = text[i];
+      if (inString) {
+        if (ch === '\\') {
+          i += 2;
+          continue;
+        }
+        if (ch === stringChar) inString = false;
+        i++;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        inString = true;
+        stringChar = ch;
+        i++;
+        continue;
+      }
+      if (ch === open) depth++;
+      else if (ch === close) depth--;
+      i++;
+    }
+    return depth === 0 ? i : -1;
+  }
+  let i = start;
+  while (i < text.length) {
+    const ch = text[i];
+    if (
+      ch === ' ' ||
+      ch === '\t' ||
+      ch === '\n' ||
+      ch === '\r' ||
+      ch === ',' ||
+      ch === '}' ||
+      ch === ']'
+    )
+      return i;
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Find the byte range of the targetPath subtree in a JSON/JSONC
+ * document. Returns `[start, end)` where the range covers the entire
+ * subtree including its enclosing braces. Returns `null` if the
+ * path doesn't exist.
+ */
+function findJsonTargetPathRange(
+  text: string,
+  targetPath: TargetPath,
+): readonly [number, number] | null {
+  if (targetPath.length === 0) return null;
+  const initialRange = findJsonTopLevelRange(text, targetPath[0]!);
+  if (initialRange === null) return null;
+  let currentRange: readonly [number, number] = initialRange;
+  for (let i = 1; i < targetPath.length; i++) {
+    const key = targetPath[i]!;
+    const [start, end] = currentRange;
+    const inner = text.slice(start, end);
+    const innerRange = findJsonTopLevelRange(inner, key);
+    if (innerRange === null) return null;
+    currentRange = [start + innerRange[0], start + innerRange[1]] as const;
+  }
+  return currentRange;
+}
+
+function jsonTopLevelKeysCheck(
+  original: string,
+  written: string,
+  allowedTopLevel: string | undefined,
+): PreservationCheckResult {
+  const origDoc = parseJsoncStrict(original) as Record<string, unknown> | null;
+  const writtenDoc = parseJsoncStrict(written) as Record<
+    string,
+    unknown
+  > | null;
+  if (
+    origDoc === null ||
+    typeof origDoc !== 'object' ||
+    Array.isArray(origDoc)
+  ) {
+    return skippedCheck('topLevelKeys');
+  }
+  if (
+    writtenDoc === null ||
+    typeof writtenDoc !== 'object' ||
+    Array.isArray(writtenDoc)
+  ) {
+    return {
+      name: 'topLevelKeys',
+      pass: false,
+      details: 'written document is not a JSON object',
+      skipped: false,
+    };
+  }
+  const missing: string[] = [];
+  const different: string[] = [];
+  for (const key of Object.keys(origDoc)) {
+    if (key === allowedTopLevel) continue;
+    if (!(key in writtenDoc)) {
+      missing.push(key);
+      continue;
+    }
+    if (!jsonDeepEqual(origDoc[key], writtenDoc[key])) {
+      different.push(key);
+    }
+  }
+  if (missing.length === 0 && different.length === 0) {
+    return { name: 'topLevelKeys', pass: true, details: '', skipped: false };
+  }
+  const parts: string[] = [];
+  if (missing.length > 0) parts.push(`missing: ${missing.join(', ')}`);
+  if (different.length > 0) parts.push(`differ: ${different.join(', ')}`);
+  return {
+    name: 'topLevelKeys',
+    pass: false,
+    details: `Top-level keys outside targetPath: ${parts.join('; ')}`,
+    skipped: false,
+  };
+}
+
+function jsonKeyOrderCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+): PreservationCheckResult {
+  const origDoc = parseJsoncStrict(original) as Record<string, unknown> | null;
+  const writtenDoc = parseJsoncStrict(written) as Record<
+    string,
+    unknown
+  > | null;
+  if (
+    origDoc === null ||
+    typeof origDoc !== 'object' ||
+    Array.isArray(origDoc)
+  ) {
+    return skippedCheck('keyOrder');
+  }
+  if (
+    writtenDoc === null ||
+    typeof writtenDoc !== 'object' ||
+    Array.isArray(writtenDoc)
+  ) {
+    return {
+      name: 'keyOrder',
+      pass: false,
+      details: 'written document is not a JSON object',
+      skipped: false,
+    };
+  }
+  // jsonc-parser preserves key order via Object.keys() on the parsed
+  // object (insertion order). The checks below rely on that.
+  const diffs: string[] = [];
+  compareContainerKeyOrder(origDoc, writtenDoc, '$', targetPath, diffs);
+  if (diffs.length === 0) {
+    return { name: 'keyOrder', pass: true, details: '', skipped: false };
+  }
+  return {
+    name: 'keyOrder',
+    pass: false,
+    details: `Key order differs at:\n${diffs
+      .slice(0, 5)
+      .map((d) => `  - ${d}`)
+      .join('\n')}`,
+    skipped: false,
+  };
+}
+
+function jsonMcpServersCheck(
+  original: string,
+  written: string,
+  mcpKey: string,
+  touchedServer: string | undefined,
+): PreservationCheckResult {
+  const origDoc = parseJsoncStrict(original) as Record<string, unknown> | null;
+  const writtenDoc = parseJsoncStrict(written) as Record<
+    string,
+    unknown
+  > | null;
+  if (
+    origDoc === null ||
+    writtenDoc === null ||
+    typeof origDoc !== 'object' ||
+    typeof writtenDoc !== 'object' ||
+    Array.isArray(origDoc) ||
+    Array.isArray(writtenDoc)
+  ) {
+    return skippedCheck('mcpServers');
+  }
+  const origMcp = origDoc[mcpKey];
+  const writtenMcp = writtenDoc[mcpKey];
+  if (origMcp === undefined) return skippedCheck('mcpServers');
+  if (
+    typeof origMcp !== 'object' ||
+    origMcp === null ||
+    Array.isArray(origMcp)
+  ) {
+    return skippedCheck('mcpServers');
+  }
+  const writtenServers =
+    writtenMcp !== undefined &&
+    typeof writtenMcp === 'object' &&
+    !Array.isArray(writtenMcp)
+      ? (writtenMcp as Record<string, unknown>)
+      : {};
+  const missing: string[] = [];
+  const different: string[] = [];
+  for (const server of Object.keys(origMcp)) {
+    if (server === touchedServer) continue;
+    if (!(server in writtenServers)) {
+      missing.push(server);
+      continue;
+    }
+    if (
+      !jsonDeepEqual(
+        (origMcp as Record<string, unknown>)[server],
+        writtenServers[server],
+      )
+    ) {
+      different.push(server);
+    }
+  }
+  if (missing.length === 0 && different.length === 0) {
+    return { name: 'mcpServers', pass: true, details: '', skipped: false };
+  }
+  const parts: string[] = [];
+  if (missing.length > 0) parts.push(`missing: ${missing.join(', ')}`);
+  if (different.length > 0) parts.push(`differ: ${different.join(', ')}`);
+  return {
+    name: 'mcpServers',
+    pass: false,
+    details: `MCP servers outside targetPath: ${parts.join('; ')}`,
+    skipped: false,
+  };
+}
+
+function jsonFormattingCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+): PreservationCheckResult {
+  const targetRange = findJsonTargetPathRange(original, targetPath);
+  const origLines = original.split('\n');
+  const writtenLines = written.split('\n');
+  // Determine which lines of `original` are inside targetPath.
+  const insideTarget = new Set<number>();
+  if (targetRange !== null) {
+    const [start, end] = targetRange;
+    let pos = 0;
+    for (let i = 0; i < origLines.length; i++) {
+      const lineStart = pos;
+      const lineEnd = pos + origLines[i]!.length + 1;
+      pos = lineEnd;
+      const lineMid = Math.floor((lineStart + lineEnd) / 2);
+      if (lineMid >= start && lineMid < end) insideTarget.add(i);
+    }
+  }
+  const diffs: string[] = [];
+  const maxLines = Math.min(origLines.length, writtenLines.length);
+  for (let i = 0; i < maxLines; i++) {
+    if (insideTarget.has(i)) continue;
+    const origLeading = origLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
+    const writtenLeading = writtenLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
+    if (origLeading !== writtenLeading) {
+      diffs.push(
+        `line ${i + 1}: leading whitespace ${JSON.stringify(origLeading)} vs ${JSON.stringify(writtenLeading)}`,
+      );
+    }
+  }
+  // Trailing newline check.
+  if (original.endsWith('\n') !== written.endsWith('\n')) {
+    diffs.push(
+      `trailing newline: original=${original.endsWith('\n')}, written=${written.endsWith('\n')}`,
+    );
+  }
+  if (diffs.length === 0) {
+    return { name: 'formatting', pass: true, details: '', skipped: false };
+  }
+  return {
+    name: 'formatting',
+    pass: false,
+    details: `Formatting drift outside targetPath:\n${diffs
+      .slice(0, 5)
+      .map((d) => `  - ${d}`)
+      .join('\n')}`,
+    skipped: false,
+  };
+}
+
+/**
+ * Deep-equal comparison for JSON values. Handles primitives, arrays,
+ * and plain objects. Does not handle `undefined`, functions, or
+ * non-JSON values.
+ */
+function jsonDeepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!jsonDeepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const ak = Object.keys(a as object);
+    const bk = Object.keys(b as object);
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) {
+      if (
+        !jsonDeepEqual(
+          (a as Record<string, unknown>)[k],
+          (b as Record<string, unknown>)[k],
+        )
+      )
+        return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Walk two parsed JSON trees and report every container whose key
+ * order differs outside the targetPath subtree. `path` is the JSON
+ * pointer to the current container.
+ */
+function compareContainerKeyOrder(
+  orig: Record<string, unknown>,
+  written: Record<string, unknown>,
+  path: string,
+  targetPath: TargetPath,
+  diffs: string[],
+): void {
+  // If this container is inside targetPath, skip it.
+  if (isPathInsideTarget(path, targetPath)) return;
+  const origKeys = Object.keys(orig);
+  const writtenKeys = Object.keys(written);
+  const common = origKeys.filter((k) => k in written);
+  const writtenOrder = common.map((k) => writtenKeys.indexOf(k));
+  const expected = common.map((_, i) => i);
+  if (JSON.stringify(writtenOrder) !== JSON.stringify(expected)) {
+    diffs.push(
+      `${path}: expected [${expected}], got [${writtenOrder}] (keys: ${JSON.stringify(common)})`,
+    );
+  }
+  // Recurse into containers outside targetPath.
+  for (const key of common) {
+    const childPath = `${path}.${key}`;
+    const o = orig[key];
+    const w = written[key];
+    if (
+      o !== null &&
+      w !== null &&
+      typeof o === 'object' &&
+      typeof w === 'object' &&
+      !Array.isArray(o) &&
+      !Array.isArray(w)
+    ) {
+      compareContainerKeyOrder(
+        o as Record<string, unknown>,
+        w as Record<string, unknown>,
+        childPath,
+        targetPath,
+        diffs,
+      );
+    }
+  }
+}
+
+/**
+ * JSON-pointer-ish path-inside-target check. A path like
+ * `$.mcpServers.filesystem` is inside targetPath `['mcpServers', 'filesystem']`.
+ */
+function isPathInsideTarget(path: string, targetPath: TargetPath): boolean {
+  if (targetPath.length === 0) return false;
+  // path starts with "$."; split into segments
+  const segments = path
+    .slice(2)
+    .split('.')
+    .filter((s) => s.length > 0);
+  if (segments.length < targetPath.length) return false;
+  for (let i = 0; i < targetPath.length; i++) {
+    if (segments[i] !== targetPath[i]) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// JSONC comment extraction
+// ---------------------------------------------------------------------------
+
+function extractJsoncComments(text: string): string[] {
+  const comments: string[] = [];
+  let i = 0;
+  let inString = false;
+  let stringChar = '';
+  while (i < text.length) {
+    const c = text[i];
+    if (inString) {
+      if (c === '\\' && i + 1 < text.length) {
+        i += 2;
+        continue;
+      }
+      if (c === stringChar) inString = false;
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      inString = true;
+      stringChar = c;
+      i++;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '/') {
+      const start = i;
+      while (i < text.length && text[i] !== '\n') i++;
+      comments.push(text.slice(start, i));
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '*') {
+      const start = i;
+      i += 2;
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) i++;
+      i = Math.min(i + 2, text.length);
+      comments.push(text.slice(start, i));
+      continue;
+    }
+    i++;
+  }
+  return comments;
+}
+
+function extractHashComments(text: string): string[] {
+  const comments: string[] = [];
+  let i = 0;
+  let inString = false;
+  let stringChar = '';
+  while (i < text.length) {
+    const c = text[i];
+    if (inString) {
+      if (c === '\\' && i + 1 < text.length) {
+        i += 2;
+        continue;
+      }
+      if (c === stringChar) inString = false;
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      inString = true;
+      stringChar = c;
+      i++;
+      continue;
+    }
+    if (c === '#') {
+      const start = i;
+      while (i < text.length && text[i] !== '\n') i++;
+      comments.push(text.slice(start, i));
+      continue;
+    }
+    i++;
+  }
+  return comments;
+}
+
+/**
+ * Extract comments from `text` that are NOT inside the targetPath
+ * subtree. For JSON/JSONC, the subtree is identified by byte range.
+ * For TOML, the subtree is identified by line range.
+ */
+function extractCommentsOutside(
+  text: string,
+  targetPath: TargetPath,
+  format: McpLocationFormat,
+): string[] {
+  if (format === 'jsonc') {
+    const range = findJsonTargetPathRange(text, targetPath);
+    if (range === null) return extractJsoncComments(text);
+    return extractJsoncCommentsByLines(text, range[0], range[1]);
+  }
+  if (format === 'toml' || format === 'yaml') {
+    const lineRange = findTomlTargetPathLineRange(text, targetPath);
+    if (lineRange === null) return extractHashComments(text);
+    return extractHashCommentsByLines(text, lineRange[0], lineRange[1]);
+  }
+  return [];
+}
+
+function extractOutside(
+  text: string,
+  targetPath: TargetPath,
+  format: McpLocationFormat,
+): string[] {
+  if (format === 'json') return [];
+  return extractCommentsOutside(text, targetPath, format);
+}
+
+function extractJsoncCommentsByLines(
+  text: string,
+  startByte: number,
+  endByte: number,
+): string[] {
+  const result: string[] = [];
+  // Walk through text, tracking which comments fall outside [startByte, endByte).
+  let i = 0;
+  let inString = false;
+  let stringChar = '';
+  while (i < text.length) {
+    const c = text[i];
+    if (inString) {
+      if (c === '\\' && i + 1 < text.length) {
+        i += 2;
+        continue;
+      }
+      if (c === stringChar) inString = false;
+      i++;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      inString = true;
+      stringChar = c;
+      i++;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '/') {
+      const start = i;
+      while (i < text.length && text[i] !== '\n') i++;
+      if (start < startByte || i >= endByte) {
+        result.push(text.slice(start, i));
+      }
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '*') {
+      const start = i;
+      i += 2;
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) i++;
+      i = Math.min(i + 2, text.length);
+      if (start < startByte || i >= endByte) {
+        result.push(text.slice(start, i));
+      }
+      continue;
+    }
+    i++;
+  }
+  return result;
+}
+
+function extractHashCommentsByLines(
+  text: string,
+  startLine: number,
+  endLine: number,
+): string[] {
+  const lines = text.split('\n');
+  const result: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (i >= startLine && i < endLine) continue;
+    const line = lines[i]!;
+    // Find first # that's not inside a string on this line.
+    let j = 0;
+    let inString = false;
+    let stringChar = '';
+    while (j < line.length) {
+      const c = line[j];
+      if (inString) {
+        if (c === '\\' && j + 1 < line.length) {
+          j += 2;
+          continue;
+        }
+        if (c === stringChar) inString = false;
+        j++;
+        continue;
+      }
+      if (c === '"' || c === "'") {
+        inString = true;
+        stringChar = c;
+        j++;
+        continue;
+      }
+      if (c === '#') {
+        result.push(line.slice(j));
+        break;
+      }
+      j++;
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// TOML helpers
+// ---------------------------------------------------------------------------
+
+function tomlTopLevelKeysCheck(
+  original: string,
+  written: string,
+  allowedTopLevel: string | undefined,
+): PreservationCheckResult {
+  const origDoc = smolTomlCjsModule.parse(original);
+  const writtenDoc = smolTomlCjsModule.parse(written);
+  if (typeof origDoc !== 'object' || origDoc === null) {
+    return skippedCheck('topLevelKeys');
+  }
+  if (typeof writtenDoc !== 'object' || writtenDoc === null) {
+    return {
+      name: 'topLevelKeys',
+      pass: false,
+      details: 'written TOML document is not an object',
+      skipped: false,
+    };
+  }
+  const missing: string[] = [];
+  const different: string[] = [];
+  for (const key of Object.keys(origDoc)) {
+    if (key === allowedTopLevel) continue;
+    if (!(key in writtenDoc)) {
+      missing.push(key);
+      continue;
+    }
+    if (
+      !tomlDeepEqual(
+        (origDoc as Record<string, unknown>)[key],
+        (writtenDoc as Record<string, unknown>)[key],
+      )
+    ) {
+      different.push(key);
+    }
+  }
+  if (missing.length === 0 && different.length === 0) {
+    return { name: 'topLevelKeys', pass: true, details: '', skipped: false };
+  }
+  const parts: string[] = [];
+  if (missing.length > 0) parts.push(`missing: ${missing.join(', ')}`);
+  if (different.length > 0) parts.push(`differ: ${different.join(', ')}`);
+  return {
+    name: 'topLevelKeys',
+    pass: false,
+    details: `Top-level keys outside targetPath: ${parts.join('; ')}`,
+    skipped: false,
+  };
+}
+
+function tomlKeyOrderCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+): PreservationCheckResult {
+  // smol-toml does not preserve key order. Use line-based: for each
+  // key=value line outside targetPath's line range, verify it appears
+  // in written at the same line offset. This is a weaker check than
+  // JSON's parse-based one but it's the best we can do for TOML
+  // without a serializer.
+  const origLineRange = findTomlTargetPathLineRange(original, targetPath);
+  const writtenLineRange = findTomlTargetPathLineRange(written, targetPath);
+  if (origLineRange === null) return skippedCheck('keyOrder');
+  const origLines = original.split('\n');
+  const writtenLines = written.split('\n');
+  const diffs: string[] = [];
+  const [startLine, endLine] = origLineRange;
+  for (let i = 0; i < origLines.length; i++) {
+    if (i >= startLine && i < endLine) continue;
+    const origLine = origLines[i]!.trim();
+    if (origLine === '' || origLine.startsWith('#')) continue;
+    // Find the same line in written.
+    const writtenIdx = writtenLines.findIndex((l) => l.trim() === origLine);
+    if (writtenIdx === -1) {
+      diffs.push(`line ${i + 1}: missing line ${JSON.stringify(origLine)}`);
+      continue;
+    }
+    // The line should appear at the same position outside targetPath.
+    if (writtenLineRange !== null) {
+      const [wStart, wEnd] = writtenLineRange;
+      if (writtenIdx >= wStart && writtenIdx < wEnd) continue; // inside written's targetPath, skip
+    }
+    if (writtenIdx !== i) {
+      diffs.push(`line ${i + 1}: appears at line ${writtenIdx + 1} instead`);
+    }
+  }
+  if (diffs.length === 0) {
+    return { name: 'keyOrder', pass: true, details: '', skipped: false };
+  }
+  return {
+    name: 'keyOrder',
+    pass: false,
+    details: `TOML line/key order drift outside targetPath:\n${diffs
+      .slice(0, 5)
+      .map((d) => `  - ${d}`)
+      .join('\n')}`,
+    skipped: false,
+  };
+}
+
+function tomlMcpServersCheck(
+  original: string,
+  written: string,
+  mcpKey: string,
+  touchedServer: string | undefined,
+): PreservationCheckResult {
+  const origDoc = smolTomlCjsModule.parse(original);
+  const writtenDoc = smolTomlCjsModule.parse(written);
+  if (typeof origDoc !== 'object' || origDoc === null)
+    return skippedCheck('mcpServers');
+  if (typeof writtenDoc !== 'object' || writtenDoc === null)
+    return skippedCheck('mcpServers');
+  const origMcp = (origDoc as Record<string, unknown>)[mcpKey];
+  const writtenMcp = (writtenDoc as Record<string, unknown>)[mcpKey];
+  if (origMcp === undefined) return skippedCheck('mcpServers');
+  if (typeof origMcp !== 'object' || origMcp === null)
+    return skippedCheck('mcpServers');
+  const writtenServers =
+    writtenMcp !== undefined &&
+    typeof writtenMcp === 'object' &&
+    writtenMcp !== null
+      ? (writtenMcp as Record<string, unknown>)
+      : {};
+  const missing: string[] = [];
+  const different: string[] = [];
+  for (const server of Object.keys(origMcp)) {
+    if (server === touchedServer) continue;
+    if (!(server in writtenServers)) {
+      missing.push(server);
+      continue;
+    }
+    if (
+      !tomlDeepEqual(
+        (origMcp as Record<string, unknown>)[server],
+        writtenServers[server],
+      )
+    ) {
+      different.push(server);
+    }
+  }
+  if (missing.length === 0 && different.length === 0) {
+    return { name: 'mcpServers', pass: true, details: '', skipped: false };
+  }
+  const parts: string[] = [];
+  if (missing.length > 0) parts.push(`missing: ${missing.join(', ')}`);
+  if (different.length > 0) parts.push(`differ: ${different.join(', ')}`);
+  return {
+    name: 'mcpServers',
+    pass: false,
+    details: `MCP servers outside targetPath: ${parts.join('; ')}`,
+    skipped: false,
+  };
+}
+
+function tomlFormattingCheck(
+  original: string,
+  written: string,
+  targetPath: TargetPath,
+): PreservationCheckResult {
+  const origLineRange = findTomlTargetPathLineRange(original, targetPath);
+  const origLines = original.split('\n');
+  const writtenLines = written.split('\n');
+  const diffs: string[] = [];
+  for (let i = 0; i < Math.min(origLines.length, writtenLines.length); i++) {
+    if (origLineRange !== null) {
+      const [s, e] = origLineRange;
+      if (i >= s && i < e) continue;
+    }
+    const origLeading = origLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
+    const writtenLeading = writtenLines[i]!.match(/^[ \t]*/)?.[0] ?? '';
+    if (origLeading !== writtenLeading) {
+      diffs.push(
+        `line ${i + 1}: leading whitespace ${JSON.stringify(origLeading)} vs ${JSON.stringify(writtenLeading)}`,
+      );
+    }
+  }
+  if (original.endsWith('\n') !== written.endsWith('\n')) {
+    diffs.push(
+      `trailing newline: original=${original.endsWith('\n')}, written=${written.endsWith('\n')}`,
+    );
+  }
+  if (diffs.length === 0) {
+    return { name: 'formatting', pass: true, details: '', skipped: false };
+  }
+  return {
+    name: 'formatting',
+    pass: false,
+    details: `Formatting drift outside targetPath:\n${diffs
+      .slice(0, 5)
+      .map((d) => `  - ${d}`)
+      .join('\n')}`,
+    skipped: false,
+  };
+}
+
+function tomlDeepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!tomlDeepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const ak = Object.keys(a as object);
+    const bk = Object.keys(b as object);
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) {
+      if (
+        !tomlDeepEqual(
+          (a as Record<string, unknown>)[k],
+          (b as Record<string, unknown>)[k],
+        )
+      )
+        return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Find the line range `[startLine, endLine)` of the targetPath
+ * subtree in a TOML document. For `['mcp_servers']`, returns the
+ * range of `[mcp_servers.*]` subtables. For `['mcp_servers', 'filesystem']`,
+ * returns the range of `[mcp_servers.filesystem]`.
+ */
+function findTomlTargetPathLineRange(
+  text: string,
+  targetPath: TargetPath,
+): readonly [number, number] | null {
+  if (targetPath.length === 0) return null;
+  const lines = text.split('\n');
+  if (targetPath.length === 1) {
+    const parent = targetPath[0]!;
+    // Find [parent] or [parent.*] headers
+    let startLine = -1;
+    let endLine = lines.length;
+    const explicitRe = new RegExp(`^\\[${escapeRegExp(parent)}\\]$`);
+    const subRe = new RegExp(`^\\[${escapeRegExp(parent)}\\.[^\\]]+\\]$`);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      if (startLine === -1 && (explicitRe.test(line) || subRe.test(line))) {
+        startLine = i;
+        continue;
+      }
+      if (
+        startLine !== -1 &&
+        line.trim().startsWith('[') &&
+        !subRe.test(line) &&
+        !explicitRe.test(line)
+      ) {
+        endLine = i;
+        break;
+      }
+    }
+    if (startLine === -1) return null;
+    return [startLine, endLine] as const;
+  }
+  if (targetPath.length === 2) {
+    const parent = targetPath[0]!;
+    const child = targetPath[1]!;
+    const headerRe = new RegExp(
+      `^\\[${escapeRegExp(parent)}\\.${escapeRegExp(child)}\\]$`,
+    );
+    let startLine = -1;
+    let endLine = lines.length;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      if (startLine === -1 && headerRe.test(line)) {
+        startLine = i;
+        continue;
+      }
+      if (startLine !== -1 && line.trim().startsWith('[')) {
+        endLine = i;
+        break;
+      }
+    }
+    if (startLine === -1) return null;
+    return [startLine, endLine] as const;
+  }
+  return null;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -204,8 +204,14 @@ export function rawBytesCheck(
 ): PreservationCheckResult {
   if (targetPath.length === 0) return skippedCheck('rawBytes');
   if (format === 'json' || format === 'jsonc') {
-    const range = findJsonTargetPathRange(original, targetPath);
-    if (range === null) {
+    // Compute the target range INDEPENDENTLY in both original and
+    // written. A writer that adds fields to the target server (e.g. a
+    // new "env" entry) changes the target's length; using the original
+    // range for the written side would then slice into the wrong
+    // content and falsely fire.
+    const origRange = findJsonTargetPathRange(original, targetPath);
+    const writtenRange = findJsonTargetPathRange(written, targetPath);
+    if (origRange === null) {
       return {
         name: 'rawBytes',
         pass: false,
@@ -213,9 +219,19 @@ export function rawBytesCheck(
         skipped: false,
       };
     }
-    const [start, end] = range;
-    const origOutside = original.slice(0, start) + original.slice(end);
-    const writtenOutside = written.slice(0, start) + written.slice(end);
+    if (writtenRange === null) {
+      return {
+        name: 'rawBytes',
+        pass: false,
+        details: `targetPath ${JSON.stringify(targetPath)} not found in written document — writer removed the target subtree entirely`,
+        skipped: false,
+      };
+    }
+    const [origStart, origEnd] = origRange;
+    const [writtenStart, writtenEnd] = writtenRange;
+    const origOutside = original.slice(0, origStart) + original.slice(origEnd);
+    const writtenOutside =
+      written.slice(0, writtenStart) + written.slice(writtenEnd);
     if (origOutside === writtenOutside) {
       return { name: 'rawBytes', pass: true, details: '', skipped: false };
     }
@@ -223,14 +239,16 @@ export function rawBytesCheck(
       'rawBytes',
       origOutside,
       writtenOutside,
-      start,
-      end,
+      origStart,
+      origEnd,
       format,
     );
   }
   if (format === 'toml') {
-    const lineRange = findTomlTargetPathLineRange(original, targetPath);
-    if (lineRange === null) {
+    // Same independence requirement for TOML line ranges.
+    const origLineRange = findTomlTargetPathLineRange(original, targetPath);
+    const writtenLineRange = findTomlTargetPathLineRange(written, targetPath);
+    if (origLineRange === null) {
       return {
         name: 'rawBytes',
         pass: false,
@@ -238,7 +256,16 @@ export function rawBytesCheck(
         skipped: false,
       };
     }
-    const [startLine, endLine] = lineRange;
+    if (writtenLineRange === null) {
+      return {
+        name: 'rawBytes',
+        pass: false,
+        details: `targetPath ${JSON.stringify(targetPath)} not found in written TOML document — writer removed the target subtree entirely`,
+        skipped: false,
+      };
+    }
+    const [startLine, endLine] = origLineRange;
+    const [writtenStartLine, writtenEndLine] = writtenLineRange;
     const origLines = original.split('\n');
     const writtenLines = written.split('\n');
     const origOutside = [
@@ -246,8 +273,8 @@ export function rawBytesCheck(
       ...origLines.slice(endLine),
     ].join('\n');
     const writtenOutside = [
-      ...writtenLines.slice(0, startLine),
-      ...writtenLines.slice(endLine),
+      ...writtenLines.slice(0, writtenStartLine),
+      ...writtenLines.slice(writtenEndLine),
     ].join('\n');
     if (origOutside === writtenOutside) {
       return { name: 'rawBytes', pass: true, details: '', skipped: false };

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -13,6 +13,8 @@
  */
 import {
   parse as parseJsonc,
+  parseTree,
+  type Node,
   type ParseError,
 } from 'jsonc-parser/lib/esm/main.js';
 import { createRequire } from 'node:module';
@@ -344,126 +346,61 @@ function parseJsoncStrict(text: string): unknown {
 }
 
 /**
- * Find a top-level JSON/JSONC property's byte range `[start, end)`.
- * The range covers the property's key (including opening quote) and
- * its value. If the property is followed by a comma, the comma is
- * included. Returns `null` if the property is not present.
- */
-function findJsonTopLevelRange(
-  text: string,
-  key: string,
-): readonly [number, number] | null {
-  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const keyPattern = new RegExp(`"${escaped}"\\s*:`, 'g');
-  const match = keyPattern.exec(text);
-  if (match === null) return null;
-  const keyStart = match.index;
-  let i = match.index + match[0].length;
-  while (i < text.length && (text[i] === ' ' || text[i] === '\t')) i++;
-  if (i >= text.length) return null;
-  const valueEnd = scanJsonValueEnd(text, i);
-  if (valueEnd === -1) return null;
-  let j = valueEnd;
-  while (
-    j < text.length &&
-    (text[j] === ' ' ||
-      text[j] === '\t' ||
-      text[j] === '\n' ||
-      text[j] === '\r')
-  ) {
-    j++;
-  }
-  let endOffset = valueEnd;
-  if (text[j] === ',') endOffset = j + 1;
-  return [keyStart, endOffset] as const;
-}
-
-function scanJsonValueEnd(text: string, start: number): number {
-  if (start >= text.length) return -1;
-  const c = text[start];
-  if (c === '"' || c === "'") {
-    let i = start + 1;
-    while (i < text.length) {
-      if (text[i] === '\\') {
-        i += 2;
-        continue;
-      }
-      if (text[i] === c) return i + 1;
-      i++;
-    }
-    return -1;
-  }
-  if (c === '{' || c === '[') {
-    const open = c;
-    const close = c === '{' ? '}' : ']';
-    let depth = 1;
-    let i = start + 1;
-    let inString = false;
-    let stringChar = '';
-    while (i < text.length && depth > 0) {
-      const ch = text[i];
-      if (inString) {
-        if (ch === '\\') {
-          i += 2;
-          continue;
-        }
-        if (ch === stringChar) inString = false;
-        i++;
-        continue;
-      }
-      if (ch === '"' || ch === "'") {
-        inString = true;
-        stringChar = ch;
-        i++;
-        continue;
-      }
-      if (ch === open) depth++;
-      else if (ch === close) depth--;
-      i++;
-    }
-    return depth === 0 ? i : -1;
-  }
-  let i = start;
-  while (i < text.length) {
-    const ch = text[i];
-    if (
-      ch === ' ' ||
-      ch === '\t' ||
-      ch === '\n' ||
-      ch === '\r' ||
-      ch === ',' ||
-      ch === '}' ||
-      ch === ']'
-    )
-      return i;
-    i++;
-  }
-  return i;
-}
-
-/**
  * Find the byte range of the targetPath subtree in a JSON/JSONC
  * document. Returns `[start, end)` where the range covers the entire
- * subtree including its enclosing braces. Returns `null` if the
- * path doesn't exist.
+ * subtree (the final value node) plus a trailing comma if present.
+ * Returns `null` if the path doesn't exist.
+ *
+ * Walks the AST once (no re-parsing of sliced text). This is correct
+ * even when an unrelated earlier object contains a nested key whose
+ * name collides with `targetPath[0]` (the regex-first-match bug), and
+ * it doesn't depend on a brace-counting scanner that would miscount
+ * braces inside comments.
  */
 function findJsonTargetPathRange(
   text: string,
   targetPath: TargetPath,
 ): readonly [number, number] | null {
   if (targetPath.length === 0) return null;
-  const initialRange = findJsonTopLevelRange(text, targetPath[0]!);
-  if (initialRange === null) return null;
-  let currentRange: readonly [number, number] = initialRange;
-  for (let i = 1; i < targetPath.length; i++) {
-    const key = targetPath[i]!;
-    const [start, end] = currentRange;
-    const inner = text.slice(start, end);
-    const innerRange = findJsonTopLevelRange(inner, key);
-    if (innerRange === null) return null;
-    currentRange = [start + innerRange[0], start + innerRange[1]] as const;
+  const errors: ParseError[] = [];
+  const root = parseTree(text, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  if (root === undefined) return null;
+  if (errors.length > 0) return null;
+  if (root.type !== 'object') return null;
+  let currentNode: Node = root;
+  for (const segment of targetPath) {
+    if (currentNode.type !== 'object' || currentNode.children === undefined) {
+      return null;
+    }
+    let found: Node | undefined;
+    for (const property of currentNode.children) {
+      if (property.type !== 'property' || property.children === undefined) {
+        continue;
+      }
+      const keyNode = property.children[0];
+      if (keyNode !== undefined && keyNode.value === segment) {
+        found = property;
+        break;
+      }
+    }
+    if (found === undefined) return null;
+    // Descend into the property's value node for the next segment.
+    if (found.children === undefined) return null;
+    const valueNode = found.children[1];
+    if (valueNode === undefined) return null;
+    currentNode = valueNode;
   }
-  return currentRange;
+  // The final node is the target value. Compute its byte range plus
+  // any trailing comma.
+  let endOffset = currentNode.offset + currentNode.length;
+  while (endOffset < text.length && /\s/.test(text[endOffset]!)) {
+    endOffset++;
+  }
+  if (text[endOffset] === ',') endOffset++;
+  return [currentNode.offset, endOffset] as const;
 }
 
 function jsonTopLevelKeysCheck(

--- a/packages/agents/src/writer-preservation/contract.spec.ts
+++ b/packages/agents/src/writer-preservation/contract.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * Contract tests for the writer preservation harness.
+ *
+ * These tests use the intentionally-broken reference writers from
+ * `__reference-writers__.ts` to prove the harness catches real
+ * writer-shaped regressions. Each reference writer is a small
+ * input→output transform that mimics what a future per-agent writer
+ * might accidentally do (strip comments, reorder keys, delete
+ * unrelated keys, drift whitespace, break idempotency, etc.).
+ *
+ * The contract: for each reference writer, the harness must fire the
+ * expected preservation check. This proves the harness works against
+ * real writer-shaped code, not just raw byte-mutator outputs.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { runPreservationChecks } from './run.js';
+import {
+  commentStrippingWriter,
+  keyReorderingWriter,
+  nonIdempotentWriter,
+  preservingWriter,
+  trailingNewlineDeletingWriter,
+  unrelatedKeyDeletingWriter,
+  unrelatedServerDeletingWriter,
+  whitespaceDriftingWriter,
+} from './__reference-writers__.js';
+import { CLAUDE_CODE_FIXTURE, CODEX_FIXTURE } from './fixtures.js';
+
+const claudeCode = CLAUDE_CODE_FIXTURE;
+const codex = CODEX_FIXTURE;
+
+const JSONC_TARGET: readonly string[] = ['mcpServers', 'filesystem'];
+const TOML_TARGET: readonly string[] = ['mcp_servers', 'filesystem'];
+
+interface ScenarioInput {
+  readonly original: string;
+  readonly format: 'json' | 'jsonc' | 'toml' | 'yaml';
+  readonly targetPath: readonly string[];
+}
+
+function applyAndCheck(
+  scenario: ScenarioInput,
+  writer: (
+    original: string,
+    format: 'json' | 'jsonc' | 'toml' | 'yaml',
+    targetPath: readonly string[],
+  ) => string,
+  applyWriterTwice = false,
+): ReturnType<typeof runPreservationChecks> {
+  const written = writer(
+    scenario.original,
+    scenario.format,
+    scenario.targetPath,
+  );
+  const rewritten = applyWriterTwice
+    ? writer(written, scenario.format, scenario.targetPath)
+    : undefined;
+  return runPreservationChecks({
+    format: scenario.format,
+    original: scenario.original,
+    written,
+    rewritten,
+    targetPath: scenario.targetPath,
+  });
+}
+
+function expectCheckFails(
+  report: ReturnType<typeof runPreservationChecks>,
+  name: string,
+): void {
+  const c = report.checks.find((x) => x.name === name);
+  expect(c, `check ${name} missing`).toBeDefined();
+  expect(c!.pass, `check ${name} should fail: ${c!.details}`).toBe(false);
+}
+
+function expectCheckPasses(
+  report: ReturnType<typeof runPreservationChecks>,
+  name: string,
+): void {
+  const c = report.checks.find((x) => x.name === name);
+  expect(c, `check ${name} missing`).toBeDefined();
+  expect(c!.pass, `check ${name} should pass: ${c!.details}`).toBe(true);
+}
+
+describe('contract — preservingWriter passes every check (jsonc)', () => {
+  it('jsonc (claude-code): all checks pass', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      preservingWriter,
+    );
+    expect(report.allPassed).toBe(true);
+  });
+});
+
+describe('contract — commentStrippingWriter fires comments', () => {
+  it('jsonc (claude-code): comments check fires', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      commentStrippingWriter,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'comments');
+  });
+
+  it('toml (codex): comments check fires', () => {
+    const report = applyAndCheck(
+      { original: codex, format: 'toml', targetPath: TOML_TARGET },
+      commentStrippingWriter,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'comments');
+  });
+});
+
+describe('contract — keyReorderingWriter fires keyOrder', () => {
+  it('jsonc (claude-code): keyOrder check fires', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      keyReorderingWriter,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'keyOrder');
+  });
+});
+
+describe('contract — unrelatedKeyDeletingWriter fires topLevelKeys', () => {
+  it('jsonc (claude-code): topLevelKeys check fires', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      unrelatedKeyDeletingWriter,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'topLevelKeys');
+  });
+
+  it('toml (codex): topLevelKeys check fires', () => {
+    const report = applyAndCheck(
+      { original: codex, format: 'toml', targetPath: TOML_TARGET },
+      unrelatedKeyDeletingWriter,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'topLevelKeys');
+  });
+});
+
+describe('contract — unrelatedServerDeletingWriter fires mcpServers', () => {
+  it('jsonc (claude-code): mcpServers check fires', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      unrelatedServerDeletingWriter,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'mcpServers');
+  });
+
+  it('toml (codex): mcpServers check fires', () => {
+    const report = applyAndCheck(
+      { original: codex, format: 'toml', targetPath: TOML_TARGET },
+      unrelatedServerDeletingWriter,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'mcpServers');
+  });
+});
+
+describe('contract — whitespaceDriftingWriter fires formatting', () => {
+  it('jsonc (claude-code): formatting check fires', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      whitespaceDriftingWriter,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'formatting');
+  });
+});
+
+describe('contract — trailingNewlineDeletingWriter fires formatting', () => {
+  it('jsonc (claude-code): formatting check fires', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      trailingNewlineDeletingWriter,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'formatting');
+  });
+});
+
+describe('contract — nonIdempotentWriter fires idempotency', () => {
+  it('jsonc (claude-code): idempotency check fires on second apply', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      nonIdempotentWriter,
+      /* applyWriterTwice */ true,
+    );
+    expect(report.allPassed).toBe(false);
+    expectCheckFails(report, 'idempotency');
+  });
+
+  it('jsonc (claude-code): single apply + rewritten=undefined skips idempotency', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      nonIdempotentWriter,
+      /* applyWriterTwice */ false,
+    );
+    // The single apply didn't break anything outside targetPath (the
+    // appended newline is at the very end, outside any target subtree).
+    // So all checks should still pass; idempotency is skipped.
+    expect(report.allPassed).toBe(true);
+    const idem = report.checks.find((c) => c.name === 'idempotency');
+    expect(idem!.skipped).toBe(true);
+  });
+});
+
+describe('contract — preservingWriter passes idempotency on second apply', () => {
+  it('jsonc (claude-code): idempotency passes when apply is a no-op', () => {
+    const report = applyAndCheck(
+      { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
+      preservingWriter,
+      /* applyWriterTwice */ true,
+    );
+    expectCheckPasses(report, 'idempotency');
+    expect(report.allPassed).toBe(true);
+  });
+});

--- a/packages/agents/src/writer-preservation/contract.spec.ts
+++ b/packages/agents/src/writer-preservation/contract.spec.ts
@@ -12,9 +12,6 @@
  * expected preservation check. This proves the harness works against
  * real writer-shaped code, not just raw byte-mutator outputs.
  */
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -59,7 +56,7 @@ function applyAndCheck(
   );
   const rewritten = applyWriterTwice
     ? writer(written, scenario.format, scenario.targetPath)
-    : undefined;
+    : written;
   return runPreservationChecks({
     format: scenario.format,
     original: scenario.original,
@@ -201,18 +198,23 @@ describe('contract — nonIdempotentWriter fires idempotency', () => {
     expectCheckFails(report, 'idempotency');
   });
 
-  it('jsonc (claude-code): single apply + rewritten=undefined skips idempotency', () => {
+  it('jsonc (claude-code): single apply + rewritten=written trivially passes idempotency, but rawBytes fires on the appended newline', () => {
+    // nonIdempotentWriter appends '\n' to the output. The newline is at
+    // the very end, outside any target subtree, so:
+    //   - rawBytes fires (the appended byte is outside targetPath)
+    //   - idempotency trivially holds (rewritten === written)
+    //   - allPassed is false because rawBytes caught a real regression
     const report = applyAndCheck(
       { original: claudeCode, format: 'jsonc', targetPath: JSONC_TARGET },
       nonIdempotentWriter,
       /* applyWriterTwice */ false,
     );
-    // The single apply didn't break anything outside targetPath (the
-    // appended newline is at the very end, outside any target subtree).
-    // So all checks should still pass; idempotency is skipped.
-    expect(report.allPassed).toBe(true);
+    expect(report.allPassed).toBe(false);
     const idem = report.checks.find((c) => c.name === 'idempotency');
-    expect(idem!.skipped).toBe(true);
+    expect(idem!.skipped).toBe(false);
+    expect(idem!.pass).toBe(true);
+    const raw = report.checks.find((c) => c.name === 'rawBytes');
+    expect(raw!.pass).toBe(false);
   });
 });
 

--- a/packages/agents/src/writer-preservation/fixtures.ts
+++ b/packages/agents/src/writer-preservation/fixtures.ts
@@ -1,0 +1,180 @@
+/**
+ * Inline fixture strings for the writer preservation harness.
+ *
+ * These are exported as constants rather than loaded from disk so the
+ * spec files compile cleanly under CommonJS (which forbids
+ * `import.meta`). The contents are byte-identical to the files in
+ * `fixtures/`; that directory is kept for documentation and for any
+ * downstream tooling that wants to read the raw bytes, but the test
+ * suite uses these constants to avoid the ESM-only `import.meta.url`
+ * API.
+ *
+ * NOTE: template-literal `\${` sequences are intentional. The fixture
+ * payloads contain literal `${VAR}` strings (e.g. shell-style env
+ * forwarders in MCP server configs); escaping with a leading
+ * backslash keeps them as literal text instead of being evaluated as
+ * template expressions.
+ */
+
+export const OPENCODE_FIXTURE = `{
+  "$schema": "https://opencode.ai/config.json",
+  "theme": "system",
+  "provider": {
+    "default": "anthropic"
+  },
+  // MCP servers (canonical: "mcp" top-level key)
+  "mcp": {
+    "filesystem": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/user/projects"
+      ],
+      "environment": {
+        "LOG_LEVEL": "info"
+      },
+      "enabled": true
+    },
+    /* second server, unrelated to the touch target */
+    "context7": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ],
+      "environment": {
+        "CONTEXT7_API_KEY": "\${CONTEXT7_API_KEY}"
+      },
+      "enabled": true,
+      "timeout": 30
+    },
+    "remote-bridge": {
+      "type": "remote",
+      "url": "https://mcp.example.com/bridge",
+      "headers": {
+        "Authorization": "Bearer \${MCP_BRIDGE_TOKEN}"
+      },
+      "enabled": true
+    }
+  }
+}
+`;
+
+export const CLAUDE_CODE_FIXTURE = `{
+  // ~/.claude.json — Claude Code MCP config
+  // Top-level keys are general Claude Code state, not MCP config.
+  "numStartups": 42,
+  "autoUpdaterStatus": "enabled",
+  "userID": "abc123def456",
+  "hasCompletedOnboarding": true,
+  "lastOnboardingVersion": "1.0.17",
+  /* MCP server inventory (canonical top-level key: "mcpServers") */
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/user/projects"
+      ],
+      "env": {
+        "LOG_LEVEL": "info"
+      }
+    },
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ],
+      "env": {
+        // Forward from the parent shell.
+        "CONTEXT7_API_KEY": "\${CONTEXT7_API_KEY}"
+      }
+    },
+    "remote-bridge": {
+      "url": "https://mcp.example.com/bridge",
+      "headers": {
+        "Authorization": "Bearer \${MCP_BRIDGE_TOKEN}"
+      }
+    }
+  }
+}
+`;
+
+export const COPILOT_CLI_FIXTURE = `{
+  // ~/.copilot/mcp-config.json — GitHub Copilot CLI MCP config
+  "$schema": "https://github.com/copilot-cli/mcp-config.schema.json",
+  "version": 1,
+  "lastUpdated": "2026-06-01T12:00:00Z",
+  /* MCP server inventory (canonical top-level key: "mcpServers") */
+  "mcpServers": {
+    "filesystem": {
+      "type": "local",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/user/projects"
+      ],
+      "tools": ["read_file", "write_file", "list_directory"]
+    },
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ],
+      "env": {
+        // Forward from the parent shell.
+        "CONTEXT7_API_KEY": "\${CONTEXT7_API_KEY}"
+      },
+      "tools": ["get-library-docs", "resolve-library-id"]
+    },
+    "remote-bridge": {
+      "type": "http",
+      "url": "https://mcp.example.com/bridge",
+      "headers": {
+        "Authorization": "Bearer \${MCP_BRIDGE_TOKEN}"
+      },
+      "tools": ["*"]
+    }
+  }
+}
+`;
+
+export const CODEX_FIXTURE = `# ~/.codex/config.toml — OpenAI Codex config
+# Top-level keys are general Codex state, not MCP config.
+model = "gpt-5"
+model_provider = "openai"
+approval_mode = "on-request"
+
+[sandbox]
+mode = "workspace-write"
+network_access = false
+
+# MCP server inventory (canonical top-level key: "mcp_servers")
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/projects"]
+startup_timeout_sec = 30
+
+# A second server, unrelated to the touch target.
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@latest"]
+startup_timeout_sec = 15
+tool_timeout_sec = 60
+
+# Forward from the parent shell.
+[mcp_servers.context7.env]
+CONTEXT7_API_KEY = "\${CONTEXT7_API_KEY}"
+
+[mcp_servers.remote-bridge]
+url = "https://mcp.example.com/bridge"
+bearer_token_env_var = "MCP_BRIDGE_TOKEN"
+`;

--- a/packages/agents/src/writer-preservation/fixtures/claude-code.jsonc
+++ b/packages/agents/src/writer-preservation/fixtures/claude-code.jsonc
@@ -1,0 +1,37 @@
+{
+  // ~/.claude.json — Claude Code MCP config
+  // Top-level keys are general Claude Code state, not MCP config.
+  "numStartups": 42,
+  "autoUpdaterStatus": "enabled",
+  "userID": "abc123def456",
+  "hasCompletedOnboarding": true,
+  "lastOnboardingVersion": "1.0.17",
+  /* MCP server inventory (canonical top-level key: "mcpServers") */
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/user/projects",
+      ],
+      "env": {
+        "LOG_LEVEL": "info",
+      },
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"],
+      "env": {
+        // Forward from the parent shell.
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}",
+      },
+    },
+    "remote-bridge": {
+      "url": "https://mcp.example.com/bridge",
+      "headers": {
+        "Authorization": "Bearer ${MCP_BRIDGE_TOKEN}",
+      },
+    },
+  },
+}

--- a/packages/agents/src/writer-preservation/fixtures/codex.toml
+++ b/packages/agents/src/writer-preservation/fixtures/codex.toml
@@ -1,0 +1,30 @@
+# ~/.codex/config.toml — OpenAI Codex config
+# Top-level keys are general Codex state, not MCP config.
+model = "gpt-5"
+model_provider = "openai"
+approval_mode = "on-request"
+
+[sandbox]
+mode = "workspace-write"
+network_access = false
+
+# MCP server inventory (canonical top-level key: "mcp_servers")
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/projects"]
+startup_timeout_sec = 30
+
+# A second server, unrelated to the touch target.
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@latest"]
+startup_timeout_sec = 15
+tool_timeout_sec = 60
+
+# Forward from the parent shell.
+[mcp_servers.context7.env]
+CONTEXT7_API_KEY = "${CONTEXT7_API_KEY}"
+
+[mcp_servers.remote-bridge]
+url = "https://mcp.example.com/bridge"
+bearer_token_env_var = "MCP_BRIDGE_TOKEN"

--- a/packages/agents/src/writer-preservation/fixtures/copilot-cli.jsonc
+++ b/packages/agents/src/writer-preservation/fixtures/copilot-cli.jsonc
@@ -1,0 +1,37 @@
+{
+  // ~/.copilot/mcp-config.json — GitHub Copilot CLI MCP config
+  "$schema": "https://github.com/copilot-cli/mcp-config.schema.json",
+  "version": 1,
+  "lastUpdated": "2026-06-01T12:00:00Z",
+  /* MCP server inventory (canonical top-level key: "mcpServers") */
+  "mcpServers": {
+    "filesystem": {
+      "type": "local",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/user/projects",
+      ],
+      "tools": ["read_file", "write_file", "list_directory"],
+    },
+    "context7": {
+      "type": "local",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"],
+      "env": {
+        // Forward from the parent shell.
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}",
+      },
+      "tools": ["get-library-docs", "resolve-library-id"],
+    },
+    "remote-bridge": {
+      "type": "http",
+      "url": "https://mcp.example.com/bridge",
+      "headers": {
+        "Authorization": "Bearer ${MCP_BRIDGE_TOKEN}",
+      },
+      "tools": ["*"],
+    },
+  },
+}

--- a/packages/agents/src/writer-preservation/fixtures/opencode.jsonc
+++ b/packages/agents/src/writer-preservation/fixtures/opencode.jsonc
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "theme": "system",
+  "provider": {
+    "default": "anthropic",
+  },
+  // MCP servers (canonical: "mcp" top-level key)
+  "mcp": {
+    "filesystem": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/user/projects",
+      ],
+      "environment": {
+        "LOG_LEVEL": "info",
+      },
+      "enabled": true,
+    },
+    /* second server, unrelated to the touch target */
+    "context7": {
+      "type": "local",
+      "command": ["npx", "-y", "@upstash/context7-mcp@latest"],
+      "environment": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}",
+      },
+      "enabled": true,
+      "timeout": 30,
+    },
+    "remote-bridge": {
+      "type": "remote",
+      "url": "https://mcp.example.com/bridge",
+      "headers": {
+        "Authorization": "Bearer ${MCP_BRIDGE_TOKEN}",
+      },
+      "enabled": true,
+    },
+  },
+}

--- a/packages/agents/src/writer-preservation/index.ts
+++ b/packages/agents/src/writer-preservation/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Public exports for the writer preservation harness.
+ *
+ * The harness is the E1 safety gate: every future per-agent MCP
+ * writer (E2 OpenCode, E3 Claude Code + Copilot CLI, E4 remaining
+ * agents) must pass `runPreservationChecks` with byte-for-byte
+ * preservation outside the targetPath subtree. No production writer
+ * exists yet; the harness is the contract future writers are held to.
+ *
+ * The test helpers in `byte-mutators.ts` are NOT exported from this
+ * package surface — they are internal scaffolding for the harness
+ * self-tests. Callers of the harness should import only from this
+ * index.
+ */
+export type {
+  PreservationCheckInput,
+  PreservationCheckName,
+  PreservationCheckResult,
+  PreservationReport,
+  TargetPath,
+} from './types.js';
+export { checksForFormat, runPreservationChecks } from './run.js';

--- a/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
+++ b/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for the writer preservation harness.
+ *
+ * These tests are the E1 RED→GREEN contract. Each scenario proves a
+ * specific preservation property:
+ *
+ *   S1  identity write passes all checks (every format)
+ *   S2  comment loss is detected (jsonc, toml)
+ *   S3  key reorder outside targetPath is detected
+ *   S4  unrelated top-level key deletion is detected
+ *   S5  unrelated MCP server deletion is detected
+ *   S6  whitespace drift is detected
+ *   S7  idempotency check fires when second apply drifts
+ *   S8  targeted key reorder inside targetPath is NOT flagged
+ *   S9  non-target-path comment edits fail
+ *   S10 all four formats are covered
+ *
+ * The byte-mutators from `byte-mutators.ts` produce the
+ * known-broken inputs.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendString,
+  deleteMcpServer,
+  deleteTopLevelKey,
+  deleteTrailingNewline,
+  driftIndentation,
+  stripComments,
+  swapMcpServers,
+  swapTopLevelKeys,
+} from './byte-mutators.js';
+import { runPreservationChecks } from './run.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(__dirname, 'fixtures');
+
+function loadFixture(name: string): string {
+  return readFileSync(join(FIXTURE_DIR, name), 'utf8');
+}
+
+const opencode = loadFixture('opencode.jsonc');
+const claudeCode = loadFixture('claude-code.jsonc');
+const copilotCli = loadFixture('copilot-cli.jsonc');
+const codex = loadFixture('codex.toml');
+
+/** Convenience: run the harness with just original/written. */
+function check(
+  format: 'json' | 'jsonc' | 'toml' | 'yaml',
+  original: string,
+  written: string,
+  targetPath: readonly string[],
+): ReturnType<typeof runPreservationChecks> {
+  return runPreservationChecks({ format, original, written, targetPath });
+}
+
+/** Find a check by name in a report. */
+function findCheck(
+  report: ReturnType<typeof runPreservationChecks>,
+  name: string,
+) {
+  const c = report.checks.find((x) => x.name === name);
+  if (c === undefined) throw new Error(`check ${name} missing`);
+  return c;
+}
+
+describe('S1 — identity write passes all checks', () => {
+  it('jsonc (claude-code): identity write passes', () => {
+    const report = check('jsonc', claudeCode, claudeCode, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(true);
+    for (const c of report.checks) {
+      expect(c.pass, `check ${c.name}: ${c.details}`).toBe(true);
+    }
+  });
+
+  it('jsonc (opencode): identity write passes', () => {
+    const report = check('jsonc', opencode, opencode, ['mcp', 'filesystem']);
+    expect(report.allPassed).toBe(true);
+    for (const c of report.checks) {
+      expect(c.pass, `check ${c.name}: ${c.details}`).toBe(true);
+    }
+  });
+
+  it('jsonc (copilot-cli): identity write passes', () => {
+    const report = check('jsonc', copilotCli, copilotCli, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(true);
+    for (const c of report.checks) {
+      expect(c.pass, `check ${c.name}: ${c.details}`).toBe(true);
+    }
+  });
+
+  it('toml (codex): identity write passes', () => {
+    const report = check('toml', codex, codex, ['mcp_servers', 'filesystem']);
+    expect(report.allPassed).toBe(true);
+    for (const c of report.checks) {
+      expect(c.pass, `check ${c.name}: ${c.details}`).toBe(true);
+    }
+  });
+});
+
+describe('S2 — comment loss is detected', () => {
+  it('jsonc: stripping // comments fires the comments check', () => {
+    const written = stripComments(claudeCode, 'jsonc');
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'comments').pass).toBe(false);
+  });
+
+  it('jsonc: stripping /* block */ comments fires the comments check', () => {
+    // claudeCode has a /* MCP server inventory */ block comment.
+    const written = stripComments(claudeCode, 'jsonc');
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(findCheck(report, 'comments').pass).toBe(false);
+  });
+
+  it('toml: stripping # comments fires the comments check', () => {
+    const written = stripComments(codex, 'toml');
+    const report = check('toml', codex, written, ['mcp_servers', 'filesystem']);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'comments').pass).toBe(false);
+  });
+
+  it('json: comments check is not in the report (JSON has no comments)', () => {
+    const report = check('json', claudeCode, claudeCode, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    // For plain JSON the comments check is not applicable and is not
+    // included in the report. JSONC/TOML/YAML do include it (skipped).
+    expect(report.checks.find((c) => c.name === 'comments')).toBeUndefined();
+  });
+});
+
+describe('S3 — key reorder outside targetPath is detected', () => {
+  it('jsonc: swapping numStartups and autoUpdaterStatus fires keyOrder', () => {
+    const written = swapTopLevelKeys(
+      claudeCode,
+      'jsonc',
+      'numStartups',
+      'autoUpdaterStatus',
+    );
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'keyOrder').pass).toBe(false);
+  });
+
+  it('jsonc: swapping two unrelated MCP servers fires keyOrder', () => {
+    const written = swapMcpServers(
+      claudeCode,
+      'jsonc',
+      'mcpServers',
+      'filesystem',
+      'context7',
+    );
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'keyOrder').pass).toBe(false);
+  });
+});
+
+describe('S4 — unrelated top-level key deletion is detected', () => {
+  it('jsonc: deleting numStartups fires topLevelKeys', () => {
+    const written = deleteTopLevelKey(claudeCode, 'jsonc', 'numStartups');
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'topLevelKeys').pass).toBe(false);
+  });
+
+  it('toml: deleting the model scalar fires topLevelKeys', () => {
+    const written = deleteTopLevelKey(codex, 'toml', 'model');
+    const report = check('toml', codex, written, ['mcp_servers', 'filesystem']);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'topLevelKeys').pass).toBe(false);
+  });
+
+  it('toml: deleting the mcp_servers implicit table fires mcpServers (context7 deleted)', () => {
+    // targetPath[0] = 'mcp_servers' is the allowed top-level key, so
+    // topLevelKeys excludes it from the check. But deleting the whole
+    // mcp_servers subtree also deletes context7, which is OUTSIDE
+    // targetPath[1] = 'filesystem'. The mcpServers check fires.
+    const written = deleteTopLevelKey(codex, 'toml', 'mcp_servers');
+    const report = check('toml', codex, written, ['mcp_servers', 'filesystem']);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'mcpServers').pass).toBe(false);
+  });
+});
+
+describe('S5 — unrelated MCP server deletion is detected', () => {
+  it('jsonc: deleting context7 server fires mcpServers', () => {
+    const written = deleteMcpServer(
+      claudeCode,
+      'jsonc',
+      'mcpServers',
+      'context7',
+    );
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'mcpServers').pass).toBe(false);
+  });
+
+  it('toml: deleting context7 server fires mcpServers', () => {
+    const written = deleteMcpServer(codex, 'toml', 'mcp_servers', 'context7');
+    const report = check('toml', codex, written, ['mcp_servers', 'filesystem']);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'mcpServers').pass).toBe(false);
+  });
+});
+
+describe('S6 — whitespace drift is detected', () => {
+  it('jsonc: drifting indentation by +2 fires formatting', () => {
+    const written = driftIndentation(claudeCode, 2);
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'formatting').pass).toBe(false);
+  });
+
+  it('jsonc: removing the trailing newline fires formatting', () => {
+    const written = deleteTrailingNewline(claudeCode);
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'formatting').pass).toBe(false);
+  });
+
+  it('toml: drifting indentation by +2 fires formatting', () => {
+    const written = driftIndentation(codex, 2);
+    const report = check('toml', codex, written, ['mcp_servers', 'filesystem']);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'formatting').pass).toBe(false);
+  });
+});
+
+describe('S7 — idempotency check fires when second apply drifts', () => {
+  it('jsonc: rewritten !== written fires idempotency', () => {
+    const written = claudeCode;
+    const rewritten = appendString(claudeCode, '\n');
+    const report = runPreservationChecks({
+      format: 'jsonc',
+      original: claudeCode,
+      written,
+      rewritten,
+      targetPath: ['mcpServers', 'filesystem'],
+    });
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'idempotency').pass).toBe(false);
+  });
+
+  it('jsonc: rewritten === written passes idempotency', () => {
+    const report = runPreservationChecks({
+      format: 'jsonc',
+      original: claudeCode,
+      written: claudeCode,
+      rewritten: claudeCode,
+      targetPath: ['mcpServers', 'filesystem'],
+    });
+    expect(findCheck(report, 'idempotency').pass).toBe(true);
+  });
+
+  it('jsonc: rewritten omitted → idempotency is skipped', () => {
+    const report = runPreservationChecks({
+      format: 'jsonc',
+      original: claudeCode,
+      written: claudeCode,
+      targetPath: ['mcpServers', 'filesystem'],
+    });
+    expect(findCheck(report, 'idempotency').skipped).toBe(true);
+    expect(findCheck(report, 'idempotency').pass).toBe(true);
+  });
+});
+
+describe('S8 — targeted mutations inside targetPath do NOT fire checks', () => {
+  it('jsonc: identity write with single-server targetPath passes every check', () => {
+    const report = check('jsonc', claudeCode, claudeCode, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(true);
+    // topLevelKeys: every key outside mcpServers is preserved
+    expect(findCheck(report, 'topLevelKeys').pass).toBe(true);
+    // keyOrder: keys outside mcpServers are unchanged
+    expect(findCheck(report, 'keyOrder').pass).toBe(true);
+    // mcpServers: every server except filesystem is preserved
+    expect(findCheck(report, 'mcpServers').pass).toBe(true);
+    // formatting: nothing outside targetPath drifted
+    expect(findCheck(report, 'formatting').pass).toBe(true);
+    // comments: every comment outside mcpServers.filesystem is preserved
+    expect(findCheck(report, 'comments').pass).toBe(true);
+  });
+
+  it('jsonc: targetPath on the whole mcp subtree still requires the rest to be preserved', () => {
+    const report = check('jsonc', claudeCode, claudeCode, ['mcpServers']);
+    expect(report.allPassed).toBe(true);
+  });
+
+  it('jsonc: empty targetPath means whole document may change — every check is skipped', () => {
+    const report = check('jsonc', claudeCode, claudeCode, []);
+    expect(report.allPassed).toBe(true);
+    for (const c of report.checks) {
+      expect(c.skipped).toBe(true);
+    }
+  });
+});
+
+describe('S9 — non-target-path comment edits fail', () => {
+  it('jsonc: editing a comment outside the target subtree fires comments', () => {
+    // Replace a comment line in the top-level (outside mcpServers.filesystem).
+    const written = claudeCode.replace(
+      '// Top-level keys are general Claude Code state, not MCP config.',
+      '// (edited)',
+    );
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(false);
+    expect(findCheck(report, 'comments').pass).toBe(false);
+  });
+});
+
+describe('S10 — all four formats are covered end-to-end', () => {
+  it('opencode (jsonc) identity write passes', () => {
+    const report = check('jsonc', opencode, opencode, ['mcp', 'filesystem']);
+    expect(report.allPassed).toBe(true);
+  });
+
+  it('claude-code (jsonc) identity write passes', () => {
+    const report = check('jsonc', claudeCode, claudeCode, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(true);
+  });
+
+  it('copilot-cli (jsonc) identity write passes', () => {
+    const report = check('jsonc', copilotCli, copilotCli, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(report.allPassed).toBe(true);
+  });
+
+  it('codex (toml) identity write passes', () => {
+    const report = check('toml', codex, codex, ['mcp_servers', 'filesystem']);
+    expect(report.allPassed).toBe(true);
+  });
+
+  it('opencode (jsonc) comment-strip breaks comments check', () => {
+    const written = stripComments(opencode, 'jsonc');
+    const report = check('jsonc', opencode, written, ['mcp', 'filesystem']);
+    expect(findCheck(report, 'comments').pass).toBe(false);
+  });
+
+  it('copilot-cli (jsonc) comment-strip breaks comments check', () => {
+    const written = stripComments(copilotCli, 'jsonc');
+    const report = check('jsonc', copilotCli, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(findCheck(report, 'comments').pass).toBe(false);
+  });
+});

--- a/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
+++ b/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
@@ -13,7 +13,7 @@
  *   S7  idempotency check fires when second apply drifts
  *   S8  targeted key reorder inside targetPath is NOT flagged
  *   S9  non-target-path comment edits fail
- *   S10 all four formats are covered
+ *   S10 every supported format (json/jsonc/toml) is covered end-to-end
  *
  * The byte-mutators from `byte-mutators.ts` produce the
  * known-broken inputs.
@@ -436,12 +436,14 @@ describe('S11 — rawBytes check is the primary E1 contract', () => {
     expect(findCheck(report, 'rawBytes').pass).toBe(true);
   });
 
-  it('rawBytes: length-changing legitimate target mutation passes', () => {
+  it('length-changing legitimate target mutation: full report passes', () => {
     // Add a new key to the target server. The target's byte length
-    // changes (longer written subtree). The fix in rawBytesCheck is to
-    // compute the target range independently in both original and
-    // written; using the original range for the written side would
-    // slice into the wrong content and falsely fire.
+    // changes (longer written subtree). Both rawBytes and formatting
+    // compute their target ranges independently in original and
+    // written; using only the original range would slice into the
+    // wrong content / shift line indices and falsely fire. Assert the
+    // FULL report passes, not just rawBytes, so a regression in
+    // formatting or any other check surfaces here.
     const written = claudeCode.replace(
       '"LOG_LEVEL": "info"',
       '"LOG_LEVEL": "info",\n        "TIMEOUT": 30',
@@ -450,7 +452,8 @@ describe('S11 — rawBytes check is the primary E1 contract', () => {
       'mcpServers',
       'filesystem',
     ]);
-    expect(findCheck(report, 'rawBytes').pass).toBe(true);
+    expect(report.allPassed).toBe(true);
+    expect(report.allPassed).toBe(true);
   });
 
   it('rawBytes: inter-value spacing change outside target fires (the false-negative structural checks miss)', () => {
@@ -548,7 +551,7 @@ describe('S11 — rawBytes check is the primary E1 contract', () => {
   });
 });
 
-describe('S10 — all four formats are covered end-to-end', () => {
+describe('S10 — every supported format (json/jsonc/toml) is covered end-to-end', () => {
   it('opencode (jsonc) identity write passes', () => {
     const report = check('jsonc', opencode, opencode, ['mcp', 'filesystem']);
     expect(report.allPassed).toBe(true);

--- a/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
+++ b/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
@@ -18,10 +18,6 @@
  * The byte-mutators from `byte-mutators.ts` produce the
  * known-broken inputs.
  */
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -34,19 +30,18 @@ import {
   swapMcpServers,
   swapTopLevelKeys,
 } from './byte-mutators.js';
+import {
+  CLAUDE_CODE_FIXTURE,
+  CODEX_FIXTURE,
+  COPILOT_CLI_FIXTURE,
+  OPENCODE_FIXTURE,
+} from './fixtures.js';
 import { runPreservationChecks } from './run.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const FIXTURE_DIR = join(__dirname, 'fixtures');
-
-function loadFixture(name: string): string {
-  return readFileSync(join(FIXTURE_DIR, name), 'utf8');
-}
-
-const opencode = loadFixture('opencode.jsonc');
-const claudeCode = loadFixture('claude-code.jsonc');
-const copilotCli = loadFixture('copilot-cli.jsonc');
-const codex = loadFixture('codex.toml');
+const opencode = OPENCODE_FIXTURE;
+const claudeCode = CLAUDE_CODE_FIXTURE;
+const copilotCli = COPILOT_CLI_FIXTURE;
+const codex = CODEX_FIXTURE;
 
 /** Convenience: run the harness with just original/written. */
 function check(
@@ -55,7 +50,13 @@ function check(
   written: string,
   targetPath: readonly string[],
 ): ReturnType<typeof runPreservationChecks> {
-  return runPreservationChecks({ format, original, written, targetPath });
+  return runPreservationChecks({
+    format,
+    original,
+    written,
+    rewritten: written,
+    targetPath,
+  });
 }
 
 /** Find a check by name in a report. */
@@ -289,15 +290,20 @@ describe('S7 — idempotency check fires when second apply drifts', () => {
     expect(findCheck(report, 'idempotency').pass).toBe(true);
   });
 
-  it('jsonc: rewritten omitted → idempotency is skipped', () => {
+  it('jsonc: rewritten=written → idempotency trivially holds', () => {
+    // `rewritten` is now a required input. Callers that don't exercise
+    // a second apply pass `written` again — the check then holds
+    // trivially and the report is honest about it.
     const report = runPreservationChecks({
       format: 'jsonc',
       original: claudeCode,
       written: claudeCode,
+      rewritten: claudeCode,
       targetPath: ['mcpServers', 'filesystem'],
     });
-    expect(findCheck(report, 'idempotency').skipped).toBe(true);
-    expect(findCheck(report, 'idempotency').pass).toBe(true);
+    const idem = findCheck(report, 'idempotency');
+    expect(idem.skipped).toBe(false);
+    expect(idem.pass).toBe(true);
   });
 });
 
@@ -325,12 +331,16 @@ describe('S8 — targeted mutations inside targetPath do NOT fire checks', () =>
     expect(report.allPassed).toBe(true);
   });
 
-  it('jsonc: empty targetPath means whole document may change — every check is skipped', () => {
+  it('jsonc: empty targetPath means whole document may change — all structural checks are skipped; idempotency still runs (rewritten is required)', () => {
     const report = check('jsonc', claudeCode, claudeCode, []);
     expect(report.allPassed).toBe(true);
     for (const c of report.checks) {
+      if (c.name === 'idempotency') continue;
       expect(c.skipped).toBe(true);
     }
+    const idem = report.checks.find((c) => c.name === 'idempotency');
+    expect(idem!.skipped).toBe(false);
+    expect(idem!.pass).toBe(true);
   });
 });
 
@@ -347,6 +357,78 @@ describe('S9 — non-target-path comment edits fail', () => {
     ]);
     expect(report.allPassed).toBe(false);
     expect(findCheck(report, 'comments').pass).toBe(false);
+  });
+});
+
+describe('S11 — rawBytes check is the primary E1 contract', () => {
+  it('rawBytes: identity write preserves every outside byte (jsonc)', () => {
+    const report = check('jsonc', claudeCode, claudeCode, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(findCheck(report, 'rawBytes').pass).toBe(true);
+  });
+
+  it('rawBytes: edited comment text fires (not just removed comments)', () => {
+    // The structured `comments` check uses a set comparison: as long as the
+    // same comments exist somewhere, it passes. rawBytes is stricter: any
+    // byte change outside targetPath fires. This test edits the text of a
+    // non-target comment (keeps the same set) and proves rawBytes catches it.
+    const written = claudeCode.replace(
+      '// Top-level keys are general Claude Code state, not MCP config.',
+      '// (edited for the test)',
+    );
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(findCheck(report, 'rawBytes').pass).toBe(false);
+  });
+
+  it('rawBytes: unrelated top-level key value change fires', () => {
+    // numStartups is outside targetPath[0]=mcpServers. A writer that
+    // changes its value (without deleting or reordering) must fire rawBytes
+    // even though the structured `topLevelKeys` check only verifies the key
+    // exists with equal content (which it would, since the value is still a
+    // number).
+    const written = claudeCode.replace(
+      '"numStartups": 42',
+      '"numStartups": 43',
+    );
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(findCheck(report, 'rawBytes').pass).toBe(false);
+  });
+
+  it('rawBytes: legitimate inside-target mutation passes', () => {
+    // Swap two MCP servers inside the target subtree. targetPath is the
+    // whole mcpServers subtree (so the swap is fully inside the target).
+    // rawBytes compares only the bytes OUTSIDE the target, so an
+    // inside-target swap must pass.
+    const written = swapMcpServers(
+      claudeCode,
+      'jsonc',
+      'mcpServers',
+      'filesystem',
+      'context7',
+    );
+    const report = check('jsonc', claudeCode, written, ['mcpServers']);
+    expect(findCheck(report, 'rawBytes').pass).toBe(true);
+  });
+
+  it('rawBytes (toml): identity write preserves every outside byte', () => {
+    const report = check('toml', codex, codex, ['mcp_servers', 'filesystem']);
+    expect(findCheck(report, 'rawBytes').pass).toBe(true);
+  });
+
+  it('rawBytes (toml): edited scalar outside target fires', () => {
+    // model is outside targetPath[0]=mcp_servers. A writer that changes
+    // its value must fire rawBytes.
+    const written = codex.replace('model = "gpt-5"', 'model = "gpt-6"');
+    const report = check('toml', codex, written, ['mcp_servers', 'filesystem']);
+    expect(findCheck(report, 'rawBytes').pass).toBe(false);
   });
 });
 

--- a/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
+++ b/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
@@ -342,6 +342,24 @@ describe('S8 — targeted mutations inside targetPath do NOT fire checks', () =>
     expect(idem!.skipped).toBe(false);
     expect(idem!.pass).toBe(true);
   });
+
+  it('jsonc: empty targetPath + rewritten !== written fires idempotency (regression)', () => {
+    // Regression test for the Oracle round-2 finding: the empty-target
+    // short-circuit must NOT hardcode idempotency pass. If the writer
+    // produced different bytes on a second apply, the harness must
+    // catch it even when the writer was allowed to mutate the whole doc.
+    const report = runPreservationChecks({
+      format: 'jsonc',
+      original: claudeCode,
+      written: claudeCode,
+      rewritten: claudeCode + '\n',
+      targetPath: [],
+    });
+    expect(report.allPassed).toBe(false);
+    const idem = report.checks.find((c) => c.name === 'idempotency');
+    expect(idem!.skipped).toBe(false);
+    expect(idem!.pass).toBe(false);
+  });
 });
 
 describe('S9 — non-target-path comment edits fail', () => {

--- a/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
+++ b/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
@@ -489,6 +489,56 @@ describe('S11 — rawBytes check is the primary E1 contract', () => {
     expect(findCheck(report, 'rawBytes').pass).toBe(true);
   });
 
+  it('rawBytes: AST path resolution finds the right top-level mcpServers (regression for nested-collision bug)', () => {
+    // A config that has an unrelated top-level key BEFORE the real
+    // mcpServers. The unrelated key's value contains a nested
+    // mcpServers.filesystem. A regex first-match would find the
+    // nested one; the AST walk must find the real top-level one.
+    const configWithCollision = `{
+  "unrelatedConfig": {
+    "mcpServers": {
+      "filesystem": {
+        "command": "fake",
+        "args": ["--nested"]
+      }
+    }
+  },
+  "mcpServers": {
+    "filesystem": {
+      "command": "real",
+      "args": ["--real"]
+    }
+  }
+}
+`;
+    // 1) Edit only the NESTED filesystem (change a command arg). The
+    //    real target is the top-level mcpServers.filesystem, so the
+    //    change is OUTSIDE the target. rawBytes must fire.
+    const writtenNestedEdit = configWithCollision.replace(
+      '"--nested"',
+      '"--nested-edited"',
+    );
+    const reportNested = check(
+      'jsonc',
+      configWithCollision,
+      writtenNestedEdit,
+      ['mcpServers', 'filesystem'],
+    );
+    expect(findCheck(reportNested, 'rawBytes').pass).toBe(false);
+
+    // 2) Edit only the REAL filesystem (change a command arg). The
+    //    change is INSIDE the target. rawBytes must pass.
+    const writtenRealEdit = configWithCollision.replace(
+      '"--real"',
+      '"--real-edited"',
+    );
+    const reportReal = check('jsonc', configWithCollision, writtenRealEdit, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(findCheck(reportReal, 'rawBytes').pass).toBe(true);
+  });
+
   it('rawBytes (toml): edited scalar outside target fires', () => {
     // model is outside targetPath[0]=mcp_servers. A writer that changes
     // its value must fire rawBytes.

--- a/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
+++ b/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
@@ -418,6 +418,54 @@ describe('S11 — rawBytes check is the primary E1 contract', () => {
     expect(findCheck(report, 'rawBytes').pass).toBe(true);
   });
 
+  it('rawBytes: length-changing legitimate target mutation passes', () => {
+    // Add a new key to the target server. The target's byte length
+    // changes (longer written subtree). The fix in rawBytesCheck is to
+    // compute the target range independently in both original and
+    // written; using the original range for the written side would
+    // slice into the wrong content and falsely fire.
+    const written = claudeCode.replace(
+      '"LOG_LEVEL": "info"',
+      '"LOG_LEVEL": "info",\n        "TIMEOUT": 30',
+    );
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    expect(findCheck(report, 'rawBytes').pass).toBe(true);
+  });
+
+  it('rawBytes: inter-value spacing change outside target fires (the false-negative structural checks miss)', () => {
+    // This is the false-negative test. The structured checks all pass:
+    //   - comments: comment set is unchanged
+    //   - topLevelKeys: deep equality holds (42 === 42, "enabled" === "enabled")
+    //   - keyOrder: key order is unchanged
+    //   - mcpServers: only the filesystem server is touched, the others
+    //     have equal content
+    //   - formatting: line-leading whitespace and trailing newline are
+    //     unchanged
+    // But the spacing between ":" and the value changed from " " to "  "
+    // (double space), which is an out-of-scope byte change. rawBytes
+    // catches it; the structured checks do not.
+    const written = claudeCode.replace(
+      '"numStartups": 42',
+      '"numStartups":  42',
+    );
+    const report = check('jsonc', claudeCode, written, [
+      'mcpServers',
+      'filesystem',
+    ]);
+    // rawBytes must fire.
+    expect(findCheck(report, 'rawBytes').pass).toBe(false);
+    // None of the structural checks fire — this is the false-negative
+    // scenario rawBytes exists to close.
+    expect(findCheck(report, 'comments').pass).toBe(true);
+    expect(findCheck(report, 'topLevelKeys').pass).toBe(true);
+    expect(findCheck(report, 'keyOrder').pass).toBe(true);
+    expect(findCheck(report, 'mcpServers').pass).toBe(true);
+    expect(findCheck(report, 'formatting').pass).toBe(true);
+  });
+
   it('rawBytes (toml): identity write preserves every outside byte', () => {
     const report = check('toml', codex, codex, ['mcp_servers', 'filesystem']);
     expect(findCheck(report, 'rawBytes').pass).toBe(true);

--- a/packages/agents/src/writer-preservation/run.ts
+++ b/packages/agents/src/writer-preservation/run.ts
@@ -57,7 +57,8 @@ export function runPreservationChecks(
 ): PreservationReport {
   const { format, targetPath, original, written, rewritten } = input;
   // Short-circuit when the writer was allowed to mutate the whole
-  // document — there is nothing to preserve.
+  // document — every structural check is trivially inapplicable, but
+  // idempotency still runs (rewritten is required).
   if (targetPath.length === 0) {
     const checks: PreservationCheckResult[] = [
       {
@@ -90,12 +91,7 @@ export function runPreservationChecks(
         details: '',
         skipped: true,
       },
-      {
-        name: 'idempotency',
-        pass: true,
-        details: '',
-        skipped: false,
-      },
+      idempotencyCheck(written, rewritten),
       {
         name: 'rawBytes',
         pass: true,
@@ -104,7 +100,7 @@ export function runPreservationChecks(
       },
     ];
     return {
-      allPassed: true,
+      allPassed: checks.every((c) => c.pass),
       checks,
     };
   }

--- a/packages/agents/src/writer-preservation/run.ts
+++ b/packages/agents/src/writer-preservation/run.ts
@@ -21,6 +21,7 @@ import {
   idempotencyCheck,
   keyOrderCheck,
   mcpServersCheck,
+  rawBytesCheck,
   topLevelKeysCheck,
 } from './checks.js';
 import type {
@@ -93,7 +94,13 @@ export function runPreservationChecks(
         name: 'idempotency',
         pass: true,
         details: '',
-        skipped: rewritten === undefined,
+        skipped: false,
+      },
+      {
+        name: 'rawBytes',
+        pass: true,
+        details: '',
+        skipped: true,
       },
     ];
     return {
@@ -103,6 +110,10 @@ export function runPreservationChecks(
   }
 
   const checks: PreservationCheckResult[] = [];
+  // rawBytes runs first because it is the strongest preservation
+  // guarantee (byte-for-byte) and surfaces regressions the structured
+  // checks might miss.
+  checks.push(rawBytesCheck(original, written, targetPath, format));
   for (const name of checksForFormat(format)) {
     if (name === 'comments') {
       checks.push(commentsCheck(original, written, targetPath, format));
@@ -116,8 +127,8 @@ export function runPreservationChecks(
       checks.push(formattingCheck(original, written, targetPath, format));
     }
   }
-  // Idempotency is always part of the report; it is skipped when
-  // `rewritten` is not supplied.
+  // Idempotency is always part of the report; `rewritten` is a
+  // required input so the check always runs.
   checks.push(idempotencyCheck(written, rewritten));
 
   const allPassed = checks.every((c) => c.pass);

--- a/packages/agents/src/writer-preservation/run.ts
+++ b/packages/agents/src/writer-preservation/run.ts
@@ -45,12 +45,13 @@ export { checksForFormat } from './checks.js';
  *
  * - `original` is the file the writer started from.
  * - `written` is the output of the writer after a single apply.
- * - `rewritten` (optional) is the output of applying the writer a
- *   second time to `written`; when supplied, the idempotency check
- *   verifies the second apply is a no-op.
+ * - `rewritten` is the output of applying the writer a second time to
+ *   `written`. Required input — the E1 contract mandates that every
+ *   future per-agent writer prove idempotency. Callers that don't
+ *   exercise a second apply can pass `written` again.
  * - `targetPath` is the path inside the document the writer was
- *   allowed to mutate. Empty array = whole document allowed (every
- *   check passes trivially).
+ *   allowed to mutate. Empty array = whole document allowed; every
+ *   structural check is skipped, but idempotency still runs.
  */
 export function runPreservationChecks(
   input: PreservationCheckInput,

--- a/packages/agents/src/writer-preservation/run.ts
+++ b/packages/agents/src/writer-preservation/run.ts
@@ -1,0 +1,125 @@
+/**
+ * Public entry point for the writer preservation harness.
+ *
+ * `runPreservationChecks` is the single function every future
+ * per-agent MCP writer (E2 OpenCode, E3 Claude Code + Copilot CLI,
+ * E4 remaining agents) must pass before it is considered safe. The
+ * harness proves that the writer preserved every byte outside the
+ * targetPath subtree: comments, formatting, key order, unrelated
+ * config keys, and unrelated MCP servers. It also verifies the
+ * writer is idempotent across repeated dry-run/apply cycles.
+ *
+ * The harness is intentionally format-aware but agent-agnostic:
+ * pass a `format` + `targetPath` + the bytes, and the harness runs
+ * every check applicable to that format. The same harness gates
+ * JSON, JSONC, and TOML writers without per-agent code paths.
+ */
+import {
+  checksForFormat,
+  commentsCheck,
+  formattingCheck,
+  idempotencyCheck,
+  keyOrderCheck,
+  mcpServersCheck,
+  topLevelKeysCheck,
+} from './checks.js';
+import type {
+  PreservationCheckInput,
+  PreservationCheckResult,
+  PreservationReport,
+} from './types.js';
+
+export type {
+  PreservationCheckInput,
+  PreservationCheckName,
+  PreservationCheckResult,
+  PreservationReport,
+  TargetPath,
+} from './types.js';
+export { checksForFormat } from './checks.js';
+
+/**
+ * Run every preservation check applicable to the input's format and
+ * aggregate the results into a {@link PreservationReport}.
+ *
+ * - `original` is the file the writer started from.
+ * - `written` is the output of the writer after a single apply.
+ * - `rewritten` (optional) is the output of applying the writer a
+ *   second time to `written`; when supplied, the idempotency check
+ *   verifies the second apply is a no-op.
+ * - `targetPath` is the path inside the document the writer was
+ *   allowed to mutate. Empty array = whole document allowed (every
+ *   check passes trivially).
+ */
+export function runPreservationChecks(
+  input: PreservationCheckInput,
+): PreservationReport {
+  const { format, targetPath, original, written, rewritten } = input;
+  // Short-circuit when the writer was allowed to mutate the whole
+  // document — there is nothing to preserve.
+  if (targetPath.length === 0) {
+    const checks: PreservationCheckResult[] = [
+      {
+        name: 'comments',
+        pass: true,
+        details: '',
+        skipped: true,
+      },
+      {
+        name: 'topLevelKeys',
+        pass: true,
+        details: '',
+        skipped: true,
+      },
+      {
+        name: 'keyOrder',
+        pass: true,
+        details: '',
+        skipped: true,
+      },
+      {
+        name: 'mcpServers',
+        pass: true,
+        details: '',
+        skipped: true,
+      },
+      {
+        name: 'formatting',
+        pass: true,
+        details: '',
+        skipped: true,
+      },
+      {
+        name: 'idempotency',
+        pass: true,
+        details: '',
+        skipped: rewritten === undefined,
+      },
+    ];
+    return {
+      allPassed: true,
+      checks,
+    };
+  }
+
+  const checks: PreservationCheckResult[] = [];
+  for (const name of checksForFormat(format)) {
+    if (name === 'comments') {
+      checks.push(commentsCheck(original, written, targetPath, format));
+    } else if (name === 'topLevelKeys') {
+      checks.push(topLevelKeysCheck(original, written, targetPath, format));
+    } else if (name === 'keyOrder') {
+      checks.push(keyOrderCheck(original, written, targetPath, format));
+    } else if (name === 'mcpServers') {
+      checks.push(mcpServersCheck(original, written, targetPath, format));
+    } else if (name === 'formatting') {
+      checks.push(formattingCheck(original, written, targetPath, format));
+    }
+  }
+  // Idempotency is always part of the report; it is skipped when
+  // `rewritten` is not supplied.
+  checks.push(idempotencyCheck(written, rewritten));
+
+  const allPassed = checks.every((c) => c.pass);
+  return { allPassed, checks };
+}

--- a/packages/agents/src/writer-preservation/types.ts
+++ b/packages/agents/src/writer-preservation/types.ts
@@ -19,8 +19,10 @@ import type { McpLocationFormat } from '../types.js';
  * Path the writer was allowed to mutate. JSON-pointer-like; supports
  * both object key paths (e.g. `['mcpServers', 'filesystem']`) and TOML
  * table paths (e.g. `['mcp_servers', 'filesystem']`). An empty array
- * means the writer was allowed to mutate the entire document — no
- * preservation checks apply and the harness short-circuits to PASS.
+ * means the writer was allowed to mutate the entire document. Every
+ * structural preservation check is trivially inapplicable, but
+ * idempotency still runs — the harness is not a free pass when
+ * the writer was allowed to mutate the whole document.
  */
 export type TargetPath = readonly string[];
 

--- a/packages/agents/src/writer-preservation/types.ts
+++ b/packages/agents/src/writer-preservation/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Writer preservation harness — public type contracts.
+ *
+ * The harness is the E1 safety gate: every future per-agent MCP writer
+ * (E2 OpenCode, E3 Claude Code + Copilot CLI, E4 remaining agents) must
+ * pass `runPreservationChecks` with byte-for-byte preservation outside
+ * the targetPath subtree. No production writer exists yet; the harness
+ * is the contract future writers are held to.
+ *
+ * The harness operates on raw bytes (the original file and the writer's
+ * output) plus the path the writer was allowed to mutate. It does NOT
+ * parse either side beyond the minimum needed for path-aware checks
+ * (key order, top-level key existence, MCP-server inventory). Comment
+ * preservation, whitespace drift, and idempotency are byte-level checks.
+ */
+import type { McpLocationFormat } from '../types.js';
+
+/**
+ * Path the writer was allowed to mutate. JSON-pointer-like; supports
+ * both object key paths (e.g. `['mcpServers', 'filesystem']`) and TOML
+ * table paths (e.g. `['mcp_servers', 'filesystem']`). An empty array
+ * means the writer was allowed to mutate the entire document — no
+ * preservation checks apply and the harness short-circuits to PASS.
+ */
+export type TargetPath = readonly string[];
+
+/**
+ * Names of every individual preservation check the harness can run.
+ * Each check is independent; the harness runs every check applicable
+ * to the input format and aggregates results into a {@link PreservationReport}.
+ *
+ * - `comments`          — comment lines/block-runs outside targetPath must appear verbatim in `written` (jsonc/toml/yaml only).
+ * - `topLevelKeys`      — every top-level key outside targetPath[0] must exist in `written` with equal parsed content.
+ * - `keyOrder`          — outside targetPath, the parsed key order must match between `original` and `written`.
+ * - `mcpServers`        — every MCP server name outside targetPath[1] (within the targetPath[0] subtree) must exist in `written` with equal parsed content.
+ * - `formatting`        — outside targetPath, line-leading whitespace and trailing newline must match.
+ * - `idempotency`       — `rewritten` (the output of a second apply) must equal `written` byte-for-byte; only runs when `rewritten` is supplied.
+ */
+export type PreservationCheckName =
+  | 'comments'
+  | 'topLevelKeys'
+  | 'keyOrder'
+  | 'mcpServers'
+  | 'formatting'
+  | 'idempotency';
+
+/**
+ * Input to {@link runPreservationChecks}. All fields are required
+ * except `rewritten` (idempotency check is opt-in).
+ */
+export interface PreservationCheckInput {
+  readonly format: McpLocationFormat;
+  /** Path the writer was allowed to mutate. Empty array = whole-doc allowed. */
+  readonly targetPath: TargetPath;
+  /** Original file bytes the writer started from. */
+  readonly original: string;
+  /** Output bytes after the writer ran once. */
+  readonly written: string;
+  /**
+   * Output bytes after applying the writer a second time to `written`.
+   * When supplied, the harness runs the `idempotency` check
+   * (`rewritten === written` byte-for-byte). When omitted, the
+   * idempotency check is skipped and reported as `pass: true, skipped: true`.
+   */
+  readonly rewritten?: string;
+}
+
+/**
+ * Result of one preservation check. `details` is populated when the
+ * check fails so test failures and future writer debugging can see
+ * exactly which byte/line/key triggered the failure.
+ */
+export interface PreservationCheckResult {
+  readonly name: PreservationCheckName;
+  readonly pass: boolean;
+  /** Human-readable failure detail. Empty when `pass` is true. */
+  readonly details: string;
+  /** True when the check was skipped (not applicable or not supplied). */
+  readonly skipped: boolean;
+}
+
+/**
+ * Aggregate result. `allPassed` is true when every applicable check
+ * passed (or was skipped); false when any check failed.
+ */
+export interface PreservationReport {
+  readonly allPassed: boolean;
+  readonly checks: readonly PreservationCheckResult[];
+}

--- a/packages/agents/src/writer-preservation/types.ts
+++ b/packages/agents/src/writer-preservation/types.ts
@@ -34,7 +34,8 @@ export type TargetPath = readonly string[];
  * - `keyOrder`          — outside targetPath, the parsed key order must match between `original` and `written`.
  * - `mcpServers`        — every MCP server name outside targetPath[1] (within the targetPath[0] subtree) must exist in `written` with equal parsed content.
  * - `formatting`        — outside targetPath, line-leading whitespace and trailing newline must match.
- * - `idempotency`       — `rewritten` (the output of a second apply) must equal `written` byte-for-byte; only runs when `rewritten` is supplied.
+ * - `idempotency`       — `rewritten` (the output of a second apply) must equal `written` byte-for-byte; required input.
+ * - `rawBytes`          — every byte outside the targetPath subtree must be byte-identical between `original` and `written`. This is the strongest preservation guarantee and is the primary E1 contract.
  */
 export type PreservationCheckName =
   | 'comments'
@@ -42,11 +43,16 @@ export type PreservationCheckName =
   | 'keyOrder'
   | 'mcpServers'
   | 'formatting'
-  | 'idempotency';
+  | 'idempotency'
+  | 'rawBytes';
 
 /**
- * Input to {@link runPreservationChecks}. All fields are required
- * except `rewritten` (idempotency check is opt-in).
+ * Input to {@link runPreservationChecks}. All fields are required.
+ *
+ * `rewritten` is mandatory (not optional): the E1 contract requires every
+ * future per-agent writer to prove idempotency across a second apply,
+ * and an optional `rewritten` would let a writer skip the check entirely.
+ * Callers that don't care about idempotency can pass `written` again.
  */
 export interface PreservationCheckInput {
   readonly format: McpLocationFormat;
@@ -58,11 +64,11 @@ export interface PreservationCheckInput {
   readonly written: string;
   /**
    * Output bytes after applying the writer a second time to `written`.
-   * When supplied, the harness runs the `idempotency` check
-   * (`rewritten === written` byte-for-byte). When omitted, the
-   * idempotency check is skipped and reported as `pass: true, skipped: true`.
+   * The harness always runs the `idempotency` check
+   * (`rewritten === written` byte-for-byte). To opt out, pass `written`
+   * again — the harness will then trivially pass the check.
    */
-  readonly rewritten?: string;
+  readonly rewritten: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements **E1 — Writer preservation harness** for the `@overture/agents` library. Every future per-agent MCP writer (E2 OpenCode, E3 Claude Code + Copilot CLI, E4 remaining) must pass `runPreservationChecks()` with byte-for-byte preservation outside `targetPath` before being considered safe.

## Public surface

```ts
import {
  runPreservationChecks,
  checksForFormat,
  type PreservationCheckInput,
  type PreservationCheckName,
  type PreservationCheckResult,
  type PreservationReport,
  type TargetPath,
} from '@overture/agents';
```

`runPreservationChecks(input: PreservationCheckInput): PreservationReport` is the single entry point.

## Preservation checks

| Check | What it proves |
| --- | --- |
| `comments` | JSONC/TOML comments outside `targetPath` are preserved (set-based) |
| `topLevelKeys` | Every top-level key outside `targetPath[0]` exists with equal parsed content |
| `keyOrder` | jsonc-parser Object.keys order (JSON/JSONC); line-based fallback (TOML) |
| `mcpServers` | Every MCP server outside `targetPath[1]` exists with equal parsed content |
| `formatting` | Line-leading whitespace + trailing newline outside `targetPath` |
| `idempotency` | `rewritten === written` (required — a second apply must be a no-op) |
| `rawBytes` | **Primary E1 contract** — byte-for-byte comparison of everything outside `targetPath` |

## Key design decisions

- **`rewritten` is required.** Forces every future writer to verify a second apply is a no-op.
- **AST-based path resolution (`jsonc-parser.parseTree`).** A regex first-match could find a nested `mcpServers` before the real top-level one, making `rawBytes` exclude the wrong subtree. jsonc-parser's `Node.offset` / `Node.length` are authoritative.
- **Independent target-range computation.** `rawBytes`, `jsonFormattingCheck`, and `tomlFormattingCheck` compute the target range independently in both `original` and `written`. A length-changing inside-target mutation (e.g. adding a field to the target server) shifts byte/line indices; using only the original range would slice the wrong content and falsely fire.
- **JSONC byte-mutator with `findJsonTopLevelRangeNoComma`.** Trailing-comma handling for swap operations. TOML mutators are line-based because smol-toml has no serializer (round-tripping would lose comments and formatting).

## Files

- `packages/agents/src/writer-preservation/`
  - `types.ts` — public contracts
  - `fixtures.ts` + `fixtures/` — 4 captured configs (opencode, claude-code, copilot-cli, codex)
  - `byte-mutators.ts` — test scaffolding (not re-exported)
  - `checks.ts` + `run.ts` — individual check functions + orchestrator
  - `__reference-writers__.ts` — intentionally-broken writers (double-underscore prefix prevents re-export)
  - `checks.spec.ts` + `run-preservation-checks.spec.ts` + `contract.spec.ts` — 304 agents tests
- `packages/agents/src/index.ts` — public re-export

## Quality gates

- 304/304 `@overture/agents` tests
- 212/212 `@jander99/overture` CLI tests
- `yarn prettier --check .` clean
- `yarn nx build @jander99/overture` successful
- `node apps/cli/scripts/verify-package.mjs` passes
- `tsc -p packages/agents/tsconfig.spec.json` clean for E1-owned files

## Oracle review

Passed 6 rounds of adversarial review (rounds 1-6). Each round addressed: `rewritten` required, YAML overstated in API, public export missing, TS strict cleanup, AST path resolution, doc-comment accuracy, idempotency in empty-target, range independence in formatting checks.

## Next slice

**E2 — First writer: OpenCode.** This PR unblocks E2 (OpenCode is the simplest local config shape; compact MCP subtree).