### PR TITLE
test(cli): isolate workspaceDir in run: scan describe block

### DIFF
--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -667,6 +667,7 @@ describe('run: scan', () => {
   let prevXdgConfig: string | undefined;
   let prevXdgState: string | undefined;
   let prevXdgCache: string | undefined;
+  let prevCwd: string;
 
   beforeEach(() => {
     stdoutSpy = vi
@@ -676,6 +677,8 @@ describe('run: scan', () => {
       .spyOn(process.stderr, 'write')
       .mockImplementation(() => true);
     tempDir = mkdtempSync(join(tmpdir(), 'overture-scan-'));
+    prevCwd = process.cwd();
+    process.chdir(tempDir);
     prevHome = process.env.HOME;
     prevXdgConfig = process.env.XDG_CONFIG_HOME;
     prevXdgState = process.env.XDG_STATE_HOME;
@@ -699,6 +702,7 @@ describe('run: scan', () => {
     else process.env.XDG_STATE_HOME = prevXdgState;
     if (prevXdgCache === undefined) delete process.env.XDG_CACHE_HOME;
     else process.env.XDG_CACHE_HOME = prevXdgCache;
+    process.chdir(prevCwd);
     rmSync(tempDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## What

`describe('run: scan')` in \`apps/cli/src/cli.spec.ts\` already isolated \`HOME\`, \`XDG_CONFIG_HOME\`, \`XDG_STATE_HOME\`, and \`XDG_CACHE_HOME\`, but did **not** isolate \`process.cwd()\`. As a result, the real workspace-relative MCP config files (e.g. \`./.github/mcp.json\`) leaked into every test on hosts that ship a real MCP config — breaking 3 of them on this host.

## Failing tests (now passing)

- \`--json returns 0 and writes parseable JSON with only matrix and conflicts keys\`
- \`no-flag scan with parse-error agent config returns 1 and writes the blocking summary\`
- \`no-flag scan with OpenCode installed returns 0 and includes "Scan complete."\`

Each failed because scan picked up the real \`.github/mcp.json\` (which contains an \`nx-mcp\` shape-conflict entry) and exited \`1\` on top of the test's expected clean state.

## Fix

Single-point: extend the describe block's existing \`beforeEach\`/\`afterEach\` to save and restore \`process.cwd()\` around \`tempDir\`. Restoration happens \`before\` \`rmSync\` deletes the temp dir, so the chdir back to the original cwd is never blocked by a missing directory.

## Verification

\`\`\`bash
yarn nx test @jander99/overture --skip-nx-cache
# Test Files  18 passed (18)
# Tests  217 passed (217)
yarn prettier --check .
# All matched files use Prettier code style!
\`\`\`

## Scope

1 file, 4 insertions, 0 deletions. No source files touched.