### PR TITLE
feat(cli): add overture apply --dry-run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,19 +88,23 @@ is what CI runs and what should gate a commit.
   any package that ends up using `import ... from 'pkg'`.
 - **CI is correct now.** `.github/workflows/ci.yml` uses `setup-node` with
   Node 24 LTS and `yarn install --immutable` via Corepack. The Quality Gates
-  job runs `npx prettier --check .`; the Lint step is a tracked-no-op until
-  a lint target is added (see `.omo/plans/`). The Test job runs
-  `npx nx test @jander99/overture`. A new `package-verify` job runs
-  `node apps/cli/scripts/verify-package.mjs` to assert the npm pack tarball
-  shape, smoke-tests the installed binary, and guards the published
+  job runs `npx prettier --check .` and `npx nx lint @jander99/overture
+--skip-nx-cache` (type-aware ESLint via `eslint.config.mjs` at the repo
+  root; the `@nx/eslint:lint` target in `apps/cli/package.json` is wired
+  with `maxWarnings: 0` so any lint error or warning fails the gate). The
+  Test job runs `npx nx test @jander99/overture`. A `package-verify` job
+  runs `node apps/cli/scripts/verify-package.mjs` to assert the npm pack
+  tarball shape, smoke-tests the installed binary, and guards the published
   contract. Local dev mirrors these: `yarn install --immutable`,
   `yarn nx test @jander99/overture`, `yarn nx build @jander99/overture`,
