### PR TITLE
E1 follow-ups: rawBytesCheck fails loudly on insert

### DIFF
--- a/packages/agents/src/opencode.write.spec.ts
+++ b/packages/agents/src/opencode.write.spec.ts
@@ -361,7 +361,7 @@ describe('E1 — opencode.mcp.write preserves OpenCode JSONC', () => {
     ).toBe(true);
   });
 
-  it('preserves OpenCode JSONC: adding a new remote server target path', async () => {
+  it('preserves OpenCode JSONC: adding a new remote server target path fails rawBytes (insert case)', async () => {
     const ctx = makeCtx();
     const newRemote: OvertureMcpServer = {
       type: 'remote',
@@ -374,14 +374,10 @@ describe('E1 — opencode.mcp.write preserves OpenCode JSONC', () => {
       ['mcp', 'new-remote'],
     );
     expect(caught).toBeNull();
-    const failures = report.checks
-      .filter((c) => !c.pass && !c.skipped)
-      .map((c) => `${c.name}: ${c.details}`)
-      .join('; ');
-    expect(
-      report.allPassed,
-      `Expected all checks to pass. Failures: ${failures}`,
-    ).toBe(true);
+    expect(report.allPassed).toBe(false);
+    const rawBytes = report.checks.find((c) => c.name === 'rawBytes');
+    expect(rawBytes?.pass).toBe(false);
+    expect(rawBytes?.details).toContain('not found in original');
   });
 
   // ----- comment preservation -----

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -217,18 +217,12 @@ export function rawBytesCheck(
     const origRange = findJsonTargetPathRange(original, targetPath);
     const writtenRange = findJsonTargetPathRange(written, targetPath);
     if (origRange === null) {
-      // INSERT case: targetPath does not exist in original document.
-      // Nothing to preserve from original — pass.
-      if (writtenRange !== null) {
-        return {
-          name: 'rawBytes',
-          pass: true,
-          details: `insert: targetPath ${JSON.stringify(targetPath)} not in original — nothing to preserve`,
-          skipped: false,
-        };
-      }
-      // Both null: nothing to preserve in either direction.
-      return skippedCheck('rawBytes');
+      return {
+        name: 'rawBytes',
+        pass: false,
+        details: `targetPath ${JSON.stringify(targetPath)} not found in original document`,
+        skipped: false,
+      };
     }
     if (writtenRange === null) {
       return {
@@ -260,18 +254,12 @@ export function rawBytesCheck(
     const origLineRange = findTomlTargetPathLineRange(original, targetPath);
     const writtenLineRange = findTomlTargetPathLineRange(written, targetPath);
     if (origLineRange === null) {
-      // INSERT case: targetPath does not exist in original TOML document.
-      // Nothing to preserve from original — pass.
-      if (writtenLineRange !== null) {
-        return {
-          name: 'rawBytes',
-          pass: true,
-          details: `insert: targetPath ${JSON.stringify(targetPath)} not in original TOML — nothing to preserve`,
-          skipped: false,
-        };
-      }
-      // Both null: nothing to preserve in either direction.
-      return skippedCheck('rawBytes');
+      return {
+        name: 'rawBytes',
+        pass: false,
+        details: `targetPath ${JSON.stringify(targetPath)} not found in original TOML document`,
+        skipped: false,
+      };
     }
     if (writtenLineRange === null) {
       return {


### PR DESCRIPTION
## Summary

Recovers the post-`#121` follow-up work from `feat/e1-writer-harness`. The 7 follow-up commits in that branch reduce to a single behavioral change in `rawBytesCheck`: a missing `targetPath` in the original document now **fails** the check with a structured error rather than silently passing as an insert.

## Behavioral change

```diff
   if (origRange === null) {
-    // INSERT case: targetPath does not exist in original document.
-    // Nothing to preserve from original — pass.
-    if (writtenRange !== null) {
-      return { name: 'rawBytes', pass: true, details: '...nothing to preserve', skipped: false };
-    }
-    return skippedCheck('rawBytes');
+    return { name: 'rawBytes', pass: false, details: 'targetPath ... not found in original document', skipped: false };
   }
```

Same change applied symmetrically to the TOML branch.

**Why this matters**: the old INSERT case hid a real policy gap — if the writer is adding a subtree that did not exist in the original, the preservation harness was passing silently. The new behavior surfaces this as an explicit failure: the harness asserts that the target subtree existed in the original, so the writer's contract is to **update** — not create — target subtrees. A writer that creates a missing target must now be called out at preservation time, not absorbed.

## Test update

`opencode.write.spec.ts`: the `preserves OpenCode JSONC: adding a new remote server target path` test was validating the old INSERT-pass policy. Updated to assert the new policy: `report.allPassed` is `false`, the `rawBytes` check has `pass: false`, and `details` contains `'not found in original'`. Test name updated to `... fails rawBytes (insert case)`.

## Why a single commit (not 7)

The 7 follow-up commits in `feat/e1-writer-harness` reduced against current `main` to a single substantive change. The other 6 commits touched `run.ts`, `types.ts`, and `run-preservation-checks.spec.ts` with **zero net diff** — either whitespace-only or content that E2 (`#122`) and E3 (`#124`) already applied. Carrying them through would just inflate the PR with 6 commits of no-op work.

## Out of scope (intentionally not touched)

- `overture apply` / backups / sync — Track F
- E2 OpenCode writer — already in main as `#122`
- E3 Claude/Copilot writers — already in main as `#124`
- E4 / byte-splice follow-up

## Verification

| Gate | Result |
|---|---|
| `yarn nx test @overture/agents --skip-nx-cache` | 359 / 359 ✅ |
| `yarn nx test @jander99/overture --skip-nx-cache` | 217 / 217 ✅ |
| `yarn prettier --check <files>` | ✅ |
| `yarn tsc -b packages/agents/tsconfig.spec.json` | exit 0 ✅ |