### PR TITLE
docs: add execution policy — never run a write path without --dry-run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,28 @@
 
 Compact guide for AI agents working in the `overture` repository.
 
+## Execution policy (read first)
+
+`overture bootstrap` (no flag) writes `overture.jsonc` to the user's config
+dir. The agent `mcp.write` functions (opencode, claude-code,
+github-copilot-cli) are wired into the registry but currently unreachable
+from the CLI; do not invoke them programmatically without explicit user
+authorization and a test-only fixture.
+
+- **Default to `--dry-run`.** For `overture bootstrap` and any future
+  inspect/apply command, always pass `--dry-run` (and `--json` if you want
+  machine-readable output). Read-only commands (`detect`, `scan`,
+  `config show`) are safe and need no flag.
+- **Never run a write path without `--dry-run` unless the user explicitly
+  asks.** A terse "go ahead", "do it", or "yes, run it" is enough
+  authorization. Absent that, do not execute. Silence is not consent.
+- **Even with explicit approval, double-check before invoking.** Re-read
+  the exact command, confirm the write target and what it will create or
+  modify, and surface that in plain language before pressing enter.
+- If you are unsure whether a command writes, audit the code first (grep
+  for `writeFile`, `rename`, `child_process`, etc.) and stop until you
+  can answer with confidence.
+
 ## What this repo is
 
 Yarn 4 (Corepack) + Nx 22 monorepo. The shipped artifact today is the


### PR DESCRIPTION
## Summary

Adds an **Execution policy** section to `AGENTS.md`, placed prominently at the top of the file (immediately after the intro paragraph, before `## What this repo is`) so future agents — human or AI — see it before invoking any command.

## Rules

- **Default to `--dry-run`** for `overture bootstrap` and any future inspect/apply command. Read-only commands (`detect`, `scan`, `config show`) are safe and need no flag.
- **Never run a write path without `--dry-run` unless the user explicitly asks.** A terse "go ahead", "do it", or "yes, run it" is enough authorization. Silence is not consent.
- **Even with explicit approval, double-check** the exact command and write target before invoking. Surface what will change in plain language.
- If unsure whether a command writes, audit the code first (grep for `writeFile`, `rename`, `child_process`, etc.) and stop until you can answer with confidence.

## Why now

The audit before this PR found:

1. `overture bootstrap` (no flag) writes `overture.jsonc` to the user's config dir via `runBootstrapInteractive` → `writeOvertureConfig` (`packages/config/src/writer.ts:266-267`). It is the **only** production write path reachable from the CLI today.
2. The agent `mcp.write` registry functions (opencode, claude-code, github-copilot-cli) are wired but **unreachable** from the CLI. They MUST NOT be invoked programmatically without explicit user authorization and a test-only fixture.

Both paths had no stated rule. This PR adds the rule.

## What's NOT in scope (intentionally)

- No code change — documentation only.
- No new gate around the actual write call (`writeOvertureConfig`). That is a code-level safety net and is a separate concern.
- No CI lint of this prose.

## Verification

| Gate | Result |
|---|---|
| `yarn prettier --check AGENTS.md` | ✅ |
| Visual review of placement / wording | manual |