-  `yarn prettier --check .`.
-- **Lint target is not configured.** `npx nx run-many -t lint --all` will
-  fail until a `lint` target is added to `apps/cli` (and the corresponding
-  ESLint toolchain). The CI step is currently a tracked no-op. Don't try to
-  silence it with `|| true`; either wire the target or leave the
-  no-op-and-log.
+  `yarn prettier --check .`, `yarn nx lint @jander99/overture --skip-nx-cache`.
+- **Lint target is wired (since #74).** `apps/cli/package.json` declares a
+  `lint` target using `@nx/eslint:lint` with `lintFilePatterns:
+['apps/cli/**/*.ts']`. The flat config at `eslint.config.mjs` enables
+  `typescript-eslint`'s `recommendedTypeChecked` + `stylisticTypeChecked`
+  presets, so most spec/implementation issues surface here rather than at
+  `tsc` time. New code must pass `yarn nx lint @jander99/overture
+--skip-nx-cache` before merge.
 - **`bin` points at the built artifact.** `overture` won't work after a
   fresh checkout until you `yarn nx run @jander99/overture:link` (which
   builds + `npm link`s). The bundle is **partially** vendored: `jsonc-parser`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,94 @@ All commands run from the repo root.
 - Verify a local npm pack + install + smoke (no publish):
   `node apps/cli/scripts/verify-package.mjs`.
 
+## Pre-PR checklist
+
+Before pushing a PR, run the full CI gate stack locally and confirm
+every command exits 0. These commands match `.github/workflows/ci.yml`
+exactly (same order, same flags); a local green light is necessary
+but not sufficient — CI may still differ if your environment drifted.
+
+**Always use the workspace-pinned versions of these tools.** RTK's
+runtime versions of `prettier`, `eslint`, `tsc`, `vitest`, and `nx`
+may not match the versions this workspace pins in `package.json`;
+CI always uses the pinned versions, so the local pre-PR run must
+too. Invoke them through `yarn` (which resolves to the workspace pin)
+or directly via `./node_modules/.bin/<tool>`. See the RTK section
+below for the full rationale.
+
+```bash
+# Run from the repo root or the worktree that owns the branch.
+
+# Quality Gates (job: quality)
+yarn nx lint @jander99/overture --skip-nx-cache    # ESLint (lint step)
+npx tsc -b apps/cli/tsconfig.json                  # typecheck (typecheck step)
+yarn prettier --check .                            # format (format step — WHOLE REPO)
+
+# Test (job: test)
+yarn nx test @jander99/overture
+
+# Package verification (job: package-verify)
+node apps/cli/scripts/verify-package.mjs
+
+# Build & detect (job: build-and-detect)
+yarn nx build @jander99/overture --skip-nx-cache   # build step
+node apps/cli/dist/main.js detect --json           # runtime smoke (see below)
+```
+
+The runtime smoke step mirrors the CI assertion at
+`.github/workflows/ci.yml:171-182`: the built binary, run on a
+clean environment with no installed MCP agents, must report all
+4 registry entries with `installed: false` and no `parseError`.
+Locally that translates to:
+
+```bash
+node apps/cli/dist/main.js detect --json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+assert isinstance(data.get('platforms'), list)
+assert len(data['platforms']) == 4
+for p in data['platforms']:
+    assert p.get('installed') is False, f'{p[\"id\"]} reports installed locally'
+    assert not p.get('parseError'), f'{p[\"id\"]} has parseError'
+print('OK')
+"
+```
+
+**What each gate catches**
+
+- `nx lint` — `@nx/eslint:lint` (target in `apps/cli/package.json`,
+  `maxWarnings: 0`) against `eslint.config.mjs` (type-aware
+  `recommendedTypeChecked` + `stylisticTypeChecked`). Catches type
+  errors `tsc` misses, unused locals/vars, non-null on optional
+  chains, unsafe `any` casts, dot-notation violations.
+- `tsc -b apps/cli/tsconfig.json` — `tsconfig.base.json` enforces
+  `strict`, `noUnusedLocals`, `noImplicitReturns`,
+  `noImplicitOverride`, `noFallthroughCasesInSwitch`,
+  `noEmitOnError`. Catches the rest of the type errors. Composite
+  projects require declaration emit; **do not pass `--noEmit`**.
+- `prettier --check .` — whole-repo formatting check. **Selective
+  subsets ship drift.** CI uses `.`; do the same locally.
+- `nx test` — Vitest 4 (`apps/cli/vitest.config.mts`); `jsdom` env,
+  `globals: true`.
+- `verify-package.mjs` — packs the workspace tarball, installs it
+  in a clean location, smoke-tests the installed binary (currently
+  `overture detect` and `overture bootstrap --dry-run`).
+- `nx build` — esbuild bundle. `--skip-nx-cache` catches `^build`
+  regressions (the `@overture/agents` package must build before
+  `apps/cli`).
+- `node dist/main.js detect --json` smoke — catches missing runtime
+  deps (e.g. `smol-toml`), broken Yarn workspace symlinks, and
+  other pipeline breakage the unit tests don't see.
+
+**Commit hygiene**
+
+- Stage only intended files. Never stage untracked `ARCHITECTURE.md`,
+  `STRUCTURE.md`, `.codegraph/`, `.cortexkit/`, or `.omo/evidence/`.
+- Each commit must be self-contained: the diff between any two
+  consecutive commits must compile, lint, format-check, test, and
+  build cleanly. CI runs against the merge-base, but reviewers read
+  commit-by-commit.
+
 ## RTK
 
 RTK intercepts shell commands at runtime — `git status` becomes

--- a/apps/cli/src/apply-command.spec.ts
+++ b/apps/cli/src/apply-command.spec.ts
@@ -1,0 +1,1099 @@
+/**
+ * F1 — `overture apply --dry-run` test suite.
+ *
+ * Locks the F1 contract: gate-5 types (`ApplyDryRunResult`,
+ * `RunApplyOptions`), the args/exit-code plumbing (`runApply`,
+ * `exitCodeForApplyDryRun`), the human renderer (`formatHumanApplyDryRun`),
+ * and the orchestration that wires the canonical config to per-agent
+ * writers via `mcp.write({ ..., dryRun: true })`.
+ *
+ * Style mirrors `apps/cli/src/bootstrap-command.spec.ts`: real tmpdirs
+ * for filesystem isolation, `BufferWriter` from
+ * `test-support/bootstrap-test-support.ts` for stdout/stderr, and
+ * per-test env override + restore via `beforeEach`/`afterEach`.
+ *
+ * Coverage map (each `it(...)` is one bullet):
+ *   1. happy path — seeded Claude + OpenCode configs, --dry-run,
+ *      seeded bytes are byte-identical before vs after.
+ *   2. --json --dry-run envelope shape (matches gate-5).
+ *   3. missing canonical config → exit 1 + "no overture config".
+ *   4. unknown `settings.defaultProfile` → exit 2.
+ *   5. unknown agent id in `sync.targets` → per-agent refusal, others
+ *      still complete.
+ *   6. agent without `mcp.write` → per-agent refusal with reason
+ *      "no writer registered".
+ *   7. `disabledServers` excludes a server from the writer input.
+ *   8. `settings.defaultProfile` is honored when set.
+ *   9. exit code 1 when any result has a refusal reason
+ *      (`not-targetable`, `parse-error`, `unsupported-shape`,
+ *      `unsupported-format`).
+ *   10. exit code 0 when every result is `no-change`.
+ *   11. `apply` without `--dry-run` → exit 2 + "not yet implemented".
+ *   12. `apply --json` without `--dry-run` → exit 2 (invalid combo).
+ *   13. regression: Claude dry-run with a planned update (seeded file
+ *       content differs from canonical) classifies as `would-update`,
+ *       not `no-change`. Different writers encode the dry-run "would
+ *       have written" signal differently (OpenCode / OpenAI Codex set
+ *       `changed: true`; Claude / GitHub Copilot CLI leave `changed:
+ *       false` and surface `serversWritten` / `bytesChanged` instead);
+ *       `statusFromWriterResult` must accept both conventions.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { defaultOverturePaths } from '@overture/config';
+import { agentRegistry } from '@overture/agents';
+import type {
+  AgentDefinition,
+  AgentMcpWriteResult,
+  PlatformId,
+} from '@overture/agents';
+
+import {
+  APPLY_USAGE,
+  exitCodeForApplyDryRun,
+  formatHumanApplyDryRun,
+  runApply,
+  type ApplyDryRunAgentResult,
+  type ApplyDryRunResult,
+  type RunApplyOptions,
+} from './apply-command.js';
+import { BufferWriter } from '../test-support/bootstrap-test-support.js';
+
+// Touch RunApplyOptions so a future refactor that removes the export
+// surfaces as a compile error here. The F1 slice exposes it for tests
+// that need to inject a path context (e.g. spies); the happy-path tests
+// below rely on the default factory, but we keep the type referenced so
+// a sloppy removal is caught.
+export type _ApplyOptionsTouched = RunApplyOptions;
+void (null as unknown as _ApplyOptionsTouched);
+
+// ---------------------------------------------------------------------------
+// Test environment helpers — mirror bootstrap-command.spec.ts.
+// ---------------------------------------------------------------------------
+
+interface ApplyTempEnv {
+  readonly home: string;
+  readonly xdgConfigHome: string;
+  readonly pathDir: string;
+  /**
+   * Isolated workspace directory. The test calls `process.chdir(workspace)`
+   * in beforeEach so Claude Code's writer picks `~/.claude.json` instead
+   * of any `.mcp.json` that may exist at the real cwd (e.g. the worktree
+   * root ships one for the `nx-mcp` server). After each test, afterEach
+   * restores the previous cwd.
+   */
+  readonly workspace: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly cleanup: readonly string[];
+}
+
+function createApplyTempEnv(): ApplyTempEnv {
+  const home = mkdtempSync(join(tmpdir(), 'overture-apply-home-'));
+  const xdgConfigHome = mkdtempSync(join(tmpdir(), 'overture-apply-xdg-'));
+  const pathDir = mkdtempSync(join(tmpdir(), 'overture-apply-path-'));
+  // Each test gets its own workspace dir; chdir there so writer pickers
+  // resolve against an isolated tree with no project-level `.mcp.json`.
+  const workspace = mkdtempSync(join(tmpdir(), 'overture-apply-ws-'));
+  return {
+    home,
+    xdgConfigHome,
+    pathDir,
+    workspace,
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: xdgConfigHome,
+      PATH: pathDir,
+    },
+    cleanup: [home, xdgConfigHome, pathDir, workspace],
+  };
+}
+
+function applyEnv(env: {
+  readonly home: string;
+  readonly xdgConfigHome: string;
+  readonly pathDir: string;
+  readonly workspace: string;
+}): void {
+  process.env.HOME = env.home;
+  process.env.XDG_CONFIG_HOME = env.xdgConfigHome;
+  process.env.PATH = env.pathDir;
+  // Isolate `cwd` so the writer pickers (Claude Code's `<workspaceDir>/.mcp.json`
+  // preference, in particular) don't see a project-level `.mcp.json` left over
+  // from the real cwd (e.g. the worktree root ships one for the `nx-mcp`
+  // server). cwd restoration lives in the suite's afterEach.
+  process.chdir(env.workspace);
+}
+
+// All four agents get stubs on PATH so binary-first detection never
+// gates the writers during the happy path. We do NOT touch installed
+// state via the agent registry — that is owned by the writer module
+// and tested separately. Here we only need the writer to be invoked.
+function seedFakeBin(pathDir: string, name: string): void {
+  const bin = join(pathDir, name);
+  writeFileSync(bin, '#!/bin/sh\nexit 0\n');
+  chmodSync(bin, 0o755);
+}
+
+function seedAllFakeBins(pathDir: string): void {
+  for (const name of ['opencode', 'claude']) {
+    seedFakeBin(pathDir, name);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Canonical config fixture builders.
+// ---------------------------------------------------------------------------
+
+interface CanonicalConfigOptions {
+  readonly defaultProfileName?: string;
+  readonly profileName?: string;
+  readonly mcpServers?: Readonly<Record<string, unknown>>;
+  readonly targets?: readonly string[];
+  readonly disabledServers?: readonly string[];
+}
+
+function buildCanonicalConfigJson(
+  options: CanonicalConfigOptions = {},
+): string {
+  const profileName = options.profileName ?? 'default';
+  const mcpServers = options.mcpServers ?? {
+    filesystem: {
+      type: 'stdio',
+      command: 'node',
+    },
+  };
+  const targets = options.targets ?? ['claude-code', 'opencode'];
+  const disabledServers = options.disabledServers ?? [];
+  const profiles: Record<string, unknown> = {
+    [profileName]: {
+      mcpServers,
+      sync: { targets, disabledServers },
+      skills: [],
+    },
+  };
+  if (profileName !== 'default') {
+    profiles['default'] = {
+      mcpServers: {},
+      sync: { targets: [], disabledServers: [] },
+      skills: [],
+    };
+  }
+  // F1 only consumes `settings.defaultProfile`. The other Settings fields
+  // are valid schema members but irrelevant to the apply preview; the spec
+  // omits them so scope greps for F2/F3 keywords (backupBeforeWrite,
+  // conflictPolicy) stay clean.
+  const settings: Record<string, unknown> = {
+    defaultProfile: options.defaultProfileName ?? profileName,
+    dryRunByDefault: true,
+  };
+  return JSON.stringify(
+    {
+      version: 1,
+      settings,
+      profiles,
+    },
+    null,
+    2,
+  );
+}
+
+function seedCanonicalConfig(xdgConfigHome: string, json: string): string {
+  // Derive the on-disk config path purely from the XDG override so this
+  // helper does not need to read process.env (the test's beforeEach has
+  // already set XDG_CONFIG_HOME by the time this runs).
+  const paths = defaultOverturePaths(
+    {},
+    {
+      ...process.env,
+      XDG_CONFIG_HOME: xdgConfigHome,
+    },
+  );
+  mkdirSync(paths.configDir, { recursive: true });
+  writeFileSync(paths.configFile, json);
+  return paths.configFile;
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent config fixtures.
+// ---------------------------------------------------------------------------
+
+function claudeUserConfigJson(serverName = 'filesystem'): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [serverName]: {
+          type: 'stdio',
+          command: 'node',
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function opencodeConfigJsonc(serverName = 'filesystem'): string {
+  return `{
+  // apply dry-run fixture
+  "mcp": {
+    "${serverName}": {
+      "type": "local",
+      "command": ["node"]
+    }
+  }
+}
+`;
+}
+
+function seedClaudeUserConfig(home: string, contents: string): string {
+  const p = join(home, '.claude.json');
+  writeFileSync(p, contents);
+  return p;
+}
+
+function seedOpencodeUserConfig(
+  xdgConfigHome: string,
+  contents: string,
+): string {
+  const dir = join(xdgConfigHome, 'opencode');
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, 'opencode.jsonc');
+  writeFileSync(p, contents);
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Suite-wide env save/restore.
+// ---------------------------------------------------------------------------
+
+const ALL_PLATFORM_IDS: readonly PlatformId[] = [
+  'claude-code',
+  'opencode',
+  'github-copilot-cli',
+  'openai-codex',
+];
+
+describe('runApply (F1 dry-run contract)', () => {
+  let cleanupDirs: readonly string[] = [];
+  let originalEnv: NodeJS.ProcessEnv;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    cleanupDirs = [];
+    originalEnv = { ...process.env };
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    for (const dir of cleanupDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    // Restore cwd so a chdir inside a test does not leak across cases.
+    // `process.chdir` throws on undefined, but beforeEach always captures
+    // a real cwd at suite start.
+    process.chdir(originalCwd);
+    // Restore env: simplest reliable approach is to drop our additions and
+    // re-apply the captured snapshot. process.env is sealed enough that
+    // restoring keys by name is the supported pattern.
+    for (const key of [
+      'HOME',
+      'XDG_CONFIG_HOME',
+      'XDG_CONFIG_DIRS',
+      'XDG_DATA_HOME',
+      'XDG_STATE_HOME',
+      'XDG_CACHE_HOME',
+      'PATH',
+      'USERPROFILE',
+    ]) {
+      const original = originalEnv[key];
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 11 + 12 — invalid flag combinations.
+  //
+  // These two cases must work even when there is no implementation
+  // behind them, so the dispatcher contract is exercised first. They
+  // live at the top so the failure mode is obvious in the run output.
+  // -------------------------------------------------------------------------
+
+  it('rejects `apply` without --dry-run with exit 2 + "not yet implemented"', async () => {
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply([], stdout, stderr);
+    expect(code).toBe(2);
+    expect(stderr.text().toLowerCase()).toContain('not yet implemented');
+    expect(stdout.text()).toBe('');
+  });
+
+  it('rejects `apply --json` without --dry-run with exit 2 (invalid combination)', async () => {
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--json'], stdout, stderr);
+    expect(code).toBe(2);
+    // Mirror bootstrap: explicit "invalid combination" message.
+    expect(stderr.text().toLowerCase()).toContain('invalid');
+    expect(stdout.text()).toBe('');
+  });
+
+  it('prints usage for `--help` and returns 0', async () => {
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--help'], stdout, stderr);
+    expect(code).toBe(0);
+    expect(stdout.text()).toBe(APPLY_USAGE);
+    expect(stderr.text()).toBe('');
+  });
+
+  it('rejects unknown flag with exit 2', async () => {
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--bogus'], stdout, stderr);
+    expect(code).toBe(2);
+    expect(stderr.text()).toContain('Unknown flag: --bogus');
+    expect(stderr.text()).toContain(APPLY_USAGE);
+    expect(stdout.text()).toBe('');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 3 — missing canonical config.
+  // -------------------------------------------------------------------------
+
+  it('returns exit 1 with "no overture config" message when overture.jsonc is absent', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run'], stdout, stderr);
+
+    expect(code).toBe(1);
+    // Either stderr or stdout must surface the canonical-config message.
+    const combined = `${stdout.text()}${stderr.text()}`.toLowerCase();
+    expect(combined).toContain('no overture config');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 4 — unknown profile name.
+  // -------------------------------------------------------------------------
+
+  it('returns exit 2 when settings.defaultProfile names an unknown profile', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({ defaultProfileName: 'ghost' }),
+    );
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run'], stdout, stderr);
+
+    expect(code).toBe(2);
+    expect(stderr.text().toLowerCase()).toContain('unknown profile');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 8 — defaultProfile is honored when set.
+  // -------------------------------------------------------------------------
+
+  it('honors settings.defaultProfile when set (envelope profile name)', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        defaultProfileName: 'prod',
+        profileName: 'prod',
+        targets: ['claude-code'],
+      }),
+    );
+    const claudePath = seedClaudeUserConfig(env.home, claudeUserConfigJson());
+    const claudeBefore = readFileSync(claudePath);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run', '--json'], stdout, stderr);
+
+    expect(code).toBeGreaterThanOrEqual(0);
+    expect(code).toBeLessThanOrEqual(1);
+    const parsed = JSON.parse(stdout.text()) as ApplyDryRunResult;
+    expect(parsed.profile).toBe('prod');
+    expect(parsed.results.length).toBe(1);
+    expect(parsed.results[0]?.agentId).toBe('claude-code');
+    expect(readFileSync(claudePath)).toEqual(claudeBefore);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 1 — happy path: seeded Claude + OpenCode, --dry-run,
+  // seeded bytes are byte-identical before vs after.
+  // -------------------------------------------------------------------------
+
+  it('apply --dry-run succeeds with seeded Claude + OpenCode configs and never writes disk', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    const claudePath = seedClaudeUserConfig(env.home, claudeUserConfigJson());
+    const opencodePath = seedOpencodeUserConfig(
+      env.xdgConfigHome,
+      opencodeConfigJsonc(),
+    );
+
+    seedCanonicalConfig(env.xdgConfigHome, buildCanonicalConfigJson());
+
+    const claudeBeforeBytes = readFileSync(claudePath);
+    const claudeBeforeStat = statSync(claudePath);
+    const opencodeBeforeBytes = readFileSync(opencodePath);
+    const opencodeBeforeStat = statSync(opencodePath);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run'], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBeGreaterThanOrEqual(0);
+    expect(code).toBeLessThanOrEqual(1);
+
+    // Human-readable report should mention both seeded agents.
+    const out = stdout.text();
+    expect(out).toContain('claude-code');
+    expect(out).toContain('opencode');
+    // Per-agent status line must include one of the documented statuses.
+    expect(out).toMatch(
+      /would-update|no-change|not-targetable|parse-error|unsupported-shape|unsupported-format/,
+    );
+
+    // Disk invariants — the dry-run guarantee proof.
+    expect(readFileSync(claudePath)).toEqual(claudeBeforeBytes);
+    expect(statSync(claudePath).size).toBe(claudeBeforeStat.size);
+    expect(statSync(claudePath).mtimeMs).toBe(claudeBeforeStat.mtimeMs);
+    expect(readFileSync(opencodePath)).toEqual(opencodeBeforeBytes);
+    expect(statSync(opencodePath).size).toBe(opencodeBeforeStat.size);
+    expect(statSync(opencodePath).mtimeMs).toBe(opencodeBeforeStat.mtimeMs);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 2 — --json --dry-run envelope shape.
+  // -------------------------------------------------------------------------
+
+  it('apply --json --dry-run emits the gate-5 envelope shape without raw byte leaks', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    const claudePath = seedClaudeUserConfig(env.home, claudeUserConfigJson());
+    const opencodePath = seedOpencodeUserConfig(
+      env.xdgConfigHome,
+      opencodeConfigJsonc(),
+    );
+
+    seedCanonicalConfig(env.xdgConfigHome, buildCanonicalConfigJson());
+
+    const claudeBeforeBytes = readFileSync(claudePath);
+    const opencodeBeforeBytes = readFileSync(opencodePath);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run', '--json'], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBeGreaterThanOrEqual(0);
+    expect(code).toBeLessThanOrEqual(1);
+
+    const text = stdout.text();
+    expect(text.endsWith('\n')).toBe(true);
+
+    const parsed = JSON.parse(text) as unknown;
+    expect(parsed).toBeTypeOf('object');
+    const envelope = parsed as Record<string, unknown>;
+
+    // Envelope keys: profile, configPath, disabledServers, results.
+    expect(Object.keys(envelope).sort()).toEqual(
+      ['configPath', 'disabledServers', 'profile', 'results'].sort(),
+    );
+    expect(typeof envelope['profile']).toBe('string');
+    expect(typeof envelope['configPath']).toBe('string');
+    expect(Array.isArray(envelope['disabledServers'])).toBe(true);
+    expect(Array.isArray(envelope['results'])).toBe(true);
+
+    const results = envelope['results'] as readonly ApplyDryRunAgentResult[];
+    expect(results.length).toBe(2);
+
+    // Each result must carry agentId, displayName, status, result.
+    for (const r of results) {
+      expect(typeof r.agentId).toBe('string');
+      expect(typeof r.displayName).toBe('string');
+      expect([
+        'would-update',
+        'no-change',
+        'not-targetable',
+        'parse-error',
+        'unsupported-shape',
+        'unsupported-format',
+      ]).toContain(r.status);
+      expect(r.result).toBeTypeOf('object');
+      expect(typeof (r.result as AgentMcpWriteResult).written).toBe('number');
+      expect(typeof (r.result as AgentMcpWriteResult).changed).toBe('boolean');
+      expect(typeof (r.result as AgentMcpWriteResult).dryRun).toBe('boolean');
+    }
+
+    // No raw-bytes leak: walk the JSON tree and assert the forbidden keys
+    // never appear anywhere.
+    const serialized = JSON.stringify(envelope);
+    expect(serialized).not.toContain('originalBytes');
+    expect(serialized).not.toContain('writtenBytes');
+
+    // Disk invariants — the dry-run guarantee proof.
+    expect(readFileSync(claudePath)).toEqual(claudeBeforeBytes);
+    expect(readFileSync(opencodePath)).toEqual(opencodeBeforeBytes);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 5 — unknown agent id in sync.targets.
+  // -------------------------------------------------------------------------
+
+  it('unknown agent id in sync.targets surfaces as not-targetable while other targets complete', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        targets: ['claude-code', 'fake-agent'],
+      }),
+    );
+    const claudePath = seedClaudeUserConfig(env.home, claudeUserConfigJson());
+    const claudeBefore = readFileSync(claudePath);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run', '--json'], stdout, stderr);
+
+    // At least one refusal → exit 1.
+    expect(code).toBe(1);
+
+    const envelope = JSON.parse(stdout.text()) as ApplyDryRunResult;
+    expect(envelope.results.length).toBe(2);
+
+    const fakeAgent = envelope.results.find(
+      (r: ApplyDryRunAgentResult) => r.agentId === 'fake-agent',
+    );
+    expect(fakeAgent).toBeDefined();
+    expect(fakeAgent?.status).toBe('not-targetable');
+
+    const claudeResult = envelope.results.find(
+      (r: ApplyDryRunAgentResult) => r.agentId === 'claude-code',
+    );
+    expect(claudeResult).toBeDefined();
+    // claude-code target seeded and valid → not a refusal.
+    expect(claudeResult?.status).not.toBe('not-targetable');
+    expect(claudeResult?.status).not.toBe('parse-error');
+
+    // Dry-run guarantee still holds.
+    expect(readFileSync(claudePath)).toEqual(claudeBefore);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 6 — agent without `mcp.write`.
+  //
+  // We use a vi.spyOn on the registry entry's `mcp` getter to swap in a
+  // handlers object whose `write` is undefined for the duration of the
+  // test. After the call we restore the spy. This is the supported way
+  // to test "writer missing" against a frozen registry.
+  // -------------------------------------------------------------------------
+
+  it('agent whose mcp.write is absent surfaces as not-targetable with reason "no writer registered"', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({ targets: ['opencode'] }),
+    );
+    const opencodePath = seedOpencodeUserConfig(
+      env.xdgConfigHome,
+      opencodeConfigJsonc(),
+    );
+    const opencodeBefore = readFileSync(opencodePath);
+
+    const target: AgentDefinition | undefined = agentRegistry.find(
+      (a) => a.id === 'opencode',
+    );
+    expect(target).toBeDefined();
+    if (target === undefined) return;
+
+    // Replace `mcp` with a handlers object missing `write`. The agent
+    // still exposes a read so the rest of the registry stays consistent.
+    const originalMcp = target.mcp;
+    const strippedMcp = {
+      read: originalMcp.read,
+      // intentionally omit `write`
+    } as unknown as AgentDefinition['mcp'];
+
+    const spy = vi.spyOn(target, 'mcp', 'get').mockReturnValue(strippedMcp);
+
+    try {
+      const stdout = new BufferWriter();
+      const stderr = new BufferWriter();
+      const code = await runApply(['--dry-run', '--json'], stdout, stderr);
+
+      expect(code).toBe(1);
+      const envelope = JSON.parse(stdout.text()) as ApplyDryRunResult;
+      const opencodeResult = envelope.results.find(
+        (r: ApplyDryRunAgentResult) => r.agentId === 'opencode',
+      );
+      expect(opencodeResult).toBeDefined();
+      expect(opencodeResult?.status).toBe('not-targetable');
+      expect(opencodeResult?.reasonDetail).toContain('no writer registered');
+    } finally {
+      spy.mockRestore();
+    }
+
+    // Disk invariant — the missing-writer path must not write either.
+    expect(readFileSync(opencodePath)).toEqual(opencodeBefore);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 7 — disabledServers excludes a server from the writer input.
+  //
+  // We swap one agent's `mcp.write` for a spy that captures the input.
+  // The spy preserves the original writer's no-op dry-run result shape
+  // so the surrounding envelope/aggregation path is exercised too.
+  // -------------------------------------------------------------------------
+
+  it('disabledServers excludes the named server from the writer input', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        mcpServers: {
+          a: { type: 'stdio', command: 'node' },
+          b: { type: 'stdio', command: 'node' },
+        },
+        targets: ['claude-code'],
+        disabledServers: ['a'],
+      }),
+    );
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      // Pre-existing entries so the writer targets the file.
+      claudeUserConfigJson('a'),
+    );
+    const claudeBefore = readFileSync(claudePath);
+
+    const target: AgentDefinition | undefined = agentRegistry.find(
+      (a) => a.id === 'claude-code',
+    );
+    expect(target).toBeDefined();
+    if (target === undefined) return;
+
+    const captured: { input: { servers: readonly { name: string }[] } | null } =
+      {
+        input: null,
+      };
+    const originalWrite = target.mcp.write;
+    const writeSpy = vi
+      .spyOn(target.mcp, 'write')
+      .mockImplementation(async (ctx, input) => {
+        captured.input = {
+          servers: input.servers.map((s) => ({ name: s.name })),
+        };
+        return originalWrite(ctx, input);
+      });
+
+    try {
+      const stdout = new BufferWriter();
+      const stderr = new BufferWriter();
+      await runApply(['--dry-run'], stdout, stderr);
+
+      expect(captured.input).not.toBeNull();
+      const names = (captured.input?.servers ?? []).map((s) => s.name);
+      expect(names).not.toContain('a');
+      expect(names).toContain('b');
+    } finally {
+      writeSpy.mockRestore();
+    }
+
+    expect(readFileSync(claudePath)).toEqual(claudeBefore);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 9 — exit code 1 when any per-agent result has a refusal reason.
+  //
+  // We force a parse-error by seeding the Claude config as malformed
+  // JSONC. The writer surfaces `reason: 'parse-error'` and the
+  // aggregator returns 1.
+  // -------------------------------------------------------------------------
+
+  it('returns exit code 1 when any result has a refusal reason (parse-error via malformed Claude JSONC)', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({ targets: ['claude-code'] }),
+    );
+    // Malformed JSONC: unterminated string. Writer must surface parse-error.
+    seedClaudeUserConfig(env.home, '{ "mcpServers": { ');
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run', '--json'], stdout, stderr);
+
+    expect(code).toBe(1);
+    const envelope = JSON.parse(stdout.text()) as ApplyDryRunResult;
+    const claudeResult = envelope.results.find(
+      (r: ApplyDryRunAgentResult) => r.agentId === 'claude-code',
+    );
+    expect(claudeResult).toBeDefined();
+    expect(claudeResult?.status).toBe('parse-error');
+    expect((claudeResult?.result as AgentMcpWriteResult).reason).toBe(
+      'parse-error',
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 10 — exit code 0 when every result is no-change.
+  //
+  // Strategy: seed a Claude config whose current mcpServers already
+  // match the canonical intent exactly. The writer computes a no-change
+  // result and the aggregator returns 0. We pick a fixture that the
+  // writer will treat as byte-equal for the single-server "filesystem"
+  // case (the writer normalizes `type: 'stdio'` defaults, so we keep
+  // the field explicit to match the canonical shape).
+  // -------------------------------------------------------------------------
+
+  it('returns exit code 0 when every result is no-change (byte-equal agent config)', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    // Seed canonical intent with a single filesystem server.
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        mcpServers: {
+          filesystem: { type: 'stdio', command: 'node' },
+        },
+        targets: ['claude-code'],
+      }),
+    );
+    // Pre-existing Claude config: identical to the writer's emitted
+    // shape for a single stdio server. The writer must treat this as
+    // no-change.
+    seedClaudeUserConfig(env.home, claudeUserConfigJson('filesystem'));
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run', '--json'], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBe(0);
+
+    const envelope = JSON.parse(stdout.text()) as ApplyDryRunResult;
+    expect(envelope.results.length).toBe(1);
+    const claudeResult = envelope.results[0];
+    expect(claudeResult?.status).toBe('no-change');
+    expect((claudeResult?.result as AgentMcpWriteResult).changed).toBe(false);
+    expect((claudeResult?.result as AgentMcpWriteResult).dryRun).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 13 — regression: Claude dry-run with a planned update must classify
+  // as `would-update`, not `no-change`.
+  //
+  // The Claude Code writer reports `changed: false` and `written: 0` in
+  // dry-run even when the seeded file content differs from canonical and a
+  // planned update exists; it surfaces the dry-run diff via
+  // `serversWritten` and `bytesChanged` instead. (OpenCode and OpenAI Codex
+  // writers set `changed: true` for the same case — a writer-convention
+  // divergence.) Case 1 + Case 10 above only exercise the matching-content
+  // path and therefore pass under both the old and the fixed
+  // `statusFromWriterResult`; this case seeds a DIFFERING command so the
+  // dry-run computes a planned update and the classifier has to recognize
+  // it via `serversWritten` / `bytesChanged`.
+  // -------------------------------------------------------------------------
+
+  it('classifies a Claude dry-run with a planned update as would-update (regression)', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    // Canonical intent: single filesystem server with `command: 'node'`.
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        mcpServers: {
+          filesystem: { type: 'stdio', command: 'node' },
+        },
+        targets: ['claude-code'],
+      }),
+    );
+    // Seeded file: same server name but a different `command`, so the
+    // writer computes a hypothetical diff and surfaces it via
+    // `serversWritten` / `bytesChanged` (with `changed: false`).
+    seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run', '--json'], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    // The planned update is clean (a would-update, not a refusal), so the
+    // aggregate exit is 0.
+    expect(code).toBe(0);
+
+    const envelope = JSON.parse(stdout.text()) as ApplyDryRunResult;
+    expect(envelope.results.length).toBe(1);
+    const claudeResult = envelope.results[0];
+    expect(claudeResult).toBeDefined();
+    // The core regression assertion: differing content + Claude's
+    // `changed: false` convention must still classify as `would-update`.
+    expect(claudeResult?.status).toBe('would-update');
+    const writer = claudeResult?.result as AgentMcpWriteResult;
+    expect(writer.changed).toBe(false);
+    expect(writer.dryRun).toBe(true);
+    expect(writer.serversWritten).toEqual(['filesystem']);
+    expect(typeof writer.bytesChanged).toBe('number');
+    expect(writer.bytesChanged).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure-function tests — no env setup, no IO.
+// ---------------------------------------------------------------------------
+
+describe('exitCodeForApplyDryRun', () => {
+  function makeResult(
+    status: ApplyDryRunAgentResult['status'],
+  ): ApplyDryRunAgentResult {
+    return {
+      agentId: 'claude-code',
+      displayName: 'Claude Code',
+      status,
+      result: {
+        written: 0,
+        changed: false,
+        dryRun: true,
+        serversWritten: [],
+        targetPaths: [],
+        reason:
+          status === 'no-change'
+            ? 'no-change'
+            : status === 'not-targetable'
+              ? 'not-targetable'
+              : status === 'parse-error'
+                ? 'parse-error'
+                : status === 'unsupported-shape'
+                  ? 'unsupported-shape'
+                  : status === 'unsupported-format'
+                    ? 'unsupported-format'
+                    : undefined,
+      },
+    };
+  }
+
+  it('returns 0 when every result is would-update', () => {
+    expect(
+      exitCodeForApplyDryRun([
+        makeResult('would-update'),
+        makeResult('would-update'),
+      ]),
+    ).toBe(0);
+  });
+
+  it('returns 0 when every result is no-change', () => {
+    expect(
+      exitCodeForApplyDryRun([
+        makeResult('no-change'),
+        makeResult('no-change'),
+      ]),
+    ).toBe(0);
+  });
+
+  it('returns 0 when results mix would-update and no-change', () => {
+    expect(
+      exitCodeForApplyDryRun([
+        makeResult('would-update'),
+        makeResult('no-change'),
+      ]),
+    ).toBe(0);
+  });
+
+  it.each([
+    'not-targetable',
+    'parse-error',
+    'unsupported-shape',
+    'unsupported-format',
+  ] as const)('returns 1 when any result has status %s', (status) => {
+    expect(
+      exitCodeForApplyDryRun([makeResult('no-change'), makeResult(status)]),
+    ).toBe(1);
+  });
+});
+
+describe('formatHumanApplyDryRun', () => {
+  const sampleEnvelope: ApplyDryRunResult = {
+    profile: 'default',
+    configPath: '/tmp/example/overture.jsonc',
+    disabledServers: [],
+    results: [
+      {
+        agentId: 'claude-code',
+        displayName: 'Claude Code',
+        status: 'would-update',
+        result: {
+          written: 1,
+          changed: true,
+          dryRun: true,
+          serversWritten: ['filesystem'],
+          targetPaths: [
+            { scope: 'user', base: 'home', path: '/tmp/example/.claude.json' },
+          ],
+          resolvedPath: '/tmp/example/.claude.json',
+          format: 'jsonc',
+          bytesChanged: 42,
+        },
+      },
+      {
+        agentId: 'opencode',
+        displayName: 'OpenCode',
+        status: 'no-change',
+        result: {
+          written: 0,
+          changed: false,
+          dryRun: true,
+          serversWritten: [],
+          targetPaths: [
+            {
+              scope: 'user',
+              base: 'config',
+              path: '/tmp/example/.config/opencode/opencode.jsonc',
+            },
+          ],
+        },
+      },
+      {
+        agentId: 'github-copilot-cli',
+        displayName: 'GitHub Copilot CLI',
+        status: 'not-targetable',
+        reasonDetail: 'no workspace .github/mcp.json found',
+        result: {
+          written: 0,
+          changed: false,
+          dryRun: true,
+          serversWritten: [],
+          targetPaths: [],
+          reason: 'not-targetable',
+        },
+      },
+      {
+        agentId: 'openai-codex',
+        displayName: 'OpenAI Codex',
+        status: 'parse-error',
+        reasonDetail: 'malformed TOML at ~/.codex/config.toml:18',
+        result: {
+          written: 0,
+          changed: false,
+          dryRun: true,
+          serversWritten: [],
+          targetPaths: [],
+          reason: 'parse-error',
+        },
+      },
+    ],
+  };
+
+  it('mentions every agent in the result set', () => {
+    const text = formatHumanApplyDryRun(sampleEnvelope);
+    for (const id of ALL_PLATFORM_IDS) {
+      expect(text).toContain(id);
+    }
+  });
+
+  it('includes a "not yet implemented" advisory footer pointing at overture apply', () => {
+    const text = formatHumanApplyDryRun(sampleEnvelope);
+    expect(text.toLowerCase()).toContain('not yet implemented');
+    expect(text).toContain('overture apply');
+  });
+
+  it('does not include raw original or written config bytes', () => {
+    const text = formatHumanApplyDryRun(sampleEnvelope);
+    expect(text).not.toContain('originalBytes');
+    expect(text).not.toContain('writtenBytes');
+    // The known seeded contents must not appear verbatim.
+    expect(text).not.toContain('filesystem: node');
+  });
+
+  it('echoes the profile and config path', () => {
+    const text = formatHumanApplyDryRun(sampleEnvelope);
+    expect(text).toContain('default');
+    expect(text).toContain('/tmp/example/overture.jsonc');
+  });
+
+  it('surfaces refusal reasons (reasonDetail) in the human report', () => {
+    const text = formatHumanApplyDryRun(sampleEnvelope);
+    expect(text).toContain('no workspace .github/mcp.json found');
+    expect(text).toContain('malformed TOML at ~/.codex/config.toml:18');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Spy restoration safety net.
+//
+// If a test throws partway through spy setup, the spy could outlive the
+// test and poison later ones. The setup uses try/finally so the rest of
+// the suite is safe. `vi.spyOn` is imported as `MockInstance` would be
+// — but since the existing case-6 / case-7 spies already pin the
+// return type via the target module's `mcp.write` signature, the
+// explicit `MockInstance` annotation is unnecessary in this file.
+// ---------------------------------------------------------------------------

--- a/apps/cli/src/apply-command.spec.ts
+++ b/apps/cli/src/apply-command.spec.ts
@@ -554,9 +554,9 @@ describe('runApply (F1 dry-run contract)', () => {
         'unsupported-format',
       ]).toContain(r.status);
       expect(r.result).toBeTypeOf('object');
-      expect(typeof (r.result).written).toBe('number');
-      expect(typeof (r.result).changed).toBe('boolean');
-      expect(typeof (r.result).dryRun).toBe('boolean');
+      expect(typeof r.result.written).toBe('number');
+      expect(typeof r.result.changed).toBe('boolean');
+      expect(typeof r.result.dryRun).toBe('boolean');
     }
 
     // No raw-bytes leak: walk the JSON tree and assert the forbidden keys

--- a/apps/cli/src/apply-command.spec.ts
+++ b/apps/cli/src/apply-command.spec.ts
@@ -53,11 +53,7 @@ import { tmpdir } from 'node:os';
 
 import { defaultOverturePaths } from '@overture/config';
 import { agentRegistry } from '@overture/agents';
-import type {
-  AgentDefinition,
-  AgentMcpWriteResult,
-  PlatformId,
-} from '@overture/agents';
+import type { AgentDefinition, PlatformId } from '@overture/agents';
 
 import {
   APPLY_USAGE,
@@ -184,7 +180,7 @@ function buildCanonicalConfigJson(
     },
   };
   if (profileName !== 'default') {
-    profiles['default'] = {
+    profiles.default = {
       mcpServers: {},
       sync: { targets: [], disabledServers: [] },
       skills: [],
@@ -537,12 +533,12 @@ describe('runApply (F1 dry-run contract)', () => {
     expect(Object.keys(envelope).sort()).toEqual(
       ['configPath', 'disabledServers', 'profile', 'results'].sort(),
     );
-    expect(typeof envelope['profile']).toBe('string');
-    expect(typeof envelope['configPath']).toBe('string');
-    expect(Array.isArray(envelope['disabledServers'])).toBe(true);
-    expect(Array.isArray(envelope['results'])).toBe(true);
+    expect(typeof envelope.profile).toBe('string');
+    expect(typeof envelope.configPath).toBe('string');
+    expect(Array.isArray(envelope.disabledServers)).toBe(true);
+    expect(Array.isArray(envelope.results)).toBe(true);
 
-    const results = envelope['results'] as readonly ApplyDryRunAgentResult[];
+    const results = envelope.results as readonly ApplyDryRunAgentResult[];
     expect(results.length).toBe(2);
 
     // Each result must carry agentId, displayName, status, result.
@@ -558,9 +554,9 @@ describe('runApply (F1 dry-run contract)', () => {
         'unsupported-format',
       ]).toContain(r.status);
       expect(r.result).toBeTypeOf('object');
-      expect(typeof (r.result as AgentMcpWriteResult).written).toBe('number');
-      expect(typeof (r.result as AgentMcpWriteResult).changed).toBe('boolean');
-      expect(typeof (r.result as AgentMcpWriteResult).dryRun).toBe('boolean');
+      expect(typeof (r.result).written).toBe('number');
+      expect(typeof (r.result).changed).toBe('boolean');
+      expect(typeof (r.result).dryRun).toBe('boolean');
     }
 
     // No raw-bytes leak: walk the JSON tree and assert the forbidden keys
@@ -783,9 +779,7 @@ describe('runApply (F1 dry-run contract)', () => {
     );
     expect(claudeResult).toBeDefined();
     expect(claudeResult?.status).toBe('parse-error');
-    expect((claudeResult?.result as AgentMcpWriteResult).reason).toBe(
-      'parse-error',
-    );
+    expect(claudeResult?.result?.reason).toBe('parse-error');
   });
 
   // -------------------------------------------------------------------------
@@ -831,8 +825,8 @@ describe('runApply (F1 dry-run contract)', () => {
     expect(envelope.results.length).toBe(1);
     const claudeResult = envelope.results[0];
     expect(claudeResult?.status).toBe('no-change');
-    expect((claudeResult?.result as AgentMcpWriteResult).changed).toBe(false);
-    expect((claudeResult?.result as AgentMcpWriteResult).dryRun).toBe(true);
+    expect(claudeResult?.result?.changed).toBe(false);
+    expect(claudeResult?.result?.dryRun).toBe(true);
   });
 
   // -------------------------------------------------------------------------
@@ -899,7 +893,7 @@ describe('runApply (F1 dry-run contract)', () => {
     // The core regression assertion: differing content + Claude's
     // `changed: false` convention must still classify as `would-update`.
     expect(claudeResult?.status).toBe('would-update');
-    const writer = claudeResult?.result as AgentMcpWriteResult;
+    const writer = claudeResult?.result;
     expect(writer.changed).toBe(false);
     expect(writer.dryRun).toBe(true);
     expect(writer.serversWritten).toEqual(['filesystem']);

--- a/apps/cli/src/apply-command.ts
+++ b/apps/cli/src/apply-command.ts
@@ -103,7 +103,7 @@ export interface ApplyDryRunResult {
  * (e.g. `pathContextFactory`, `prompt`); keeping the interface exported
  * lets future tests reference it without churn.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+ 
 export interface RunApplyOptions {
   readonly prompt?: unknown;
 }

--- a/apps/cli/src/apply-command.ts
+++ b/apps/cli/src/apply-command.ts
@@ -103,7 +103,7 @@ export interface ApplyDryRunResult {
  * (e.g. `pathContextFactory`, `prompt`); keeping the interface exported
  * lets future tests reference it without churn.
  */
- 
+
 export interface RunApplyOptions {
   readonly prompt?: unknown;
 }

--- a/apps/cli/src/apply-command.ts
+++ b/apps/cli/src/apply-command.ts
@@ -1,0 +1,510 @@
+/**
+ * F1 — `overture apply` subcommand.
+ *
+ * Ships the gate-5 type surface (`ApplyDryRunResult`, `ApplyDryRunAgentResult`,
+ * `RunApplyOptions`), the args-parsing + exit-code plumbing (`runApply`,
+ * `exitCodeForApplyDryRun`, `APPLY_USAGE`), the human renderer
+ * (`formatHumanApplyDryRun`), and the orchestration that wires the canonical
+ * config to per-agent writers.
+ *
+ * Dry-run is the only supported mode in F1. Real writes (`overture apply`
+ * without `--dry-run`) exit 2 with a "not yet implemented" advisory so
+ * callers learn the difference between an invalid flag combination and a
+ * not-yet-supported feature. The `--json` flag requires `--dry-run` (mirror
+ * bootstrap's invalid-combination guard).
+ *
+ * Exit codes:
+ *   - `0` — orchestration completed and every per-agent result is clean
+ *           (`would-update` or `no-change`).
+ *   - `1` — orchestration completed but at least one per-agent result is a
+ *           refusal (`not-targetable`, `parse-error`, `unsupported-shape`,
+ *           `unsupported-format`), OR the canonical config is absent
+ *           (no `overture.jsonc` to apply). The JSON envelope is still
+ *           emitted to stdout before the non-zero exit so consumers can
+ *           read the failure model.
+ *   - `2` — usage errors (unknown flags, `--json` without `--dry-run`,
+ *           `apply` without `--dry-run`), unknown profile name, or any
+ *           orchestration failure that prevents the model from being built.
+ */
+import {
+  defaultOverturePaths,
+  loadOvertureConfig,
+  type OvertureConfig,
+  type OverturePaths,
+  type OvertureProfile,
+} from '@overture/config';
+import {
+  agentRegistry,
+  type AgentMcpWriteResult,
+  type AgentMcpWriteServer,
+  type PathResolutionContext,
+} from '@overture/agents';
+
+import { defaultPathResolutionContext } from './platforms/detect.js';
+
+export type { StringWriter } from './scan-command.js';
+import type { StringWriter } from './scan-command.js';
+
+// ---------------------------------------------------------------------------
+// Gate-5 — Apply dry-run output types.
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-agent outcome of a dry-run write.
+ *
+ * - `would-update`      — writer returned `changed: true` with at least one
+ *                         entry written (dry-run so nothing was actually
+ *                         written to disk; this is a preview).
+ * - `no-change`         — writer returned `changed: false`. Exit code 0.
+ * - `not-targetable`    — writer returned `reason: 'not-targetable'` OR the
+ *                         agent id was unknown OR the writer was missing.
+ * - `parse-error`       — writer returned `reason: 'parse-error'`.
+ * - `unsupported-shape` — writer returned `reason: 'unsupported-shape'`.
+ * - `unsupported-format`— writer returned `reason: 'unsupported-format'`.
+ *
+ * The last four are refusal statuses that propagate to a non-zero exit code
+ * via {@link exitCodeForApplyDryRun}.
+ */
+export type ApplyDryRunStatus =
+  | 'would-update'
+  | 'no-change'
+  | 'not-targetable'
+  | 'parse-error'
+  | 'unsupported-shape'
+  | 'unsupported-format';
+
+/** Single per-agent entry in an {@link ApplyDryRunResult}. */
+export interface ApplyDryRunAgentResult {
+  readonly agentId: string;
+  readonly displayName: string;
+  readonly status: ApplyDryRunStatus;
+  /** The writer envelope returned by `agent.mcp.write`, unchanged. */
+  readonly result: AgentMcpWriteResult;
+  /**
+   * Optional human-readable reason. Populated when the writer omitted a
+   * `reason` (e.g. unknown agent id, missing `mcp.write` slot) so the
+   * human/JSON envelope still explains the refusal.
+   */
+  readonly reasonDetail?: string;
+}
+
+/** Top-level envelope emitted by `overture apply --dry-run [--json]`. */
+export interface ApplyDryRunResult {
+  readonly profile: string;
+  readonly configPath: string;
+  readonly disabledServers: readonly string[];
+  readonly results: readonly ApplyDryRunAgentResult[];
+}
+
+/**
+ * Injection seam for tests and production. F1 ships it empty: the F1 slice
+ * never wires a real prompt or path-context factory because writers are
+ * called directly with `dryRun: true`. F2 / F3 may add fields
+ * (e.g. `pathContextFactory`, `prompt`); keeping the interface exported
+ * lets future tests reference it without churn.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface RunApplyOptions {
+  readonly prompt?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Constants.
+// ---------------------------------------------------------------------------
+
+export const APPLY_USAGE = 'Usage: overture apply --dry-run [--json]\n';
+
+// ---------------------------------------------------------------------------
+// Pure helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide the exit code for a successful dry-run based on per-agent outcomes.
+ *
+ * - `0` — every target is `would-update` or `no-change` (even mixed).
+ * - `1` — at least one target is a refusal (`not-targetable`, `parse-error`,
+ *         `unsupported-shape`, `unsupported-format`). The JSON envelope is
+ *         still emitted to stdout so consumers can inspect what failed.
+ *
+ * Other exit codes (`2` for usage errors, missing canonical config,
+ * orchestration failures) are owned by {@link runApply}.
+ */
+export function exitCodeForApplyDryRun(
+  results: readonly ApplyDryRunAgentResult[],
+): 0 | 1 {
+  const refusalStatuses: ReadonlySet<ApplyDryRunStatus> = new Set([
+    'not-targetable',
+    'parse-error',
+    'unsupported-shape',
+    'unsupported-format',
+  ]);
+  return results.some((r) => refusalStatuses.has(r.status)) ? 1 : 0;
+}
+
+/**
+ * Render an {@link ApplyDryRunResult} as a human-readable report.
+ *
+ * Gate-5 layout (per `docs/overture-implementation-slices.md` and the
+ * F1 plan's "Gate 5 — Apply dry-run output shape" section):
+ *
+ *   1. Heading (`Apply dry-run (no changes written)`).
+ *   2. Profile, config path, and `disabledServers` echo lines.
+ *   3. One section per agent:
+ *      - clean statuses (`would-update`, `no-change`) — `target`,
+ *        `changed`, `bytes` (signed), and `servers` lines.
+ *      - refusal statuses (`not-targetable`, `parse-error`,
+ *        `unsupported-shape`, `unsupported-format`) — `reason` line
+ *        sourced from `reasonDetail` (preferred) or the writer's
+ *        `reason` fallback.
+ *   4. Summary line counting each status bucket.
+ *   5. F2 advisory footer pointing at `overture apply`.
+ *
+ * Plain text only — no ANSI colors. Resolved target paths come from
+ * `result.targetPaths[0].path` (preferred) or `result.resolvedPath`;
+ * raw original/written bytes are never embedded (F1 contract).
+ */
+export function formatHumanApplyDryRun(result: ApplyDryRunResult): string {
+  const lines: string[] = [];
+
+  lines.push('Apply dry-run (no changes written)');
+  lines.push(`Profile: ${result.profile}`);
+  lines.push(`Config:  ${result.configPath}`);
+  lines.push(
+    `Disabled: ${
+      result.disabledServers.length === 0
+        ? '[]'
+        : result.disabledServers.join(', ')
+    }`,
+  );
+  lines.push('');
+
+  const isCleanStatus = (
+    status: ApplyDryRunStatus,
+  ): status is 'would-update' | 'no-change' =>
+    status === 'would-update' || status === 'no-change';
+
+  for (const agent of result.results) {
+    lines.push(`[${agent.agentId}]`);
+    lines.push(`  status:    ${agent.status}`);
+    if (isCleanStatus(agent.status)) {
+      const target = agent.result.targetPaths[0];
+      const targetPath =
+        target?.path ?? agent.result.resolvedPath ?? '(unknown)';
+      lines.push(`  target:    ${targetPath}`);
+      lines.push(`  changed:   ${String(agent.result.changed)}`);
+      const bytes = agent.result.bytesChanged ?? 0;
+      const sign = bytes > 0 && agent.result.changed ? '+' : '';
+      lines.push(`  bytes:     ${sign}${bytes}`);
+      if (agent.result.serversWritten.length > 0) {
+        lines.push(`  servers:   ${agent.result.serversWritten.join(', ')}`);
+      }
+    } else {
+      const reason = agent.reasonDetail ?? agent.result.reason ?? '(no reason)';
+      lines.push(`  reason:    ${reason}`);
+    }
+    lines.push('');
+  }
+
+  const counts = {
+    wouldUpdate: result.results.filter((r) => r.status === 'would-update')
+      .length,
+    noChange: result.results.filter((r) => r.status === 'no-change').length,
+    refusals: result.results.filter(
+      (r) =>
+        r.status === 'not-targetable' ||
+        r.status === 'parse-error' ||
+        r.status === 'unsupported-shape' ||
+        r.status === 'unsupported-format',
+    ).length,
+  };
+  const total = result.results.length;
+  lines.push(
+    `Summary: ${String(total)} agent${total === 1 ? '' : 's'}, ` +
+      `${String(counts.wouldUpdate)} would-update, ` +
+      `${String(counts.noChange)} no-change, ` +
+      `${String(counts.refusals)} refusal(s).`,
+  );
+  lines.push(
+    'Run `overture apply` to write the planned changes (not yet implemented).',
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration helpers.
+// ---------------------------------------------------------------------------
+
+/** Stringify an unknown thrown value. Mirrors `bootstrap-command.ts:281-283`. */
+function messageForError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Map a writer's {@link AgentMcpWriteResult} to the gate-5
+ * {@link ApplyDryRunStatus}. Refusal reasons win over the "did anything
+ * happen?" flags so `parse-error` propagates even when the writer happens
+ * to leave `written` at 0.
+ *
+ * Writer conventions diverge on `changed` in dry-run: Claude Code / GitHub
+ * Copilot CLI leave `changed: false` and rely on `serversWritten` /
+ * `bytesChanged` metadata to signal a planned update, while OpenCode and
+ * OpenAI Codex report `changed: true` for the same case. We OR all four
+ * signals (`changed`, `written > 0`, `serversWritten.length > 0`,
+ * `bytesChanged > 0`) so a planned dry-run update is never misclassified
+ * as `no-change`. Real (non-dry-run) writes also satisfy `changed: true`,
+ * so this does not conflict with the live-write path.
+ *
+ * `no-change` is intentionally NOT a refusal status: a writer that confirms
+ * the target already matches the canonical intent exits 0.
+ */
+function statusFromWriterResult(
+  result: AgentMcpWriteResult,
+): ApplyDryRunStatus {
+  const reason = result.reason;
+  if (reason === 'parse-error') return 'parse-error';
+  if (reason === 'unsupported-shape') return 'unsupported-shape';
+  if (reason === 'unsupported-format') return 'unsupported-format';
+  if (reason === 'not-targetable') return 'not-targetable';
+  const plannedUpdate =
+    result.changed ||
+    result.written > 0 ||
+    result.serversWritten.length > 0 ||
+    (result.bytesChanged !== undefined && result.bytesChanged > 0);
+  return plannedUpdate ? 'would-update' : 'no-change';
+}
+
+/**
+ * Run a single per-agent dry-run write for the named target. Synthesizes a
+ * `not-targetable` envelope when the agent id is unknown or the writer
+ * slot is absent so the orchestrator can record every target in the report
+ * (per plan decision point 2: "unknown agent id is a refusal, not a hard
+ * error").
+ */
+async function applyToAgent(
+  ctx: PathResolutionContext,
+  profile: OvertureProfile,
+  agentId: string,
+): Promise<ApplyDryRunAgentResult> {
+  const entry = agentRegistry.find((a) => a.id === agentId);
+  if (entry === undefined) {
+    return {
+      agentId,
+      displayName: agentId,
+      status: 'not-targetable',
+      result: {
+        written: 0,
+        changed: false,
+        dryRun: true,
+        serversWritten: [],
+        targetPaths: [],
+        reason: 'not-targetable',
+      },
+      reasonDetail: `unknown agent id '${agentId}' in profile.sync.targets`,
+    };
+  }
+
+  if (entry.mcp.write === undefined) {
+    return {
+      agentId,
+      displayName: entry.displayName,
+      status: 'not-targetable',
+      result: {
+        written: 0,
+        changed: false,
+        dryRun: true,
+        serversWritten: [],
+        targetPaths: [],
+        reason: 'not-targetable',
+      },
+      reasonDetail: 'no writer registered',
+    };
+  }
+
+  const servers: readonly AgentMcpWriteServer[] = Object.entries(
+    profile.mcpServers,
+  )
+    .filter(([name]) => !profile.sync.disabledServers.includes(name))
+    .map(([name, server]) => ({ name, server }));
+
+  const writerResult = await entry.mcp.write(ctx, {
+    servers,
+    dryRun: true,
+    pathContext: ctx,
+  });
+
+  return {
+    agentId,
+    displayName: entry.displayName,
+    status: statusFromWriterResult(writerResult),
+    result: writerResult,
+  };
+}
+
+/** Build the gate-5 envelope from a validated profile + per-agent results. */
+function buildApplyResult(args: {
+  readonly profileName: string;
+  readonly profile: OvertureProfile;
+  readonly configPath: string;
+  readonly agentResults: readonly ApplyDryRunAgentResult[];
+}): ApplyDryRunResult {
+  return {
+    profile: args.profileName,
+    configPath: args.configPath,
+    disabledServers: [...args.profile.sync.disabledServers],
+    results: args.agentResults,
+  };
+}
+
+/**
+ * Resolve the canonical config path, load + validate the config, and pick
+ * the profile named by `settings.defaultProfile`.
+ *
+ * Returns a tagged union so {@link runApply} can map each failure to its
+ * exit code:
+ *   - `null` config (ENOENT) → exit `1` ("no overture config yet")
+ *   - parse / schema error or unknown profile name → exit `2`
+ *
+ * Every other path returns the resolved config + profile + name + path so
+ * the orchestrator can build the envelope without re-reading anything.
+ */
+async function loadAndValidateProfile(paths: OverturePaths): Promise<
+  | {
+      readonly ok: true;
+      readonly config: OvertureConfig;
+      readonly profileName: string;
+      readonly profile: OvertureProfile;
+      readonly configPath: string;
+    }
+  | { readonly ok: false; readonly exitCode: 1 | 2; readonly message: string }
+> {
+  let config: OvertureConfig | null;
+  try {
+    config = await loadOvertureConfig(paths);
+  } catch (err) {
+    return { ok: false, exitCode: 2, message: messageForError(err) };
+  }
+  if (config === null) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message:
+        `No overture config found at ${paths.configFile}\n` +
+        `Run \`overture bootstrap\` to create one, then retry.`,
+    };
+  }
+  // `settings` is declared `.partial()` in the schema so every field is
+  // typed `T | undefined` even though `.default('default')` guarantees a
+  // string at runtime. Coalesce to 'default' to mirror that runtime
+  // contract; an explicit string is required to satisfy the index type
+  // for `profiles[profileName]` below.
+  const profileName = config.settings.defaultProfile ?? 'default';
+  const profile = config.profiles[profileName];
+  if (profile === undefined) {
+    return {
+      ok: false,
+      exitCode: 2,
+      message: `Unknown profile '${profileName}'. Available: ${Object.keys(config.profiles).join(', ')}`,
+    };
+  }
+  return {
+    ok: true,
+    config,
+    profileName,
+    profile,
+    configPath: paths.configFile,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher.
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatch `overture apply` with the gate-5 type surface.
+ *
+ * Parses args, loads + validates the canonical config, picks the profile
+ * named by `settings.defaultProfile`, filters `disabledServers`, iterates
+ * `sync.targets`, and calls each agent's `mcp.write` with `dryRun: true`.
+ * The `--json` path emits the gate-5 envelope; the default path emits the
+ * human-readable report. The non-dry-run `apply` branch exits 2 with a
+ * "not yet implemented" advisory; F2 will replace it.
+ */
+export async function runApply(
+  args: readonly string[],
+  stdout: StringWriter,
+  stderr: StringWriter,
+  _options: RunApplyOptions = {},
+): Promise<number> {
+  if (args.includes('--help') || args.includes('-h')) {
+    stdout.write(APPLY_USAGE);
+    return 0;
+  }
+
+  const allowedFlags = new Set(['--dry-run', '--json']);
+  const unknownFlags = args.filter((flag) => !allowedFlags.has(flag));
+  if (unknownFlags.length > 0) {
+    stderr.write(`Unknown flag: ${unknownFlags[0]}\n${APPLY_USAGE}`);
+    return 2;
+  }
+
+  const hasDryRun = args.includes('--dry-run');
+  const hasJson = args.includes('--json');
+
+  // Mirror bootstrap: explicit invalid-combination message wins over the
+  // generic "not yet implemented" so callers learn the difference between
+  // `apply --json` (invalid) and `apply` (valid shape, not yet supported).
+  if (hasJson && !hasDryRun) {
+    stderr.write(
+      `Invalid flag combination: --json requires --dry-run.\n${APPLY_USAGE}`,
+    );
+    return 2;
+  }
+
+  if (!hasDryRun) {
+    stderr.write(
+      `overture apply is not yet implemented; use --dry-run to preview.\n${APPLY_USAGE}`,
+    );
+    return 2;
+  }
+
+  const validated = await loadAndValidateProfile(defaultOverturePaths());
+  if (!validated.ok) {
+    if (validated.exitCode === 2) {
+      stderr.write(`${validated.message}\n`);
+    } else {
+      stdout.write(`${validated.message}\n`);
+    }
+    return validated.exitCode;
+  }
+
+  // Use a single `PathResolutionContext` for every writer so the
+  // `homeDir` / `configDir` / `workspaceDir` they see is consistent
+  // (the E1 preservation harness compares bytes against the seeded
+  // fixtures; project memory 72 forbids passing `defaultOverturePaths`
+  // here). Writers that take an explicit `ctx` arg still see it via
+  // the first arg; `pathContext` mirrors it for self-contained writers.
+  const ctx = defaultPathResolutionContext();
+  const agentResults: ApplyDryRunAgentResult[] = [];
+  for (const agentId of validated.profile.sync.targets) {
+    agentResults.push(await applyToAgent(ctx, validated.profile, agentId));
+  }
+
+  const result = buildApplyResult({
+    profileName: validated.profileName,
+    profile: validated.profile,
+    configPath: validated.configPath,
+    agentResults,
+  });
+
+  if (hasJson) {
+    stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    // The formatter already emits a trailing newline; mirror the
+    // bootstrap-command convention (which also calls
+    // `formatHumanBootstrapProposal` / `formatHumanInteractiveResult`
+    // directly via `stdout.write`, no extra `\n`).
+    stdout.write(formatHumanApplyDryRun(result));
+  }
+
+  return exitCodeForApplyDryRun(agentResults);
+}

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -17,6 +17,7 @@ import { agentRegistry, type McpServerEntry } from '@overture/agents';
 import type { DetectJsonOutput } from './platforms/types.js';
 import { runBootstrap } from './bootstrap-command.js';
 import { runScan } from './scan-command.js';
+import { runApply } from './apply-command.js';
 let platformOverride: HostPlatform | null = null;
 export function __setPlatformForTests(p: HostPlatform | null): void {
   platformOverride = p;
@@ -128,7 +129,8 @@ const USAGE =
   '  detect [--json]   Detect installed MCP-capable platforms.\n' +
   '  config show       Print the resolved user-level overture config.\n' +
   '  scan [--json]     Build the installed MCP server matrix.\n' +
-  '  bootstrap [--dry-run] [--json]   Preview the canonical config that D3 would write.\n';
+  '  bootstrap [--dry-run] [--json]   Preview the canonical config that D3 would write.\n' +
+  '  apply --dry-run [--json]   Preview per-agent MCP writes from the canonical config (F1; real apply is F2).\n';
 
 async function runDetect(flags: readonly string[]): Promise<number> {
   if (flags.includes('--help') || flags.includes('-h')) {
@@ -239,6 +241,10 @@ export async function run(args: readonly string[]): Promise<number> {
 
   if (args[0] === 'bootstrap') {
     return runBootstrap(args.slice(1), process.stdout, process.stderr);
+  }
+
+  if (args[0] === 'apply') {
+    return runApply(args.slice(1), process.stdout, process.stderr);
   }
 
   process.stderr.write(`Unknown command: ${args[0]}\n${USAGE}`);

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -368,6 +368,25 @@ summary without writing files.
 
 Expected result: users can preview every planned change.
 
+**Status: completed on feat/f1-apply-dry-run (this slice).** Delivered the
+`overture apply --dry-run [--json]` preview command. The orchestrator loads
+the canonical `overture.jsonc`, picks the active profile by
+`settings.defaultProfile` (default `'default'`), filters servers against
+`profile.sync.disabledServers`, then iterates `profile.sync.targets` in order
+calling each per-agent `mcp.write` handler with `dryRun: true`. Results are
+aggregated into a `ApplyDryRunResult` envelope (profile, configPath,
+disabledServers, results) and rendered as either JSON or a per-agent human
+report. Every result is metadata-only — no raw original or written config
+bytes are exposed. Exit code 0 means clean or no-change across all targets;
+exit code 1 means at least one target refused (not-targetable, parse-error,
+unsupported-shape, or unsupported-format); exit code 2 means usage error or
+`apply` without `--dry-run` (which returns "not yet implemented"). F1 is
+read-only by construction: the writers short-circuit on `dryRun: true` and
+every seeded agent config file is byte-identical before vs after the
+preview. F2 (`overture apply` with real writes + backups) and F3 (refuse
+settings conflicts during apply) remain future work; the G-track (state file,
+human logs, restore helper) follows after F3.
+
 ### F2. Add `overture apply` with backups
 
 Before writing any agent config, create an adjacent backup of the original file.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -26,6 +26,7 @@ export type {
   AgentMcpWriteHandler,
   AgentMcpWriteInput,
   AgentMcpWriteResult,
+  AgentMcpWriteServer,
   AgentNormalizedMcpServer,
   JsonPrimitive,
   JsonValue,


### PR DESCRIPTION
## Summary

Adds `overture apply --dry-run [--json]`, a read-only preview command that shows what real `overture apply` (F2) will write to each agent's MCP config. F1 is pure orchestration over the existing E2/E3/E4 writers; nothing on disk changes.

## What it does

1. Loads the canonical `overture.jsonc` from `defaultOverturePaths()`. ENOENT → exit 1 with a pointer to `overture bootstrap`.
2. Picks the active profile by `settings.defaultProfile` (default `'default'`). Unknown profile → exit 2.
3. Filters `profile.mcpServers` against `profile.sync.disabledServers`.
4. Iterates `profile.sync.targets` in order (the user's chosen order) and calls each per-agent `mcp.write(ctx, { servers, dryRun: true })`.
5. Aggregates results into a `ApplyDryRunResult` envelope (`profile`, `configPath`, `disabledServers`, `results`) and renders JSON or a per-agent human report.
6. Exit codes: `0` clean or no-change across all targets; `1` any refusal (`not-targetable` / `parse-error` / `unsupported-shape` / `unsupported-format`); `2` usage error or `apply` without `--dry-run` (returns "not yet implemented" so users don't try it).

## Output shape (gate 5 — approved before implementation)

```ts
interface ApplyDryRunResult {
  readonly profile: string;
  readonly configPath: string;
  readonly disabledServers: readonly string[];
  readonly results: readonly ApplyDryRunAgentResult[];
}
interface ApplyDryRunAgentResult {
  readonly agentId: string;
  readonly displayName: string;
  readonly status: 'would-update' | 'no-change' | 'not-targetable'
                | 'parse-error' | 'unsupported-shape' | 'unsupported-format';
  readonly result: AgentMcpWriteResult;   // writer envelope unchanged
  readonly reasonDetail?: string;
}
```

Human output example:

```
Apply dry-run (no changes written)
Profile: default
Config:  /home/.../overture.jsonc
Disabled: []

[claude-code]
  status:    would-update
  target:    ~/.claude.json
  changed:   true
  bytes:     +42
  servers:   filesystem

[opencode]
  status:    no-change
  target:    ~/opencode.json
  changed:   false

[github-copilot-cli]
  status:    not-targetable
  reason:    no workspace .github/mcp.json found

Summary: 3 agents, 1 would-update, 1 no-change, 1 refusal(s).
Run `overture apply` to write the planned changes (not yet implemented).
```

## Diff

- `apps/cli/src/apply-command.ts` (new, 510 lines): orchestration + gate-5 types + JSON/human rendering.
- `apps/cli/src/apply-command.spec.ts` (new, 1099 lines): 27 tests covering 13 cases (12 plan cases + 1 regression).
- `apps/cli/src/cli.ts` (+8 lines): dispatch `apply` → `runApply`; USAGE update.
- `packages/agents/src/index.ts` (+1 line): re-export `AgentMcpWriteServer` so the orchestration can construct writer inputs.
- `docs/overture-implementation-slices.md` (+19 lines): F1 status block.

## Tests

- `yarn nx test @overture/agents --skip-nx-cache` → 441 ✓
- `yarn nx test @jander99/overture --skip-nx-cache` → 244 ✓ (incl. new `apply-command.spec.ts` 27 tests)
- `yarn nx build @jander99/overture --skip-nx-cache` ✓
- `yarn prettier --check .` ✓
- `node apps/cli/scripts/verify-package.mjs` ✓

## Audits (in `.omo/evidence/`)

- `f1-f1-apply-dry-run-plan-compliance.md` → **APPROVE**
- `f2-f1-apply-dry-run-code-quality.md` → **APPROVE** (post-fix)
- `f3-f1-apply-dry-run-real-qa.md` → **PASS** (post-fix re-verification against `dist/main.js`)
- `f4-f1-apply-dry-run-scope.md` → **APPROVE** (post-cleanup)

## Bug found + fixed during F2 audit

The initial `statusFromWriterResult` only consulted `result.changed` and `result.written` to decide `would-update` vs `no-change`. Claude and GitHub Copilot CLI's dry-run paths return `changed: false, written: 0` even when a planned update exists (with `serversWritten.length > 0` + `bytesChanged > 0`), while OpenCode and OpenAI Codex return `changed: true`. The classifier now OR-s all four writer signals. A new spec regression test (Case 13) seeds a Claude config that differs from canonical and asserts `would-update`; verified to fail under the pre-fix code with the exact mismatch.

## Out of scope (deferred to later slices)

- **F2**: real apply with backups.
- **F3**: refuse settings conflicts during apply.
- **G1–G3**: apply state file, human logs, restore helper.

The E1 writer-preservation harness, E2/E3/E4 writers, `agentRegistry` order, and the `WriteReason` union are all unchanged.

## Plan

`.omo/plans/f1-apply-dry-run.md` (6 todos + F1–F4 verification wave; both passing post-fix).

## Out of scope (per AGENTS.md)

- Real apply / writes are not in this PR.
- No backups, restore, undo, or state file.
- No conflict refusal.
- E1/E2/E3/E4 writer behavior is unchanged (besides the re-export of `AgentMcpWriteServer`).