### PR TITLE
feat(agents): OpenAI Codex TOML writer (E4)

### DIFF
--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -11,16 +11,16 @@
   },
   "references": [
     {
-      "path": "../../packages/agents"
+      "path": "../../packages/agents/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/config"
+      "path": "../../packages/config/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/os"
+      "path": "../../packages/os/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/scan-matrix"
+      "path": "../../packages/scan-matrix/tsconfig.lib.json"
     }
   ],
   "include": ["src/**/*.ts"],

--- a/apps/cli/tsconfig.spec.json
+++ b/apps/cli/tsconfig.spec.json
@@ -13,16 +13,16 @@
   },
   "references": [
     {
-      "path": "../../packages/agents"
+      "path": "../../packages/agents/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/config"
+      "path": "../../packages/config/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/os"
+      "path": "../../packages/os/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/scan-matrix"
+      "path": "../../packages/scan-matrix/tsconfig.lib.json"
     }
   ],
   "include": [

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -355,6 +355,8 @@ Add the rest in batches grouped by native config format:
 Expected result: each batch extends coverage without changing the writer safety
 contract.
 
+**Status: completed on feat/e4-openai-codex-toml-writer (this slice).** Delivered the OpenAI Codex TOML update-only writer against the E1 writer-preservation harness. The writer is an E3-style byte splice (no whole-document TOML reserialization) that preserves comments, key order, and unrelated top-level Codex config; native Codex extension fields (`env_vars`, `enabled_tools`, `disabled_tools`, `scopes`, `startup_timeout_sec`, `tool_timeout_sec`, `oauth_resource`, `required`, `enabled`, `bearer_token_env_var`, `cwd`, `env_http_headers`, `http_headers`, `url`, `command`, `args`, `env`) are preserved when compatible, and incompatible transport fields are intentionally dropped on transport switch. New harness coverage in `packages/agents/src/writer-preservation/` now treats descendant server subtables (e.g. `[mcp_servers.context7.env]`) as inside the touched server target, including bare-key and quoted-key table headers (`[mcp_servers."server.with.dot"]`); a quoted-key fixture ships with `CODEX_FIXTURE`. Non-contiguous target-descendant layouts are refused at the writer level as `unsupported-shape` (the harness is intentionally single-range). E4 is update-only: no missing-file, missing-container, or missing-server creation, no apply/backup/undo surface. Next slice: **F1 (`overture apply --dry-run`)**.
+
 ## Track F: apply behavior
 
 Apply uses canonical intent to update clients.

--- a/packages/agents/src/openai-codex-write-helpers.ts
+++ b/packages/agents/src/openai-codex-write-helpers.ts
@@ -1,0 +1,55 @@
+/**
+ * OpenAI Codex write target resolution.
+ *
+ * Codex read-path precedence is USER-FIRST (unlike Copilot's workspace-first):
+ *   1. <homeDir>/.codex/config.toml (user scope)
+ *   2. <workspaceDir>/.codex/config.toml (workspace scope)
+ *
+ * The picker is conservative: it returns a descriptor that records the
+ * path it found. It never reads the file itself; the writer is responsible
+ * for the byte-level splice.
+ *
+ * No creation. If no applicable target exists, the picker returns
+ * { kind: 'none', path: '' } so the writer can surface reason: 'not-targetable'.
+ */
+import { access } from 'node:fs/promises';
+import type { PathResolutionContext, TargetPath } from './types.js';
+
+export type CodexWriteTarget =
+  | { readonly kind: 'user'; readonly path: string }
+  | { readonly kind: 'workspace'; readonly path: string }
+  | { readonly kind: 'none'; readonly path: '' };
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function pickCodexWriteTarget(
+  ctx: PathResolutionContext,
+): Promise<CodexWriteTarget> {
+  const home = typeof ctx.homeDir === 'string' ? ctx.homeDir : '';
+  const wsDir = typeof ctx.workspaceDir === 'string' ? ctx.workspaceDir : '';
+  const userPath = home.length > 0 ? `${home}/.codex/config.toml` : '';
+  const workspacePath = wsDir.length > 0 ? `${wsDir}/.codex/config.toml` : '';
+
+  if (userPath.length > 0 && (await exists(userPath))) {
+    return { kind: 'user', path: userPath };
+  }
+  if (workspacePath.length > 0 && (await exists(workspacePath))) {
+    return { kind: 'workspace', path: workspacePath };
+  }
+  return { kind: 'none', path: '' };
+}
+
+export function targetPathFor(
+  target: Exclude<CodexWriteTarget, { kind: 'none' }>,
+): TargetPath {
+  const scope = target.kind === 'user' ? 'user' : 'project';
+  const base = target.kind === 'user' ? 'home' : 'workspace';
+  return { scope, base, path: target.path };
+}

--- a/packages/agents/src/openai-codex-write.ts
+++ b/packages/agents/src/openai-codex-write.ts
@@ -1,0 +1,920 @@
+/**
+ * OpenAI Codex MCP writer helpers (E4 slice).
+ *
+ * Pure helpers: no I/O, no FS. The actual `writeOpenAICodexMcpConfig`
+ * function lives in this file too per the plan, but Todo 5 will add
+ * the FS orchestration (path resolution, splice mechanics, registry
+ * wiring). For this todo the module only exports the deterministic
+ * conversion + render helpers and their types.
+ *
+ * Two public surfaces:
+ *
+ *  - `toOpenAICodexMcpServer(canonical, existing?)` converts a canonical
+ *    `OvertureMcpServer` into the native Codex entry shape, preserving
+ *    compatible extension fields from `existing`. It is total over
+ *    valid native entries: unsupported extension shapes throw
+ *    `UnsupportedCodexExtensionShapeError`, which the writer (Todo 5)
+ *    catches and surfaces as `reason: 'unsupported-shape'`.
+ *
+ *  - `renderCodexServerBlock(name, server)` produces a deterministic
+ *    TOML block for the rewritten server subtree. The output ends with
+ *    a single trailing newline so it can be dropped into the byte
+ *    range the splice helper computes.
+ */
+import type { OvertureMcpServer } from '@overture/config';
+
+// ---------------------------------------------------------------------------
+// Sentinel for unsupported extension shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by `toOpenAICodexMcpServer` when an existing native entry
+ * contains a value whose shape is not part of the supported Codex
+ * extension set, and by `renderCodexServerBlock` when a value cannot
+ * be emitted deterministically.
+ *
+ * The writer (Todo 5) catches this and surfaces it as
+ * `reason: 'unsupported-shape'` in the `AgentMcpWriteResult`.
+ *
+ * Per the E4 spec, the rejection cases are:
+ *  - arrays on non-known fields (only `args`, `env_vars`,
+ *    `enabled_tools`, `disabled_tools`, `scopes` are accepted as arrays)
+ *  - arrays containing non-string elements
+ *  - maps on non-known fields (only `env`, `http_headers`,
+ *    `env_http_headers` are accepted as maps)
+ *  - maps containing non-string values
+ *  - explicit `null`
+ *  - any value the renderer cannot emit deterministically
+ */
+export class UnsupportedCodexExtensionShapeError extends Error {
+  readonly #key: string;
+  readonly #value: unknown;
+
+  constructor(message: string, key: string, value: unknown) {
+    super(message);
+    this.name = 'UnsupportedCodexExtensionShapeError';
+    this.#key = key;
+    this.#value = value;
+  }
+
+  /** The offending extension key (or canonical key, in the render path). */
+  get key(): string {
+    return this.#key;
+  }
+
+  /** The offending value, captured for the writer's diagnostic context. */
+  get value(): unknown {
+    return this.#value;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public type: native Codex writable server entry
+// ---------------------------------------------------------------------------
+
+/**
+ * Native OpenAI Codex server entry that `toOpenAICodexMcpServer`
+ * produces and `renderCodexServerBlock` accepts.
+ *
+ * Field names mirror the documented TOML keys (`env_vars`,
+ * `startup_timeout_sec`, `tool_timeout_sec`, `enabled_tools`,
+ * `disabled_tools`, `oauth_resource`, `required`, `enabled`,
+ * `bearer_token_env_var`, `http_headers`, `env_http_headers`).
+ * All fields are optional; the transport is implied by the presence
+ * of `command` (stdio) or `url` (remote).
+ *
+ * The open index signature allows transport-agnostic scalar extension
+ * fields the user may have added to their config (for example, an
+ * undocumented flag Codex recognizes). Arrays and maps are restricted
+ * to the known field set; everything else throws
+ * `UnsupportedCodexExtensionShapeError` at conversion time.
+ */
+export type OpenAICodexWritableMcpServer = {
+  /** Stdio: command to spawn. Remote servers omit this. */
+  command?: string;
+  /** Stdio: command-line arguments. */
+  args?: string[];
+  /** Stdio: inline environment variables as a string map. */
+  env?: Record<string, string>;
+  /** Stdio: names of environment variables to forward from the parent process. */
+  env_vars?: string[];
+  /** Stdio: working directory for the server process. */
+  cwd?: string;
+  /** Stdio: startup timeout in seconds. */
+  startup_timeout_sec?: number;
+  /** Per-tool invocation timeout in seconds. */
+  tool_timeout_sec?: number;
+  /** Allowlist of tool names this server exposes. */
+  enabled_tools?: string[];
+  /** Blocklist of tool names this server exposes. */
+  disabled_tools?: string[];
+  /** OAuth scopes to request for this server. */
+  scopes?: string[];
+  /** OAuth resource URL the client should target. */
+  oauth_resource?: string;
+  /** Whether this server is required by the agent. */
+  required?: boolean;
+  /** Whether this server is enabled. */
+  enabled?: boolean;
+  /** Remote: URL the MCP client connects to. */
+  url?: string;
+  /** Remote: environment variable name holding the bearer token. */
+  bearer_token_env_var?: string;
+  /** Remote: static HTTP headers attached to requests. */
+  http_headers?: Record<string, string>;
+  /** Remote: HTTP headers sourced from environment variables. */
+  env_http_headers?: Record<string, string>;
+  /** Index signature for transport-agnostic scalar extension fields. */
+  [key: string]: unknown;
+};
+
+// ---------------------------------------------------------------------------
+// Field classification sets
+// ---------------------------------------------------------------------------
+
+/** Canonical stdio fields populated from the OvertureMcpServer stdio shape. */
+const STDIO_CANONICAL_FIELDS: ReadonlySet<string> = new Set([
+  'command',
+  'args',
+  'env',
+]);
+
+/** Canonical remote fields populated from the OvertureMcpServer remote shape. */
+const REMOTE_CANONICAL_FIELDS: ReadonlySet<string> = new Set([
+  'url',
+  'http_headers',
+]);
+
+/**
+ * Stdio-only fields dropped on a stdio→remote transport switch.
+ * Includes the canonical stdio fields plus stdio-only extensions.
+ */
+const STDIO_ONLY_FIELDS: ReadonlySet<string> = new Set([
+  'command',
+  'args',
+  'env',
+  'env_vars',
+  'cwd',
+]);
+
+/**
+ * Remote-only fields dropped on a remote→stdio transport switch.
+ * Includes the canonical remote fields plus remote-only extensions.
+ */
+const REMOTE_ONLY_FIELDS: ReadonlySet<string> = new Set([
+  'url',
+  'bearer_token_env_var',
+  'http_headers',
+  'env_http_headers',
+]);
+
+/** Known Codex fields that accept an inline array of strings. */
+const KNOWN_STRING_ARRAY_FIELDS: ReadonlySet<string> = new Set([
+  'args',
+  'env_vars',
+  'enabled_tools',
+  'disabled_tools',
+  'scopes',
+]);
+
+/** Known Codex fields that accept an inline map of string→string. */
+const KNOWN_STRING_MAP_FIELDS: ReadonlySet<string> = new Set([
+  'env',
+  'http_headers',
+  'env_http_headers',
+]);
+
+// ---------------------------------------------------------------------------
+// Conversion: canonical OvertureMcpServer → native Codex entry
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a canonical `OvertureMcpServer` into a native Codex entry.
+ *
+ *  - stdio canonical → `{ command, args?, env? }` plus stdio-compatible
+ *    extension fields preserved from `existing`.
+ *  - remote canonical → `{ url, http_headers? }` plus remote-compatible
+ *    extension fields preserved from `existing`.
+ *
+ * Transport switch cleanup (per the E4 spec):
+ *  - stdio → remote drops `command`, `args`, `env`, `env_vars`, `cwd`.
+ *  - remote → stdio drops `url`, `bearer_token_env_var`, `http_headers`,
+ *    `env_http_headers`.
+ *
+ * Extension validation:
+ *  - Scalar values (string / number / boolean) on any key pass through.
+ *  - Arrays are accepted only on known string-array fields (`args`,
+ *    `env_vars`, `enabled_tools`, `disabled_tools`, `scopes`) when
+ *    every element is a string.
+ *  - Maps are accepted only on known string-map fields (`env`,
+ *    `http_headers`, `env_http_headers`) when every value is a string.
+ *  - Anything else throws `UnsupportedCodexExtensionShapeError`.
+ *
+ * The output preserves canonical field order first (always:
+ * `command, [args], [env]` for stdio; `url, [http_headers]` for
+ * remote) followed by extension fields in the order they appear on
+ * `existing`. That ordering is what lets the writer's no-change
+ * detection use a stable `JSON.stringify` equality check.
+ */
+export function toOpenAICodexMcpServer(
+  server: OvertureMcpServer,
+  existing?: OpenAICodexWritableMcpServer,
+): OpenAICodexWritableMcpServer {
+  const base: Record<string, unknown> = {};
+  if (server.type === 'stdio') {
+    base['command'] = server.command;
+    if (server.args !== undefined) {
+      base['args'] = server.args;
+    }
+    if (server.env !== undefined) {
+      base['env'] = server.env;
+    }
+  } else {
+    base['url'] = server.url;
+    if (server.headers !== undefined) {
+      base['http_headers'] = server.headers;
+    }
+  }
+
+  const extensions: Record<string, unknown> = {};
+  if (existing !== undefined) {
+    for (const key of Object.keys(existing)) {
+      const value = existing[key];
+      if (value === undefined) {
+        continue;
+      }
+      // Skip canonical fields: they are sourced from the canonical
+      // input and must not be duplicated as extensions. Skipping them
+      // also means transport-switch cleanup of `command`/`url`/etc. is
+      // implicit — the canonical fields only appear when the target
+      // transport is the same as the canonical's `type`.
+      const isCanonical =
+        server.type === 'stdio'
+          ? STDIO_CANONICAL_FIELDS.has(key)
+          : REMOTE_CANONICAL_FIELDS.has(key);
+      if (isCanonical) {
+        continue;
+      }
+      // Transport switch cleanup: drop incompatible transport fields.
+      if (server.type === 'remote' && STDIO_ONLY_FIELDS.has(key)) {
+        continue;
+      }
+      if (server.type === 'stdio' && REMOTE_ONLY_FIELDS.has(key)) {
+        continue;
+      }
+      // Validate and add extension.
+      validateCodexExtensionValue(key, value);
+      extensions[key] = value;
+    }
+  }
+
+  return { ...base, ...extensions };
+}
+
+function validateCodexExtensionValue(key: string, value: unknown): void {
+  if (value === null) {
+    throw new UnsupportedCodexExtensionShapeError(
+      `OpenAI Codex extension "${key}" is null; null values are not supported`,
+      key,
+      value,
+    );
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    if (!KNOWN_STRING_ARRAY_FIELDS.has(key)) {
+      throw new UnsupportedCodexExtensionShapeError(
+        `OpenAI Codex extension "${key}" is an array but is not a known Codex string-array field`,
+        key,
+        value,
+      );
+    }
+    for (let i = 0; i < value.length; i++) {
+      if (typeof value[i] !== 'string') {
+        throw new UnsupportedCodexExtensionShapeError(
+          `OpenAI Codex extension "${key}" contains a non-string array element at index ${i}`,
+          key,
+          value,
+        );
+      }
+    }
+    return;
+  }
+  if (typeof value === 'object') {
+    if (!KNOWN_STRING_MAP_FIELDS.has(key)) {
+      throw new UnsupportedCodexExtensionShapeError(
+        `OpenAI Codex extension "${key}" is a map but is not a known Codex string-map field`,
+        key,
+        value,
+      );
+    }
+    for (const [subKey, subValue] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      if (typeof subValue !== 'string') {
+        throw new UnsupportedCodexExtensionShapeError(
+          `OpenAI Codex extension "${key}" contains a non-string inline-table value at "${subKey}"`,
+          key,
+          value,
+        );
+      }
+    }
+    return;
+  }
+  throw new UnsupportedCodexExtensionShapeError(
+    `OpenAI Codex extension "${key}" has unsupported value type: ${typeof value}`,
+    key,
+    value,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Render: native Codex entry → deterministic TOML block
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a native Codex server entry as a deterministic TOML block.
+ *
+ * Output shape:
+ *  - One `[mcp_servers.<name>]` header.
+ *  - One `key = value` line per non-undefined key, in the order keys
+ *    appear on `server`.
+ *  - Strings: double-quoted with TOML basic escaping (`\\`, `\"`).
+ *  - Booleans: literal `true` / `false`.
+ *  - Numbers: emitted as-is via `String(value)`.
+ *  - String arrays: TOML inline arrays `["a", "b"]`.
+ *  - String maps (`env`, `http_headers`, `env_http_headers`): TOML
+ *    inline tables `{ KEY = "value" }`.
+ *  - Extension scalar values (number / bool / string) on any other
+ *    key: emitted as-is.
+ *  - Arrays or maps on unknown fields throw
+ *    `UnsupportedCodexExtensionShapeError`.
+ *
+ * The returned string ends with exactly one trailing newline so the
+ * writer can splice it directly into the target line range.
+ */
+export function renderCodexServerBlock(
+  name: string,
+  server: OpenAICodexWritableMcpServer,
+): string {
+  const lines: string[] = [];
+  lines.push(`[mcp_servers.${name}]`);
+  for (const key of Object.keys(server)) {
+    const value = server[key];
+    if (value === undefined) {
+      continue;
+    }
+    lines.push(`${key} = ${renderCodexValue(key, value)}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function renderCodexValue(key: string, value: unknown): string {
+  if (typeof value === 'string') {
+    return renderCodexString(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return renderCodexInlineArray(key, value);
+  }
+  if (typeof value === 'object' && value !== null) {
+    return renderCodexInlineTable(key, value as Record<string, unknown>);
+  }
+  throw new UnsupportedCodexExtensionShapeError(
+    `OpenAI Codex value for "${key}" cannot be rendered as TOML (type: ${typeof value})`,
+    key,
+    value,
+  );
+}
+
+function renderCodexString(value: string): string {
+  // TOML basic string escaping covers the universal escapes; for the
+  // minimal contract the E4 spec calls out (`\\` and `\"`), we only
+  // emit those. Control characters and Unicode escapes are out of
+  // scope for this helper; the writer surfaces upstream refusal if
+  // such values appear in canonical or extension inputs.
+  const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function renderCodexInlineArray(
+  key: string,
+  items: readonly unknown[],
+): string {
+  const rendered: string[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (typeof item !== 'string') {
+      throw new UnsupportedCodexExtensionShapeError(
+        `OpenAI Codex value for "${key}" contains a non-string array element at index ${i}`,
+        key,
+        items,
+      );
+    }
+    rendered.push(renderCodexString(item));
+  }
+  return `[${rendered.join(', ')}]`;
+}
+
+function renderCodexInlineTable(
+  key: string,
+  obj: Record<string, unknown>,
+): string {
+  const rendered: string[] = [];
+  for (const subKey of Object.keys(obj)) {
+    const subValue = obj[subKey];
+    if (typeof subValue !== 'string') {
+      throw new UnsupportedCodexExtensionShapeError(
+        `OpenAI Codex value for "${key}" contains a non-string inline-table value at "${subKey}"`,
+        key,
+        obj,
+      );
+    }
+    rendered.push(`${subKey} = ${renderCodexString(subValue)}`);
+  }
+  return `{ ${rendered.join(', ')} }`;
+}
+
+// ---------------------------------------------------------------------------
+// Writer: file orchestration + byte-level splice
+// ---------------------------------------------------------------------------
+
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import {
+  pickCodexWriteTarget,
+  targetPathFor,
+  type CodexWriteTarget,
+} from './openai-codex-write-helpers.js';
+import type {
+  AgentMcpWriteInput,
+  AgentMcpWriteResult,
+  McpLocationFormat,
+  PathResolutionContext,
+  WriteReason,
+} from './types.js';
+
+/**
+ * smol-toml loaded at module-init time via `createRequire` so the
+ * bundle can resolve the dependency the same way `parse-mcp-servers.ts`
+ * and `writer-preservation/checks.ts` already do. Consumers running
+ * `npm install @jander99/overture` get `smol-toml` alongside as a
+ * declared runtime dependency.
+ */
+const smolTomlCjsModule = createRequire(__filename)('smol-toml') as {
+  parse: (text: string) => unknown;
+};
+
+/**
+ * Pattern that detects any textual reference to `mcp_servers` outside
+ * of a top-level `[mcp_servers]` table header. Matches:
+ *  - descendant headers: `[mcp_servers.foo]`, `[mcp_servers."q"]`,
+ *    `[mcp_servers.foo.env]`
+ *  - inline assignments: `mcp_servers = "x"`, `mcp_servers = {...}`,
+ *    `mcp_servers = [...]`
+ *
+ * Used to distinguish "no MCP servers block in this file"
+ * (`not-targetable`) from "mcp_servers exists but in the wrong
+ * shape/position" (`unsupported-shape`).
+ */
+const NON_TOP_LEVEL_MCP_SERVERS_REFERENCE =
+  /^\s*(?:\[\s*mcp_servers(?:\.[^\]]*)?\s*\]|mcp_servers\s*=)/m;
+
+/**
+ * Atomic file write: writes `contents` to a same-directory temp file,
+ * then renames over `targetPath`. On any failure the temp file is
+ * best-effort cleaned up. Mirrors the
+ * `github-copilot-cli-write.ts` atomicWrite pattern.
+ */
+async function atomicWrite(
+  targetPath: string,
+  contents: string,
+): Promise<void> {
+  await mkdir(dirname(targetPath), { recursive: true });
+  const tempPath = join(
+    dirname(targetPath),
+    `.${basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    await writeFile(tempPath, contents, 'utf8');
+
+    await rename(tempPath, targetPath);
+  } catch (err) {
+    try {
+      await rm(tempPath, { force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw err;
+  }
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    typeof (err as Record<string, unknown>)['code'] === 'string' &&
+    (err as Record<string, string>)['code'] === 'ENOENT'
+  );
+}
+
+type Target = Exclude<CodexWriteTarget, { kind: 'none' }>;
+
+function notTargetableResult(
+  dryRun: boolean,
+  target: Target,
+): AgentMcpWriteResult {
+  return {
+    written: 0,
+    changed: false,
+    dryRun,
+    serversWritten: [],
+    targetPaths: [targetPathFor(target)],
+    resolvedPath: target.path,
+    format: 'toml' as McpLocationFormat,
+    reason: 'not-targetable' as WriteReason,
+  };
+}
+
+function parseErrorResult(
+  dryRun: boolean,
+  target: Target,
+): AgentMcpWriteResult {
+  return {
+    written: 0,
+    changed: false,
+    dryRun,
+    serversWritten: [],
+    targetPaths: [targetPathFor(target)],
+    resolvedPath: target.path,
+    format: 'toml' as McpLocationFormat,
+    reason: 'parse-error' as WriteReason,
+  };
+}
+
+function unsupportedShapeResult(
+  dryRun: boolean,
+  target: Target,
+): AgentMcpWriteResult {
+  return {
+    written: 0,
+    changed: false,
+    dryRun,
+    serversWritten: [],
+    targetPaths: [targetPathFor(target)],
+    resolvedPath: target.path,
+    format: 'toml' as McpLocationFormat,
+    reason: 'unsupported-shape' as WriteReason,
+  };
+}
+
+function noChangeResult(dryRun: boolean, target: Target): AgentMcpWriteResult {
+  return {
+    written: 0,
+    changed: false,
+    dryRun,
+    serversWritten: [],
+    targetPaths: [targetPathFor(target)],
+    resolvedPath: target.path,
+    format: 'toml' as McpLocationFormat,
+    bytesChanged: 0,
+    reason: 'no-change' as WriteReason,
+  };
+}
+
+/**
+ * Parse a TOML table header (e.g. `[mcp_servers.filesystem]` or
+ * `[mcp_servers."server.with.dot"]`) into its segments. Returns
+ * `null` for non-header lines or malformed headers. Mirrors the
+ * helper in `writer-preservation/checks.ts` but is duplicated here
+ * to keep the writer independent of internal harness helpers.
+ */
+function parseCodexHeaderPath(line: string): readonly string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return null;
+  const inner = trimmed.slice(1, -1);
+  const segments: string[] = [];
+  let i = 0;
+  while (i < inner.length) {
+    while (i < inner.length && (inner[i] === ' ' || inner[i] === '\t')) i++;
+    if (i >= inner.length) break;
+    const ch = inner[i];
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      const start = i + 1;
+      let j = start;
+      while (j < inner.length && inner[j] !== quote) {
+        if (inner[j] === '\\' && j + 1 < inner.length) j += 2;
+        else j++;
+      }
+      if (j >= inner.length) return null;
+      segments.push(inner.slice(start, j));
+      i = j + 1;
+    } else {
+      const start = i;
+      while (i < inner.length && /[A-Za-z0-9_-]/.test(inner[i] ?? '')) {
+        i++;
+      }
+      if (i === start) return null;
+      segments.push(inner.slice(start, i));
+    }
+    if (i < inner.length) {
+      if (inner[i] === '.') i++;
+      else return null;
+    }
+  }
+  if (segments.length === 0) return null;
+  return segments;
+}
+
+/**
+ * Compute the byte range `[startByte, endByte)` for a half-open
+ * line range in `text`. Splits on `\n` and treats the last segment
+ * as a (possibly empty) trailing fragment that has no newline.
+ */
+function lineRangeToByteRange(
+  text: string,
+  startLine: number,
+  endLine: number,
+): readonly [number, number] {
+  const lines = text.split('\n');
+  if (startLine < 0 || endLine > lines.length || startLine > endLine) {
+    throw new Error(`Invalid line range [${startLine}, ${endLine})`);
+  }
+  let startByte = startLine;
+  for (let i = 0; i < startLine; i++) {
+    startByte += lines[i]!.length;
+  }
+  let endByte = endLine;
+  for (let i = 0; i < endLine; i++) {
+    endByte += lines[i]!.length;
+  }
+  return [startByte, endByte] as const;
+}
+
+/**
+ * Find the contiguous line range covering the table whose header
+ * segments are exactly `[parent, child]`, plus any descendant
+ * subtables whose first two segments also match. Returns
+ * `[startLine, endLine)` (half-open), or `null` if no matching
+ * header was found.
+ *
+ * Mirrors the semantics of `findTomlTargetPathLineRange` from
+ * `writer-preservation/checks.ts` so the writer's splice math stays
+ * consistent with the preservation harness's view of the same
+ * subtree.
+ */
+function findCodexServerLineRange(
+  text: string,
+  serverName: string,
+): readonly [number, number] | null {
+  const lines = text.split('\n');
+  const parent = 'mcp_servers';
+  let startLine = -1;
+  let endLine = lines.length;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (startLine === -1) {
+      const path = parseCodexHeaderPath(line);
+      if (
+        path !== null &&
+        path.length >= 2 &&
+        path[0] === parent &&
+        path[1] === serverName
+      ) {
+        startLine = i;
+        continue;
+      }
+    } else {
+      const path = parseCodexHeaderPath(line);
+      if (path === null) continue; // non-header line, include in range
+      const isDescendant =
+        path.length > 2 && path[0] === parent && path[1] === serverName;
+      if (!isDescendant) {
+        endLine = i;
+        break;
+      }
+    }
+  }
+  if (startLine === -1) return null;
+  return [startLine, endLine] as const;
+}
+
+/**
+ * Self-contained Codex MCP writer.
+ *
+ * Carries its own path resolution via `pickCodexWriteTarget`, refuses
+ * to create missing files, parses the target TOML with `smol-toml`
+ * for shape validation only (the byte-level splice happens on the
+ * original text), and writes via same-directory temp file + rename
+ * to keep the on-disk swap atomic.
+ *
+ * The writer is update-only: every requested server name must
+ * already exist under `mcp_servers` in the target document. New
+ * servers, deletions, and shape changes that create non-contiguous
+ * descendant layouts are all rejected.
+ */
+export async function writeOpenAICodexMcpConfig(
+  ctx: PathResolutionContext,
+  input: AgentMcpWriteInput,
+): Promise<AgentMcpWriteResult> {
+  const dryRun = input.dryRun ?? false;
+
+  const target = await pickCodexWriteTarget(ctx);
+  if (target.kind === 'none') {
+    return {
+      written: 0,
+      changed: false,
+      dryRun,
+      serversWritten: [],
+      targetPaths: [],
+      reason: 'not-targetable' as WriteReason,
+    };
+  }
+
+  // Read the target file (UTF-8). Surface ENOENT as not-targetable.
+  let originalText: string;
+  try {
+    originalText = await readFile(target.path, 'utf-8');
+  } catch (err) {
+    if (isEnoent(err)) {
+      return notTargetableResult(dryRun, target);
+    }
+    throw err;
+  }
+
+  if (originalText.length === 0 || originalText.trim() === '') {
+    return notTargetableResult(dryRun, target);
+  }
+
+  // Parse for shape validation only. The actual splice runs on the
+  // original bytes so comments, key order, and unrelated top-level
+  // keys survive unchanged.
+  let parsed: unknown;
+  try {
+    parsed = smolTomlCjsModule.parse(originalText);
+  } catch {
+    return parseErrorResult(dryRun, target);
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return unsupportedShapeResult(dryRun, target);
+  }
+
+  const doc = parsed as Record<string, unknown>;
+  const mcpServers = doc['mcp_servers'];
+  if (mcpServers === undefined) {
+    // Distinguish "no mcp_servers block anywhere" (not-targetable)
+    // from "mcp_servers present but in the wrong shape/position"
+    // (unsupported-shape). The non-top-level reference scan covers
+    // inline-table assignments, scalar assignments, and nested
+    // `[mcp_servers.X]` headers that smol-toml parses under a
+    // parent section instead of at the document root.
+    if (NON_TOP_LEVEL_MCP_SERVERS_REFERENCE.test(originalText)) {
+      return unsupportedShapeResult(dryRun, target);
+    }
+    return notTargetableResult(dryRun, target);
+  }
+  if (
+    typeof mcpServers !== 'object' ||
+    mcpServers === null ||
+    Array.isArray(mcpServers)
+  ) {
+    return unsupportedShapeResult(dryRun, target);
+  }
+
+  const mcpServersObj = mcpServers as Record<string, unknown>;
+
+  // Update-only: every requested server must already exist in the
+  // target document. Missing names are rejected with not-targetable
+  // so callers do not silently create new server tables.
+  for (const entry of input.servers) {
+    if (!Object.prototype.hasOwnProperty.call(mcpServersObj, entry.name)) {
+      return notTargetableResult(dryRun, target);
+    }
+  }
+
+  // Non-contiguous descendant check: any `[mcp_servers.<serverName>.<X>]` header
+  // that lies outside the server's contiguous range would be orphaned by a
+  // splice, so reject the entire write as unsupported-shape.
+  for (const entry of input.servers) {
+    const range = findCodexServerLineRange(originalText, entry.name);
+    if (range === null) continue;
+    const [startLine, endLine] = range;
+    const lines = originalText.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      if (i >= startLine && i < endLine) continue;
+      const path = parseCodexHeaderPath(lines[i]!);
+      if (
+        path !== null &&
+        path.length > 2 &&
+        path[0] === 'mcp_servers' &&
+        path[1] === entry.name
+      ) {
+        return unsupportedShapeResult(dryRun, target);
+      }
+    }
+  }
+
+  // Build the native entries for each requested server, preserving
+  // compatible extension fields from the existing native entry.
+  // Track only the entries that actually change so unchanged
+  // writes do not bump the `written` counter.
+  // compatible extension fields from the existing native entry.
+  // Track only the entries that actually change so unchanged
+  // writes do not bump the `written` counter.
+  const patches = new Map<string, OpenAICodexWritableMcpServer>();
+  const touched: string[] = [];
+  for (const entry of input.servers) {
+    const existing = mcpServersObj[entry.name] as
+      | OpenAICodexWritableMcpServer
+      | undefined;
+    let native: OpenAICodexWritableMcpServer;
+    try {
+      native = toOpenAICodexMcpServer(entry.server, existing);
+    } catch (err) {
+      if (err instanceof UnsupportedCodexExtensionShapeError) {
+        return unsupportedShapeResult(dryRun, target);
+      }
+      throw err;
+    }
+    if (existing !== undefined && deepEqual(existing, native)) {
+      continue;
+    }
+    patches.set(entry.name, native);
+    touched.push(entry.name);
+  }
+
+  if (touched.length === 0) {
+    return noChangeResult(dryRun, target);
+  }
+
+  // Splice each touched server subtree. Process in descending source
+  // order so an earlier splice cannot invalidate the line indices
+  // a later splice depends on.
+  let workingText = originalText;
+  const spliceJobs: { name: string; startLine: number; endLine: number }[] = [];
+  for (const name of touched) {
+    const range = findCodexServerLineRange(workingText, name);
+    if (range === null) {
+      // Should not happen: we confirmed the server exists above.
+      // Surface as not-targetable so we never silently drop a patch.
+      return notTargetableResult(dryRun, target);
+    }
+    spliceJobs.push({ name, startLine: range[0], endLine: range[1] });
+  }
+  spliceJobs.sort((a, b) => b.startLine - a.startLine);
+
+  for (const job of spliceJobs) {
+    const native = patches.get(job.name);
+    if (native === undefined) {
+      // Defensive: every job has a patch above.
+      return notTargetableResult(dryRun, target);
+    }
+    const newBlock = renderCodexServerBlock(job.name, native);
+    const [startByte, endByte] = lineRangeToByteRange(
+      workingText,
+      job.startLine,
+      job.endLine,
+    );
+    workingText =
+      workingText.slice(0, startByte) + newBlock + workingText.slice(endByte);
+  }
+
+  if (workingText === originalText) {
+    return noChangeResult(dryRun, target);
+  }
+
+  if (!dryRun) {
+    await atomicWrite(target.path, workingText);
+  }
+
+  const originalByteLength = Buffer.byteLength(originalText, 'utf-8');
+  const nextByteLength = Buffer.byteLength(workingText, 'utf-8');
+  return {
+    written: touched.length,
+    changed: true,
+    dryRun,
+    serversWritten: touched,
+    targetPaths: [targetPathFor(target)],
+    resolvedPath: target.path,
+    format: 'toml' as McpLocationFormat,
+    bytesChanged: Math.abs(nextByteLength - originalByteLength),
+  };
+}

--- a/packages/agents/src/openai-codex.ts
+++ b/packages/agents/src/openai-codex.ts
@@ -10,6 +10,7 @@ import {
 } from './normalize-mcp-config.js';
 import { parseTomlMcpServerMap } from './parse-mcp-servers.js';
 import { readAgentMcpConfig } from './read-mcp-config.js';
+import { writeOpenAICodexMcpConfig } from './openai-codex-write.js';
 import { defineAgent } from './define-agent.js';
 import type { OvertureMcpServer } from '@overture/config';
 import type {
@@ -166,6 +167,7 @@ export const openaiCodex: AgentDefinition = defineAgent({
   mcp: {
     parseServers: parseOpenAICodexMcpServers,
     normalize: asRegistryNormalizeHandler(normalizeOpenAICodexMcpServers),
+    write: writeOpenAICodexMcpConfig,
   },
 });
 

--- a/packages/agents/src/openai-codex.write.spec.ts
+++ b/packages/agents/src/openai-codex.write.spec.ts
@@ -1,0 +1,720 @@
+/**
+ * Contract tests for the OpenAI Codex metadata-only MCP write (E4 slice).
+ *
+ * These tests cover the E4 wiring contract:
+ *  1. Target selection: user config wins over workspace when both exist.
+ *  2. `not-targetable` when no applicable target file exists.
+ *  3. `unsupported-shape` when mcp_servers is not a table.
+ *  4. `dryRun` is honored (echoed on the result).
+ *  5. The result carries no raw bytes regardless of the reason.
+ *  6. E1 preservation: extension fields survive a server value update.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, writeFile, readFile, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openaiCodex } from './openai-codex.js';
+import type { OpenAICodexMcpConfig } from './openai-codex.js';
+import type { PathResolutionContext } from './types.js';
+import type { OvertureMcpServer } from '@overture/config';
+import { runPreservationChecks } from './writer-preservation/run.js';
+import { CODEX_FIXTURE } from './writer-preservation/fixtures.js';
+
+// ---------------------------------------------------------------------------
+// Per-test scratch directory
+// ---------------------------------------------------------------------------
+
+let scratchDir = '';
+
+async function tmp(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'codex-write-'));
+}
+
+beforeEach(async () => {
+  scratchDir = await tmp();
+});
+
+afterEach(async () => {
+  if (scratchDir) {
+    await rm(scratchDir, { recursive: true, force: true });
+    scratchDir = '';
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Context helper
+// ---------------------------------------------------------------------------
+
+function makeCtx(home?: string, ws?: string): PathResolutionContext {
+  return {
+    homeDir: home ?? scratchDir,
+    configDir: home ?? scratchDir,
+    workspaceDir: ws ?? scratchDir,
+    platform: 'linux' as const,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Config seed helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed a user .codex/config.toml file.
+ */
+async function seedUserConfig(dir: string, contents: string): Promise<string> {
+  const codexDir = join(dir, '.codex');
+  await mkdir(codexDir, { recursive: true });
+  const filePath = join(codexDir, 'config.toml');
+  await writeFile(filePath, contents, 'utf-8');
+  return filePath;
+}
+
+/**
+ * Seed a workspace .codex/config.toml file.
+ */
+async function seedWorkspaceConfig(
+  dir: string,
+  contents: string,
+): Promise<string> {
+  const codexDir = join(dir, '.codex');
+  await mkdir(codexDir, { recursive: true });
+  const filePath = join(codexDir, 'config.toml');
+  await writeFile(filePath, contents, 'utf-8');
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// Write-and-harness helpers (user target)
+// ---------------------------------------------------------------------------
+
+async function codexWriteAndHarnessUser(
+  ctx: PathResolutionContext,
+  servers: readonly { name: string; server: OvertureMcpServer }[],
+  targetPath: readonly string[],
+): Promise<{
+  caught: unknown;
+  report: ReturnType<typeof runPreservationChecks>;
+  written: string;
+  rewritten: string;
+}> {
+  const homeDir = ctx.homeDir;
+  const fixturePath = join(homeDir, '.codex', 'config.toml');
+
+  // ----- First apply -----
+  let firstCaught: unknown = null;
+  try {
+    await openaiCodex.mcp.write(ctx, { servers });
+  } catch (err) {
+    firstCaught = err;
+  }
+
+  let firstWritten = '';
+  try {
+    firstWritten = await readFile(fixturePath, 'utf-8');
+  } catch {
+    // Stub rejected before any IO
+  }
+
+  // ----- Second apply: idempotency proof -----
+  let secondCaught: unknown = null;
+  try {
+    await openaiCodex.mcp.write(ctx, { servers });
+  } catch (err) {
+    secondCaught = err;
+  }
+
+  let secondWritten = firstWritten;
+  try {
+    secondWritten = await readFile(fixturePath, 'utf-8');
+  } catch {
+    // Stub rejected before any IO during second apply
+  }
+
+  const original = await readFile(fixturePath, 'utf-8').catch(
+    () => CODEX_FIXTURE,
+  );
+  const report = runPreservationChecks({
+    format: 'toml',
+    original,
+    written: firstWritten,
+    rewritten: secondWritten,
+    targetPath: targetPath as string[],
+  });
+
+  const caught = firstCaught ?? secondCaught;
+  return { caught, report, written: firstWritten, rewritten: secondWritten };
+}
+
+// ---------------------------------------------------------------------------
+// Write-and-harness helpers (workspace target)
+// ---------------------------------------------------------------------------
+
+async function codexWriteAndHarnessWorkspace(
+  ctx: PathResolutionContext,
+  servers: readonly { name: string; server: OvertureMcpServer }[],
+  targetPath: readonly string[],
+): Promise<{
+  caught: unknown;
+  report: ReturnType<typeof runPreservationChecks>;
+  written: string;
+  rewritten: string;
+}> {
+  const wsDir = ctx.workspaceDir;
+  const fixturePath = join(wsDir, '.codex', 'config.toml');
+
+  // ----- First apply -----
+  let firstCaught: unknown = null;
+  try {
+    await openaiCodex.mcp.write(ctx, { servers });
+  } catch (err) {
+    firstCaught = err;
+  }
+
+  let firstWritten = '';
+  try {
+    firstWritten = await readFile(fixturePath, 'utf-8');
+  } catch {
+    // Stub rejected before any IO
+  }
+
+  // ----- Second apply: idempotency proof -----
+  let secondCaught: unknown = null;
+  try {
+    await openaiCodex.mcp.write(ctx, { servers });
+  } catch (err) {
+    secondCaught = err;
+  }
+
+  let secondWritten = firstWritten;
+  try {
+    secondWritten = await readFile(fixturePath, 'utf-8');
+  } catch {
+    // Stub rejected before any IO during second apply
+  }
+
+  const original = await readFile(fixturePath, 'utf-8').catch(
+    () => CODEX_FIXTURE,
+  );
+  const report = runPreservationChecks({
+    format: 'toml',
+    original,
+    written: firstWritten,
+    rewritten: secondWritten,
+    targetPath: targetPath as string[],
+  });
+
+  const caught = firstCaught ?? secondCaught;
+  return { caught, report, written: firstWritten, rewritten: secondWritten };
+}
+
+// ---------------------------------------------------------------------------
+// E4 — openaiCodex.mcp.write byte-splice contract
+// ---------------------------------------------------------------------------
+
+describe('openaiCodex.mcp.write (E4 byte-splice)', () => {
+  // -------------------------------------------------------------------------
+  // Target selection
+  // -------------------------------------------------------------------------
+
+  it('user-before-workspace: user config wins when both exist', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      await seedWorkspaceConfig(ws, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const canonicalFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/new/path'],
+      };
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: canonicalFs }],
+      });
+      // User target must be selected (scope === 'user')
+      expect(res.targetPaths).toHaveLength(1);
+      expect(res.targetPaths[0].scope).toBe('user');
+      expect(res.targetPaths[0].base).toBe('home');
+      expect(res.targetPaths[0].path).toContain('.codex/config.toml');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('workspace fallback: workspace config selected when user does not exist', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedWorkspaceConfig(ws, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const canonicalFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/new/path'],
+      };
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: canonicalFs }],
+      });
+      expect(res.targetPaths).toHaveLength(1);
+      expect(res.targetPaths[0].scope).toBe('project');
+      expect(res.targetPaths[0].base).toBe('workspace');
+      expect(res.targetPaths[0].path).toContain('.codex/config.toml');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('not-targetable when neither user nor workspace config exists', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      const ctx = makeCtx(home, ws);
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [
+          {
+            name: 'filesystem',
+            server: { type: 'stdio', command: 'echo', args: [] },
+          },
+        ],
+      });
+      expect(res.reason).toBe('not-targetable');
+      expect(res.written).toBe(0);
+      expect(res.changed).toBe(false);
+      expect(res.serversWritten).toHaveLength(0);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('not-targetable when user config file is empty', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, '');
+      await seedWorkspaceConfig(ws, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [
+          {
+            name: 'filesystem',
+            server: { type: 'stdio', command: 'echo', args: [] },
+          },
+        ],
+      });
+      expect(res.reason).toBe('not-targetable');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('not-targetable when mcp_servers table is missing', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      // Workspace exists but has no mcp_servers table; user config absent.
+      // Use a minimal TOML without any [mcp_servers.*] table.
+      await seedWorkspaceConfig(
+        ws,
+        '# config without mcp_servers\nmodel = "gpt-5"\n\n[sandbox]\nmode = "workspace-write"\n',
+      );
+      const ctx = makeCtx(home, ws);
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [
+          {
+            name: 'filesystem',
+            server: { type: 'stdio', command: 'echo', args: [] },
+          },
+        ],
+      });
+      expect(res.reason).toBe('not-targetable');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('unsupported-shape when mcp_servers is a scalar string', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      const badToml = 'mcp_servers = "not a table"';
+      await seedUserConfig(home, badToml);
+      const ctx = makeCtx(home, ws);
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [
+          {
+            name: 'filesystem',
+            server: { type: 'stdio', command: 'echo', args: [] },
+          },
+        ],
+      });
+      expect(res.reason).toBe('unsupported-shape');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('not-targetable when requested server is absent from config', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [
+          {
+            name: 'this-server-does-not-exist',
+            server: { type: 'stdio', command: 'echo', args: [] },
+          },
+        ],
+      });
+      expect(res.reason).toBe('not-targetable');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Metadata envelope — dry-run
+  // -------------------------------------------------------------------------
+
+  it('dry-run leaves disk unchanged', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const fixturePath = join(home, '.codex', 'config.toml');
+      const before = await readFile(fixturePath, 'utf-8');
+      const updatedFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/dryrun/path'],
+      };
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: updatedFs }],
+        dryRun: true,
+      });
+      expect(res.dryRun).toBe(true);
+      expect(res.written).toBe(1);
+      expect(res.changed).toBe(true);
+      expect(res.serversWritten).toEqual(['filesystem']);
+      expect(res.targetPaths).toHaveLength(1);
+      expect(res.format).toBe('toml');
+      expect(res.bytesChanged).toBeGreaterThan(0);
+      const after = await readFile(fixturePath, 'utf-8');
+      expect(after).toBe(before);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Metadata envelope — no-change
+  // -------------------------------------------------------------------------
+
+  it('no-change returns no-change metadata without modifying disk', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const fixturePath = join(home, '.codex', 'config.toml');
+      const before = await readFile(fixturePath, 'utf-8');
+      // Send the exact same server that's already in the fixture
+      const existingFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'npx',
+        args: [
+          '-y',
+          '@modelcontextprotocol/server-filesystem',
+          '/home/user/projects',
+        ],
+      };
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: existingFs }],
+      });
+      expect(res.reason).toBe('no-change');
+      expect(res.written).toBe(0);
+      expect(res.changed).toBe(false);
+      const after = await readFile(fixturePath, 'utf-8');
+      expect(after).toBe(before);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Metadata envelope — changed update (stdio)
+  // -------------------------------------------------------------------------
+
+  it('changed stdio update returns full metadata (format: toml)', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const updatedFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'npx',
+        args: [
+          '-y',
+          '@modelcontextprotocol/server-filesystem',
+          '/updated/path',
+        ],
+      };
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: updatedFs }],
+      });
+      expect(res.written).toBe(1);
+      expect(res.changed).toBe(true);
+      expect(res.dryRun).toBe(false);
+      expect(res.serversWritten).toEqual(['filesystem']);
+      expect(res.targetPaths).toHaveLength(1);
+      expect(res.resolvedPath).toContain('.codex/config.toml');
+      expect(res.format).toBe('toml');
+      expect(res.bytesChanged).toBeGreaterThan(0);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Metadata envelope — changed update (remote)
+  // -------------------------------------------------------------------------
+
+  it('changed remote update returns full metadata (format: toml)', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const updatedRemote: OvertureMcpServer = {
+        type: 'remote',
+        url: 'https://mcp.example.com/new-bridge',
+        headers: { Authorization: 'Bearer new-token' },
+      };
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: updatedRemote }],
+      });
+      expect(res.written).toBe(1);
+      expect(res.changed).toBe(true);
+      expect(res.dryRun).toBe(false);
+      expect(res.serversWritten).toEqual(['filesystem']);
+      expect(res.targetPaths).toHaveLength(1);
+      expect(res.format).toBe('toml');
+      expect(res.bytesChanged).toBeGreaterThan(0);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // E1 preservation — user target
+  // -------------------------------------------------------------------------
+
+  it('E1 preservation: stdio update user target passes runPreservationChecks', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const updatedFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'npx',
+        args: [
+          '-y',
+          '@modelcontextprotocol/server-filesystem',
+          '/updated/user/path',
+        ],
+      };
+      const { caught, report } = await codexWriteAndHarnessUser(
+        ctx,
+        [{ name: 'filesystem', server: updatedFs }],
+        ['mcp_servers', 'filesystem'],
+      );
+      expect(caught).toBeNull();
+      const failures = report.checks
+        .filter((c) => !c.pass && !c.skipped)
+        .map((c) => `${c.name}: ${c.details}`)
+        .join('; ');
+      expect(
+        report.allPassed,
+        `Expected all checks to pass. Failures: ${failures}`,
+      ).toBe(true);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('E1 preservation: remote update user target passes runPreservationChecks', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const updatedRemote: OvertureMcpServer = {
+        type: 'remote',
+        url: 'https://mcp.example.com/updated-remote',
+        headers: { Authorization: 'Bearer updated-token' },
+      };
+      const { caught, report } = await codexWriteAndHarnessUser(
+        ctx,
+        [{ name: 'filesystem', server: updatedRemote }],
+        ['mcp_servers', 'filesystem'],
+      );
+      expect(caught).toBeNull();
+      const failures = report.checks
+        .filter((c) => !c.pass && !c.skipped)
+        .map((c) => `${c.name}: ${c.details}`)
+        .join('; ');
+      expect(
+        report.allPassed,
+        `Expected all checks to pass. Failures: ${failures}`,
+      ).toBe(true);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Registry spy — second-apply idempotency
+  // -------------------------------------------------------------------------
+
+  it('registry spy: openaiCodex.mcp.write invoked exactly twice in codexWriteAndHarnessWorkspace', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedWorkspaceConfig(ws, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const updatedFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'npx',
+        args: [
+          '-y',
+          '@modelcontextprotocol/server-filesystem',
+          '/idempotency/path',
+        ],
+      };
+
+      const writeSpy = vi.spyOn(openaiCodex.mcp, 'write');
+
+      try {
+        const {
+          report,
+          written: firstWritten,
+          rewritten: secondWritten,
+        } = await codexWriteAndHarnessWorkspace(
+          ctx,
+          [{ name: 'filesystem', server: updatedFs }],
+          ['mcp_servers', 'filesystem'],
+        );
+
+        expect(writeSpy.mock.calls.length).toBe(2);
+
+        // Second invocation's on-disk bytes must match the first invocation's written bytes
+        expect(secondWritten).toBe(firstWritten);
+
+        // Sanity: the preservation report still passes identity for the workspace target
+        expect(report.allPassed).toBe(true);
+      } finally {
+        writeSpy.mockRestore();
+      }
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-contiguous descendant layout
+  // -------------------------------------------------------------------------
+
+  it('non-contiguous descendant layout returns unsupported-shape', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      // TOML where mcp_servers.foo has a sibling bar that comes after it,
+      // but foo also has a descendant foo.env that appears after bar.
+      // The harness range stops at bar, so foo.env is outside the contiguous range.
+      const nestedToml = `
+[sandbox]
+mode = "workspace-write"
+
+[mcp_servers.foo]
+command = "npx"
+args = ["-y", "foo-mcp"]
+
+[mcp_servers.bar]
+command = "npx"
+args = ["-y", "bar-mcp"]
+
+[mcp_servers.foo.env]
+FOO_API_KEY = "\${FOO_API_KEY}"
+`;
+      await seedUserConfig(home, nestedToml);
+      const ctx = makeCtx(home, ws);
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [
+          {
+            name: 'foo',
+            server: { type: 'stdio', command: 'npx', args: ['-y', 'foo-mcp'] },
+          },
+        ],
+      });
+      expect(res.reason).toBe('unsupported-shape');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Transport switch drops incompatible fields
+  // -------------------------------------------------------------------------
+
+  it('transport switch drops incompatible fields', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      // Seed with a stdio server entry
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      // Switch filesystem from stdio to remote
+      const remoteServer: OvertureMcpServer = {
+        type: 'remote',
+        url: 'https://mcp.example.com/bridge',
+      };
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: remoteServer }],
+      });
+      expect(res.changed).toBe(true);
+      expect(res.written).toBe(1);
+      // After transport switch, the written entry should have url but not command/args
+      const fixturePath = join(home, '.codex', 'config.toml');
+      const written = await readFile(fixturePath, 'utf-8');
+      expect(written).toContain('url');
+      // Verify the filesystem block specifically has no command = (not just any server in the file)
+      const filesystemBlock =
+        written
+          .split('[mcp_servers.filesystem]')[1]
+          ?.split(/\[mcp_servers\.\w+\]/)[0] ?? '';
+      expect(filesystemBlock).not.toMatch(/^\s*command\s*=/m);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agents/src/openai-codex.write.spec.ts
+++ b/packages/agents/src/openai-codex.write.spec.ts
@@ -14,7 +14,6 @@ import { mkdtemp, writeFile, readFile, rm, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { openaiCodex } from './openai-codex.js';
-import type { OpenAICodexMcpConfig } from './openai-codex.js';
 import type { PathResolutionContext } from './types.js';
 import type { OvertureMcpServer } from '@overture/config';
 import { runPreservationChecks } from './writer-preservation/run.js';

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -1178,10 +1178,61 @@ function tomlDeepEqual(a: unknown, b: unknown): boolean {
 }
 
 /**
+ * Parse a TOML table header line (e.g. `[mcp_servers.filesystem]` or
+ * `[mcp_servers."server.with.dot".env]`) into the sequence of segment
+ * strings that the header names. Handles bare keys and quoted segments
+ * (single or double quotes). Returns null for malformed headers.
+ */
+function parseTomlHeaderPath(line: string): readonly string[] | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return null;
+  const inner = trimmed.slice(1, -1);
+  const segments: string[] = [];
+  let i = 0;
+  while (i < inner.length) {
+    // Skip whitespace between segments.
+    while (i < inner.length && (inner[i] === ' ' || inner[i] === '\t')) i++;
+    if (i >= inner.length) break;
+    const ch = inner[i];
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      const start = i + 1;
+      let j = start;
+      while (j < inner.length && inner[j] !== quote) {
+        if (inner[j] === '\\' && j + 1 < inner.length) j += 2;
+        else j++;
+      }
+      if (j >= inner.length) return null; // unterminated quote
+      segments.push(inner.slice(start, j));
+      i = j + 1;
+    } else {
+      // Bare key: letters, digits, '-', '_'.
+      const start = i;
+      while (i < inner.length && /[A-Za-z0-9_-]/.test(inner[i] ?? '')) {
+        i++;
+      }
+      if (i === start) return null; // bare key has zero chars
+      segments.push(inner.slice(start, i));
+    }
+    // After a segment, expect either '.' (more segments) or end-of-header.
+    if (i < inner.length) {
+      if (inner[i] === '.') i++;
+      else return null; // unexpected character between segments
+    }
+  }
+  if (segments.length === 0) return null;
+  return segments;
+}
+
+/**
  * Find the line range `[startLine, endLine)` of the targetPath
  * subtree in a TOML document. For `['mcp_servers']`, returns the
  * range of `[mcp_servers.*]` subtables. For `['mcp_servers', 'filesystem']`,
- * returns the range of `[mcp_servers.filesystem]`.
+ * returns the range starting at `[mcp_servers.filesystem]` and including
+ * contiguous descendant subtables `[mcp_servers.filesystem.*]`. Stops
+ * at the first sibling or non-descendant header (single contiguous
+ * range only — the writer must reject non-contiguous layouts
+ * separately as `unsupported-shape`).
  */
 function findTomlTargetPathLineRange(
   text: string,
@@ -1218,20 +1269,36 @@ function findTomlTargetPathLineRange(
   if (targetPath.length === 2) {
     const parent = targetPath[0]!;
     const child = targetPath[1]!;
-    const headerRe = new RegExp(
-      `^\\s*\\[${escapeRegExp(parent)}\\.${escapeRegExp(child)}\\]$`,
-    );
+    // Find the start header via parseTomlHeaderPath so quoted-key
+    // segments like `[mcp_servers."server.with.dot"]` match exactly.
+    // Then continue including descendant headers whose parsed path
+    // starts with [parent, child, ...] and is strictly longer than 2
+    // segments. Stop at the first header that is not a descendant.
     let startLine = -1;
     let endLine = lines.length;
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
-      if (startLine === -1 && headerRe.test(line)) {
-        startLine = i;
-        continue;
-      }
-      if (startLine !== -1 && line.trim().startsWith('[')) {
-        endLine = i;
-        break;
+      if (startLine === -1) {
+        const path = parseTomlHeaderPath(line);
+        if (
+          path !== null &&
+          path.length >= 2 &&
+          path[0] === parent &&
+          path[1] === child
+        ) {
+          startLine = i;
+          continue;
+        }
+      } else {
+        // We're inside the target range; check if this header is a descendant.
+        const path = parseTomlHeaderPath(line);
+        if (path === null) continue; // non-header line, include in range
+        const isDescendant =
+          path.length > 2 && path[0] === parent && path[1] === child;
+        if (!isDescendant) {
+          endLine = i;
+          break;
+        }
       }
     }
     if (startLine === -1) return null;

--- a/packages/agents/src/writer-preservation/fixtures.ts
+++ b/packages/agents/src/writer-preservation/fixtures.ts
@@ -178,3 +178,68 @@ CONTEXT7_API_KEY = "\${CONTEXT7_API_KEY}"
 url = "https://mcp.example.com/bridge"
 bearer_token_env_var = "MCP_BRIDGE_TOKEN"
 `;
+export const CODEX_DESCENDANT_FIXTURE = `# Codex config with descendant subtables for both target AND a sibling.
+# Used by S12 to prove the harness treats descendant subtables of the
+# target as inside the target, while descendant subtables of a SIBLING
+# (filesystem.env) are correctly treated as outside.
+model = "gpt-5"
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem"]
+
+[mcp_servers.filesystem.env]
+LOG_LEVEL = "info"
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@latest"]
+
+[mcp_servers.context7.env]
+CONTEXT7_API_KEY = "\${CONTEXT7_API_KEY}"
+
+[mcp_servers.remote-bridge]
+url = "https://mcp.example.com/bridge"
+`;
+
+export const CODEX_QUOTED_KEY_FIXTURE = `# Codex config with a quoted-key MCP server name (dot in name).
+# Used by S13 to prove the harness parses [mcp_servers."server.with.dot"]
+# as path segments ["mcp_servers", "server.with.dot"] (not four segments
+# split on the literal dot).
+model = "gpt-5"
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem"]
+
+[mcp_servers."server.with.dot"]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@latest"]
+startup_timeout_sec = 15
+
+[mcp_servers."server.with.dot".env]
+API_KEY = "\${API_KEY}"
+
+[mcp_servers.remote-bridge]
+url = "https://mcp.example.com/bridge"
+`;
+
+export const CODEX_NON_CONTIGUOUS_FIXTURE = `# Codex config with a non-contiguous descendant layout.
+# The harness uses a single contiguous line range, so when a target
+# descendant ([mcp_servers.foo.env]) appears AFTER a sibling
+# ([mcp_servers.bar]), the harness range stops at the sibling and the
+# descendant is OUTSIDE the range. The writer (Todo 2) rejects this
+# layout as unsupported-shape; the harness simply reports the descendant
+# as outside the allowed mutation zone.
+[mcp_servers.foo]
+command = "npx"
+args = ["-y", "foo-mcp"]
+
+[mcp_servers.bar]
+command = "npx"
+args = ["-y", "bar-mcp"]
+
+# This descendant appears AFTER a sibling — outside the harness range.
+[mcp_servers.foo.env]
+FOO_API_KEY = "\${FOO_API_KEY}"
+`;

--- a/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
+++ b/packages/agents/src/writer-preservation/run-preservation-checks.spec.ts
@@ -33,6 +33,9 @@ import {
 import {
   CLAUDE_CODE_FIXTURE,
   CODEX_FIXTURE,
+  CODEX_DESCENDANT_FIXTURE,
+  CODEX_NON_CONTIGUOUS_FIXTURE,
+  CODEX_QUOTED_KEY_FIXTURE,
   COPILOT_CLI_FIXTURE,
   OPENCODE_FIXTURE,
 } from './fixtures.js';
@@ -591,5 +594,69 @@ describe('S10 — every supported format (json/jsonc/toml) is covered end-to-end
       'filesystem',
     ]);
     expect(findCheck(report, 'comments').pass).toBe(false);
+  });
+});
+
+describe('S12 — TOML descendant tables inside target', () => {
+  it('A: mutate CONTEXT7_API_KEY (inside target descendant) → allPassed', () => {
+    const original = CODEX_DESCENDANT_FIXTURE;
+    const written = original.replace(
+      'CONTEXT7_API_KEY = "${CONTEXT7_API_KEY}"',
+      'CONTEXT7_API_KEY = "NEW_VALUE"',
+    );
+    const report = check('toml', original, written, [
+      'mcp_servers',
+      'context7',
+    ]);
+    expect(report.allPassed).toBe(true);
+  });
+
+  it('B: mutate filesystem command (outside target) → rawBytes fails', () => {
+    const original = CODEX_DESCENDANT_FIXTURE;
+    const written = original.replace('command = "npx"', 'command = "deno"');
+    const report = check('toml', original, written, [
+      'mcp_servers',
+      'context7',
+    ]);
+    expect(findCheck(report, 'rawBytes').pass).toBe(false);
+  });
+});
+
+describe('S13 — TOML quoted keys', () => {
+  it('A: mutate API_KEY inside quoted-key server → allPassed', () => {
+    const original = CODEX_QUOTED_KEY_FIXTURE;
+    const written = original.replace(
+      'API_KEY = "${API_KEY}"',
+      'API_KEY = "NEW_VALUE"',
+    );
+    const report = check('toml', original, written, [
+      'mcp_servers',
+      'server.with.dot',
+    ]);
+    expect(report.allPassed).toBe(true);
+  });
+
+  it('B: mutate filesystem command (outside quoted-key target) → rawBytes fails', () => {
+    const original = CODEX_QUOTED_KEY_FIXTURE;
+    const written = original.replace('command = "npx"', 'command = "deno"');
+    const report = check('toml', original, written, [
+      'mcp_servers',
+      'server.with.dot',
+    ]);
+    expect(findCheck(report, 'rawBytes').pass).toBe(false);
+  });
+});
+
+describe('S14 — TOML non-contiguous descendants', () => {
+  it('mutate FOO_API_KEY where descendant appears after sibling → rawBytes fails', () => {
+    // [mcp_servers.foo.env] appears AFTER [mcp_servers.bar]. The harness
+    // range stops at [mcp_servers.bar], so foo.env is OUTSIDE the target.
+    const original = CODEX_NON_CONTIGUOUS_FIXTURE;
+    const written = original.replace(
+      'FOO_API_KEY = "${FOO_API_KEY}"',
+      'FOO_API_KEY = "NEW_VALUE"',
+    );
+    const report = check('toml', original, written, ['mcp_servers', 'foo']);
+    expect(findCheck(report, 'rawBytes').pass).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Implements the fourth and final registered agent's update-only MCP writer: **OpenAI Codex**. The writer splices `[mcp_servers.<name>]` subtrees via line-range byte splicing on `.codex/config.toml`, mirroring the E3 JSONC byte-splice approach.

## Behavior

- **Update-only**: refuses to create missing files, missing `mcp_servers` containers, or missing server names (`reason: 'not-targetable'`).
- **Non-object `mcp_servers`** → `unsupported-shape`.
- **Non-contiguous descendant layouts** (e.g. `[mcp_servers.foo.env]` after `[mcp_servers.bar]`) → `unsupported-shape`.
- **Preserves compatible native extension fields**: `startup_timeout_sec`, `tool_timeout_sec`, `enabled_tools`, `disabled_tools`, `scopes`, `oauth_resource`, `required`, `enabled`, `env_vars`, `cwd`, `bearer_token_env_var`, `env_http_headers`.
- **Transport switch cleanup**: stdio→remote drops `command`, `args`, `env`, `env_vars`, `cwd`; remote→stdio drops `url`, `bearer_token_env_var`, `http_headers`, `env_http_headers`.
- **Unknown array/map extension values** → `unsupported-shape`.
- **Parser failures** → `reason: 'parse-error'` (no parser text in result).
- **Dry-run** leaves disk bytes unchanged.

## Preservation harness hardening

The E1 preservation harness was extended to:
- Parse TOML headers via a new `parseTomlHeaderPath` helper that handles bare keys, double-quoted segments, and single-quoted segments (so `[mcp_servers."server.with.dot"]` matches correctly).
- Treat `[mcp_servers.X]` targets as inclusive of contiguous descendant subtables `[mcp_servers.X.*]` in a single contiguous line range.
- Stop at the first non-descendant header (sibling or outside table).

Harness remains single-range; non-contiguous descendants are the writer-level rejection responsibility (per the plan).

## Out of scope (per E4 plan)

- No `overture apply` / `apply --dry-run` / backups / state files / logs / restore helper.
- No insertion of missing Codex config files / tables / servers.
- No YAML writers or new agents.
- No changes to `AGENT_REGISTRY_ORDER`.
- No expansion of the public `WriteReason` union.
- No raw original/written TOML bytes in `AgentMcpWriteResult`.

## Final gate results

- `yarn nx test @overture/agents --skip-nx-cache`: PASS
- `yarn nx build @overture/agents --skip-nx-cache`: PASS
- `yarn nx test @jander99/overture --skip-nx-cache`: PASS (217 tests across 18 spec files)
- `yarn nx build @jander99/overture --skip-nx-cache`: PASS
- `yarn prettier --check .`: PASS
- `node apps/cli/scripts/verify-package.mjs`: PASS (bootstrap smoke + tarball shape)

## Next slice

`F1` — `overture apply --dry-run`.

## Merge policy

**This PR is open and should NOT be merged yet** — the project workflow is to merge E4 after explicit user authorization.