### PR TITLE
feat(cli): add overture apply with backups (F2)

### DIFF
--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -541,14 +541,13 @@ logStep('Apply real-write smoke (F2)');
 // byte-identical contents to the pre-write seed. End-to-end guard for
 // the F2 two-pass (dryRun → backup → real) orchestration.
 //
-// Claude Code is the chosen target because its writer preserves the
-// existing entry's KEY when replacing the value (verified by the
-// F2 spec Case 14 + Case 18 contracts). The OpenCode writer's
-// `findServerPropertyRange` / `renderServer` interaction drops the
-// server key for existing entries (see `packages/agents/src/opencode-write.ts`
-// line 345), so exercising it here would surface a writer-side quirk
-// rather than the F2 orchestrator surface. The unit-spec opencode
-// coverage lives in `packages/agents/src/opencode.write.spec.ts`.
+// Claude Code is the chosen target because it is the simplest single-
+// target writer (one file per call), making the F2 surface easy to
+// verify end-to-end. OpenCode is covered by the F2 spec Case 14 in
+// apps/cli/src/apply-command.spec.ts (real-write happy path covers
+// both Claude and OpenCode side-by-side). GitHub Copilot CLI and
+// OpenAI Codex are covered by their unit-specs (see
+// packages/agents/src/{github-copilot-cli,openai-codex}.write.spec.ts).
 const applyHome = mkdtempSync('/tmp/overture-verify-apply-home-');
 const applyXdg = mkdtempSync('/tmp/overture-verify-apply-xdg-');
 const applyPath = mkdtempSync('/tmp/overture-verify-apply-path-');

--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -48,10 +48,11 @@ function run(cmd, args, opts = {}) {
   }
 }
 
-function spawnWithEnv(args, env) {
+function spawnWithEnv(args, env, opts = {}) {
   return spawnSync(process.execPath, args, {
     encoding: 'utf8',
     env,
+    ...opts,
   });
 }
 
@@ -532,6 +533,143 @@ if (
   );
 }
 console.log('bootstrap --help: exit=0 usage=PASS');
+
+logStep('Apply real-write smoke (F2)');
+// Seed a tmpdir with `overture.jsonc` + a Claude Code config that
+// differs from canonical, run `overture apply` (no flag), assert the
+// target file was modified and a timestamped backup file exists with
+// byte-identical contents to the pre-write seed. End-to-end guard for
+// the F2 two-pass (dryRun → backup → real) orchestration.
+//
+// Claude Code is the chosen target because its writer preserves the
+// existing entry's KEY when replacing the value (verified by the
+// F2 spec Case 14 + Case 18 contracts). The OpenCode writer's
+// `findServerPropertyRange` / `renderServer` interaction drops the
+// server key for existing entries (see `packages/agents/src/opencode-write.ts`
+// line 345), so exercising it here would surface a writer-side quirk
+// rather than the F2 orchestrator surface. The unit-spec opencode
+// coverage lives in `packages/agents/src/opencode.write.spec.ts`.
+const applyHome = mkdtempSync('/tmp/overture-verify-apply-home-');
+const applyXdg = mkdtempSync('/tmp/overture-verify-apply-xdg-');
+const applyPath = mkdtempSync('/tmp/overture-verify-apply-path-');
+const applyWorkspace = mkdtempSync('/tmp/overture-verify-apply-ws-');
+const applyEnv = {
+  ...process.env,
+  HOME: applyHome,
+  XDG_CONFIG_HOME: applyXdg,
+  PATH: applyPath,
+};
+const applyClaudeConfig = join(applyHome, '.claude.json');
+const applyClaudeBefore = JSON.stringify(
+  {
+    mcpServers: {
+      filesystem: { type: 'stdio', command: 'old' },
+    },
+  },
+  null,
+  2,
+);
+writeFileSync(applyClaudeConfig, applyClaudeBefore);
+const applyClaudeBeforeBytes = readFileSync(applyClaudeConfig);
+
+// Seed a fake claude binary on the apply PATH so the claude-code agent
+// passes binary-first detection.
+const applyClaudeBin = join(applyPath, 'claude');
+writeFileSync(applyClaudeBin, '#!/bin/sh\nexit 0\n');
+chmodSync(applyClaudeBin, 0o755);
+
+// Seed the canonical config so apply has a real target to write to.
+const applyOvertureConfigDir = join(applyXdg, 'overture');
+mkdirSync(applyOvertureConfigDir, { recursive: true });
+const applyOvertureConfig = join(applyOvertureConfigDir, 'overture.jsonc');
+writeFileSync(
+  applyOvertureConfig,
+  JSON.stringify(
+    {
+      version: 1,
+      settings: {
+        defaultProfile: 'default',
+        backupBeforeWrite: true,
+      },
+      profiles: {
+        default: {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'node' },
+          },
+          sync: {
+            targets: ['claude-code'],
+            disabledServers: [],
+          },
+          skills: [],
+        },
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+const applyResult = spawnWithEnv([distMain, 'apply'], applyEnv, {
+  cwd: applyWorkspace,
+});
+if (applyResult.status !== 0) {
+  fail(
+    `apply (no flag) exited ${applyResult.status} (expected 0)\nstdout:\n${applyResult.stdout}\nstderr:\n${applyResult.stderr}`,
+  );
+}
+
+// Target was modified.
+const applyClaudeAfterBytes = readFileSync(applyClaudeConfig);
+if (applyClaudeAfterBytes.equals(applyClaudeBeforeBytes)) {
+  fail(
+    `apply (no flag) did not modify the seeded claude config\nbefore: ${applyClaudeBeforeBytes.length} bytes\nafter:  ${applyClaudeAfterBytes.length} bytes`,
+  );
+}
+if (!applyClaudeAfterBytes.toString('utf8').includes('filesystem')) {
+  fail(
+    `apply (no flag) did not write the canonical filesystem server\nafter: ${applyClaudeAfterBytes.toString('utf8')}`,
+  );
+}
+
+// Find the backup file (`<target>.bak.<ts>` adjacent to the target).
+const applyHomeDir = dirname(applyClaudeConfig);
+const applyBackups = readdirSync(applyHomeDir).filter((entry) =>
+  entry.startsWith('.claude.json.bak.'),
+);
+if (applyBackups.length === 0) {
+  fail(
+    `apply (no flag) did not create a backup file\ndir: ${applyHomeDir}\nfiles: ${readdirSync(applyHomeDir).join(', ')}`,
+  );
+}
+const applyBackupPath = join(applyHomeDir, applyBackups[0]);
+const applyBackupBytes = readFileSync(applyBackupPath);
+if (!applyBackupBytes.equals(applyClaudeBeforeBytes)) {
+  fail(
+    `apply backup is not byte-identical to the seeded content\nbackup: ${applyBackupPath}\nseed length: ${applyClaudeBeforeBytes.length}\nbackup length: ${applyBackupBytes.length}`,
+  );
+}
+
+// Human report must mention the backup path.
+if (!applyResult.stdout.includes(applyBackupPath)) {
+  fail(
+    `apply (no flag) stdout missing backup path ${applyBackupPath}\nstdout:\n${applyResult.stdout}`,
+  );
+}
+if (!applyResult.stdout.includes('Apply (changes written)')) {
+  fail(
+    `apply (no flag) stdout missing "Apply (changes written)" heading\nstdout:\n${applyResult.stdout}`,
+  );
+}
+
+console.log(
+  `apply (no flag): exit=${applyResult.status} targetModified=PASS backupCreated=PASS backupByteIdentical=PASS`,
+);
+
+// Cleanup apply tmpdirs.
+rmSync(applyHome, { recursive: true, force: true });
+rmSync(applyXdg, { recursive: true, force: true });
+rmSync(applyPath, { recursive: true, force: true });
+rmSync(applyWorkspace, { recursive: true, force: true });
 
 logStep('Cleanup');
 rmSync(packTmp, { recursive: true, force: true });

--- a/apps/cli/src/apply-command.spec.ts
+++ b/apps/cli/src/apply-command.spec.ts
@@ -1014,19 +1014,12 @@ describe('runApply (F2 real-write contract)', () => {
   // Case 14 — real-write happy path.
   //
   // Seeds BOTH Claude and OpenCode configs that differ from canonical so
-  // each writer plans an update. Canonical uses a remote filesystem
-  // (`type: 'remote'`, url + headers) because the OpenCode writer's
-  // existing-entry update path is only correct for remote canonicals;
-  // stdio canonicals trigger a planEdits round-trip through the
-  // local → remote fallthrough (see `packages/agents/src/opencode-write.ts`
-  // `toOpenCodeMcpServer` + `planEdits`). Per-writer correctness is locked
-  // by the unit-specs in
-  // `packages/agents/src/{claude-code,opencode,...}.write.spec.ts`; this
-  // case covers the F2 orchestrator's two-pass + backup surface, not
-  // per-writer byte fidelity.
-  //
-  // Claude converts remote → `{ type: 'http', url, headers }`.
-  // OpenCode passes remote through unchanged.
+  // each writer plans an update (Claude: `command: 'old'` vs canonical
+  // `'node'`; OpenCode: `type: 'local'` + `command: ['old']` vs canonical
+  // `type: 'stdio'` + `command: 'node'`). Case 14 covers both writers'
+  // real-write paths with byte-level assertions; per-writer byte fidelity
+  // is locked by the unit-specs in
+  // `packages/agents/src/{claude-code,opencode,...}.write.spec.ts`.
   // -------------------------------------------------------------------------
 
   it('apply (no flag) writes the target and creates a byte-identical timestamped backup', async () => {
@@ -1035,8 +1028,8 @@ describe('runApply (F2 real-write contract)', () => {
     applyEnv(env);
     seedAllFakeBins(env.pathDir);
 
-    // Claude seeded with a stdio `filesystem` so the writer plans an
-    // update (remote canonical differs from stdio seed).
+    // Claude seeded with `command: 'old'` so the writer plans an update
+    // (not no-change).
     const claudePath = seedClaudeUserConfig(
       env.home,
       JSON.stringify(
@@ -1050,8 +1043,8 @@ describe('runApply (F2 real-write contract)', () => {
       ),
     );
     // OpenCode seeded with `type: 'local'` + `command: ['old']` so its
-    // writer plans an update (remote canonical differs from local seed
-    // in both transport and value).
+    // writer plans an update (canonical is `type: 'stdio'` +
+    // `command: 'node'`, which differs in both shape and value).
     const opencodePath = seedOpencodeUserConfig(
       env.xdgConfigHome,
       `{
@@ -1068,11 +1061,7 @@ describe('runApply (F2 real-write contract)', () => {
       env.xdgConfigHome,
       buildCanonicalConfigJson({
         mcpServers: {
-          filesystem: {
-            type: 'remote',
-            url: 'https://mcp.example.com/filesystem',
-            headers: { Authorization: 'Bearer test-token' },
-          },
+          filesystem: { type: 'stdio', command: 'node' },
         },
       }),
     );
@@ -1093,19 +1082,13 @@ describe('runApply (F2 real-write contract)', () => {
     expect(claudeAfterBytes).not.toEqual(claudeBeforeBytes);
     expect(opencodeAfterBytes).not.toEqual(opencodeBeforeBytes);
 
-    // The canonical filesystem server name should appear in both updated files.
+    // The canonical filesystem server name and stdio+node intent should
+    // appear in both updated files (Claude passes stdio through; OpenCode
+    // converts to its native `local` form but still carries `node`).
     expect(claudeAfterBytes.toString('utf8')).toContain('filesystem');
     expect(opencodeAfterBytes.toString('utf8')).toContain('filesystem');
-
-    // The canonical URL should appear in both files (Claude writes
-    // `type: 'http'` + url + headers; OpenCode passes the remote form
-    // through unchanged).
-    expect(claudeAfterBytes.toString('utf8')).toContain(
-      'https://mcp.example.com/filesystem',
-    );
-    expect(opencodeAfterBytes.toString('utf8')).toContain(
-      'https://mcp.example.com/filesystem',
-    );
+    expect(claudeAfterBytes.toString('utf8')).toContain('"node"');
+    expect(opencodeAfterBytes.toString('utf8')).toContain('"node"');
 
     // Backups exist adjacent to each target, byte-identical to the seed.
     const claudeBackups = findBackupFiles(

--- a/apps/cli/src/apply-command.spec.ts
+++ b/apps/cli/src/apply-command.spec.ts
@@ -1,14 +1,11 @@
 /**
- * F1 — `overture apply --dry-run` test suite.
+ * F1 + F2 — `overture apply` test suite.
  *
- * Locks the F1 contract: gate-5 types (`ApplyDryRunResult`,
- * `RunApplyOptions`), the args/exit-code plumbing (`runApply`,
- * `exitCodeForApplyDryRun`), the human renderer (`formatHumanApplyDryRun`),
- * and the orchestration that wires the canonical config to per-agent
- * writers via `mcp.write({ ..., dryRun: true })`.
- *
- * Style mirrors `apps/cli/src/bootstrap-command.spec.ts`: real tmpdirs
- * for filesystem isolation, `BufferWriter` from
+ * Locks the F1 contract (gate-5 types, args/exit-code plumbing, dry-run
+ * human renderer) and the F2 real-write contract (backup helper,
+ * two-pass orchestration, `ApplyResult` envelope, real-write human
+ * renderer, exit-code helper). Mirrors `apps/cli/src/bootstrap-command.spec.ts`:
+ * real tmpdirs for filesystem isolation, `BufferWriter` from
  * `test-support/bootstrap-test-support.ts` for stdout/stderr, and
  * per-test env override + restore via `beforeEach`/`afterEach`.
  *
@@ -29,6 +26,8 @@
  *      `unsupported-format`).
  *   10. exit code 0 when every result is `no-change`.
  *   11. `apply` without `--dry-run` → exit 2 + "not yet implemented".
+ *       F2 replaces this stub: the assertion becomes outdated after
+ *       F2 lands (Todo 3 replaces it with a real-write assertion).
  *   12. `apply --json` without `--dry-run` → exit 2 (invalid combo).
  *   13. regression: Claude dry-run with a planned update (seeded file
  *       content differs from canonical) classifies as `would-update`,
@@ -37,6 +36,31 @@
  *       `changed: true`; Claude / GitHub Copilot CLI leave `changed:
  *       false` and surface `serversWritten` / `bytesChanged` instead);
  *       `statusFromWriterResult` must accept both conventions.
+ *
+ * F2 — `overture apply` real-write (cases 14-23):
+ *   14. real-write happy path — seeded Claude + OpenCode configs,
+ *       apply (no flag) writes both targets and creates adjacent
+ *       timestamped backups byte-identical to the seeded content.
+ *   15. `settings.backupBeforeWrite: false` skips backups entirely
+ *       but still performs writes.
+ *   16. backup collision suffix — pre-creating `<target>.bak.<ts>`
+ *       forces the backup to land at `<target>.bak.<ts>-<hex4>`.
+ *   17. `backup-failed` refusal — chmod 0o555 on the parent directory
+ *       makes `fs.copyFile` throw `EACCES`; status surfaces
+ *       `backup-failed`, the writer is not called, the target is
+ *       untouched.
+ *   18. `--dry-run` byte-identical regression — backups are NEVER
+ *       created under `--dry-run`; targets unchanged.
+ *   19. `--json` without `--dry-run` still exit 2 (regression for
+ *       the invalid-combination guard from F1).
+ *   20. agent without `mcp.write` still surfaces `not-targetable`
+ *       (regression for the F1 refusal path).
+ *   21. `disabledServers` excludes a server from BOTH Pass 1 (dry-run)
+ *       and Pass 2 (real-write) writer inputs.
+ *   22. exit code 1 when at least one result is `backup-failed`.
+ *   23. multi-target backup — a writer that returns two `targetPaths`
+ *       entries causes the backup orchestrator to create one backup
+ *       file per resolved target.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -44,11 +68,12 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { defaultOverturePaths } from '@overture/config';
@@ -58,6 +83,7 @@ import type { AgentDefinition, PlatformId } from '@overture/agents';
 import {
   APPLY_USAGE,
   exitCodeForApplyDryRun,
+  formatBackupTimestamp,
   formatHumanApplyDryRun,
   runApply,
   type ApplyDryRunAgentResult,
@@ -148,6 +174,28 @@ function seedAllFakeBins(pathDir: string): void {
   }
 }
 
+// List `<targetName>.bak.*` entries inside `dir`. Used by F2 cases to
+// assert that backups were created (or, in Case 18, that none were).
+function findBackupFiles(dir: string, targetName: string): string[] {
+  if (!existsDir(dir)) return [];
+  const entries = readdirSync(dir);
+  return entries
+    .filter((e: string) => e.startsWith(`${targetName}.bak.`))
+    .map((e: string) => join(dir, e))
+    .sort();
+}
+
+// `existsSync` is imported for the chmod helpers above; use a tiny
+// wrapper here so the F2 cases can call it without re-importing.
+function existsDir(dir: string): boolean {
+  try {
+    const s = statSync(dir);
+    return s.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Canonical config fixture builders.
 // ---------------------------------------------------------------------------
@@ -158,6 +206,13 @@ interface CanonicalConfigOptions {
   readonly mcpServers?: Readonly<Record<string, unknown>>;
   readonly targets?: readonly string[];
   readonly disabledServers?: readonly string[];
+  /**
+   * Optional `settings.backupBeforeWrite` flag (F2). Defaults to
+   * `undefined` so the existing F1 fixtures stay clean — the schema
+   * default of `true` fills it in. Tests that want to assert the
+   * `false` behavior pass `false` here.
+   */
+  readonly backupBeforeWrite?: boolean;
 }
 
 function buildCanonicalConfigJson(
@@ -186,14 +241,17 @@ function buildCanonicalConfigJson(
       skills: [],
     };
   }
-  // F1 only consumes `settings.defaultProfile`. The other Settings fields
-  // are valid schema members but irrelevant to the apply preview; the spec
-  // omits them so scope greps for F2/F3 keywords (backupBeforeWrite,
-  // conflictPolicy) stay clean.
+  // F1 only consumes `settings.defaultProfile` and `settings.dryRunByDefault`.
+  // F2 threads `settings.backupBeforeWrite` through the orchestrator. We
+  // omit every other Settings field so scope greps for F3 keywords
+  // (conflictPolicy) stay clean.
   const settings: Record<string, unknown> = {
     defaultProfile: options.defaultProfileName ?? profileName,
     dryRunByDefault: true,
   };
+  if (options.backupBeforeWrite !== undefined) {
+    settings.backupBeforeWrite = options.backupBeforeWrite;
+  }
   return JSON.stringify(
     {
       version: 1,
@@ -265,7 +323,12 @@ function seedOpencodeUserConfig(
 ): string {
   const dir = join(xdgConfigHome, 'opencode');
   mkdirSync(dir, { recursive: true });
-  const p = join(dir, 'opencode.jsonc');
+  // The opencode writer targets `opencode.json` (not `.jsonc`) per
+  // `packages/agents/src/opencode.ts` `mcpLocations[0]`. Seed the file the
+  // writer will actually find; F1 dry-run tests still pass because dry-run
+  // never writes, and F2 real-write tests need a real target on disk so
+  // the backup step has something to copy.
+  const p = join(dir, 'opencode.json');
   writeFileSync(p, contents);
   return p;
 }
@@ -323,21 +386,12 @@ describe('runApply (F1 dry-run contract)', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Case 11 + 12 — invalid flag combinations.
+  // Case 12 — invalid flag combination (`--json` requires `--dry-run`).
   //
-  // These two cases must work even when there is no implementation
-  // behind them, so the dispatcher contract is exercised first. They
-  // live at the top so the failure mode is obvious in the run output.
+  // This case works whether or not the real-write path is implemented, so
+  // it lives near the top of the F1 suite to exercise the dispatcher
+  // contract before any feature flags flip.
   // -------------------------------------------------------------------------
-
-  it('rejects `apply` without --dry-run with exit 2 + "not yet implemented"', async () => {
-    const stdout = new BufferWriter();
-    const stderr = new BufferWriter();
-    const code = await runApply([], stdout, stderr);
-    expect(code).toBe(2);
-    expect(stderr.text().toLowerCase()).toContain('not yet implemented');
-    expect(stdout.text()).toBe('');
-  });
 
   it('rejects `apply --json` without --dry-run with exit 2 (invalid combination)', async () => {
     const stdout = new BufferWriter();
@@ -816,6 +870,10 @@ describe('runApply (F1 dry-run contract)', () => {
 
     const stdout = new BufferWriter();
     const stderr = new BufferWriter();
+    // F2 changed the default: `apply` (no flag) now real-writes. To
+    // assert "no-change" semantics with the F1 JSON envelope shape,
+    // pass `--dry-run --json` so we exercise the dry-run path that
+    // already covers no-change classification.
     const code = await runApply(['--dry-run', '--json'], stdout, stderr);
 
     expect(stderr.text()).toBe('');
@@ -900,6 +958,533 @@ describe('runApply (F1 dry-run contract)', () => {
     expect(typeof writer.bytesChanged).toBe('number');
     expect(writer.bytesChanged).toBeGreaterThan(0);
   });
+});
+
+// ---------------------------------------------------------------------------
+// F2 — `overture apply` real-write contract.
+//
+// Each new `it(...)` is one bullet from the F2 plan (cases 14-23). They run
+// against the same env scaffolding as the F1 suite above (real tmpdirs,
+// `applyEnv` for env + cwd isolation, `seedAllFakeBins` for binary markers).
+// ---------------------------------------------------------------------------
+
+describe('runApply (F2 real-write contract)', () => {
+  let cleanupDirs: readonly string[] = [];
+  let originalEnv: NodeJS.ProcessEnv;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    cleanupDirs = [];
+    originalEnv = { ...process.env };
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    for (const dir of cleanupDirs) {
+      // Best-effort restore permissions so a chmod 0o555 in Case 17 does not
+      // make `rmSync` fail.
+      try {
+        chmodSync(dir, 0o755);
+      } catch {
+        /* ignore */
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+    process.chdir(originalCwd);
+    for (const key of [
+      'HOME',
+      'XDG_CONFIG_HOME',
+      'XDG_CONFIG_DIRS',
+      'XDG_DATA_HOME',
+      'XDG_STATE_HOME',
+      'XDG_CACHE_HOME',
+      'PATH',
+      'USERPROFILE',
+    ]) {
+      const original = originalEnv[key];
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 14 — real-write happy path.
+  //
+  // Seeds Claude with a `command: 'old'` so its writer plans an update
+  // (the seeded Claude content must differ from canonical; otherwise the
+  // writer classifies as `no-change` and no backup is created). OpenCode's
+  // seeded content already differs from canonical (type: 'local' vs
+  // 'stdio', command shape), so it always plans an update. The test
+  // asserts both targets are written and both backups exist, byte-identical
+  // to the pre-write seed.
+  // -------------------------------------------------------------------------
+
+  it('apply (no flag) writes the target and creates a byte-identical timestamped backup', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    // Claude seeded with `command: 'old'` so the writer plans an update
+    // (not no-change). Single-target setup so the test focuses on F2's
+    // two-pass + backup orchestration; opencode + multi-target backup is
+    // exercised separately by `verify-package.mjs`.
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        targets: ['claude-code'],
+        mcpServers: {
+          filesystem: { type: 'stdio', command: 'node' },
+        },
+      }),
+    );
+
+    const claudeBeforeBytes = readFileSync(claudePath);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply([], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBe(0);
+
+    // Target was updated.
+    const claudeAfterBytes = readFileSync(claudePath);
+    expect(claudeAfterBytes).not.toEqual(claudeBeforeBytes);
+
+    // The canonical filesystem server name should appear in the updated bytes.
+    expect(claudeAfterBytes.toString('utf8')).toContain('filesystem');
+
+    // Backup exists adjacent to the target, byte-identical to the seed.
+    const claudeDir = dirname(claudePath);
+    const claudeBackups = findBackupFiles(claudeDir, basename(claudePath));
+
+    expect(claudeBackups.length).toBeGreaterThanOrEqual(1);
+    expect(readFileSync(claudeBackups[0])).toEqual(claudeBeforeBytes);
+
+    // Human-readable report must mention the backup path so the operator
+    // can find it.
+    const out = stdout.text();
+    expect(out).toMatch(/Apply \(changes written\)/);
+    for (const bp of claudeBackups) {
+      expect(out).toContain(bp);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 15 — `settings.backupBeforeWrite: false` skips backups but still
+  // writes.
+  // -------------------------------------------------------------------------
+
+  it('settings.backupBeforeWrite: false skips backups but still writes the target', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({ backupBeforeWrite: false }),
+    );
+
+    const claudeBeforeBytes = readFileSync(claudePath);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply([], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBe(0);
+
+    // Target written.
+    const claudeAfterBytes = readFileSync(claudePath);
+    expect(claudeAfterBytes).not.toEqual(claudeBeforeBytes);
+
+    // No backup files created.
+    const claudeDir = dirname(claudePath);
+    const claudeBackups = findBackupFiles(claudeDir, basename(claudePath));
+    expect(claudeBackups.length).toBe(0);
+
+    // Human report still renders.
+    const out = stdout.text();
+    expect(out).toMatch(/Apply \(changes written\)/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 16 — backup collision suffix.
+  //
+  // We inject a deterministic clock via `RunApplyOptions.now` and pre-create
+  // `<target>.bak.<expected-ts>` so the timestamped name collides. The
+  // helper must retry with a `-<hex4>` suffix.
+  // -------------------------------------------------------------------------
+
+  it('pre-existing <target>.bak.<ts> forces a -<hex4> collision suffix', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    const fixedNow = new Date('2026-07-03T18:30:00.123Z');
+    const expectedTs = formatBackupTimestamp(fixedNow);
+
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const claudeDir = dirname(claudePath);
+
+    // Pre-create the colliding backup path.
+    const collidingPath = `${claudePath}.bak.${expectedTs}`;
+    writeFileSync(collidingPath, 'collision\n');
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        targets: ['claude-code'],
+        mcpServers: {
+          filesystem: { type: 'stdio', command: 'node' },
+        },
+      }),
+    );
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply([], stdout, stderr, { now: fixedNow });
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBe(0);
+
+    const backups = findBackupFiles(claudeDir, basename(claudePath));
+    // The colliding path may still exist; we look for the suffixed one.
+    // The regex matches `<target>.bak.<ts>-<4 hex>` — 4 lowercase hex chars
+    // appended after the timestamp's trailing `-`.
+    const collisionSuffixRegex = new RegExp(
+      `\\.bak\\.${expectedTs}-[0-9a-f]{4}$`,
+    );
+    const suffixed = backups.filter(
+      (p) => collisionSuffixRegex.test(p) && p !== collidingPath,
+    );
+    expect(suffixed.length).toBe(1);
+    // Confirm the suffix shape: 4 hex chars after `-`.
+    expect(suffixed[0]).toMatch(collisionSuffixRegex);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 17 — backup-failed refusal.
+  //
+  // chmodSync the target's parent directory to 0o555 so `fs.copyFile`
+  // throws EACCES. The orchestrator must surface `status: 'backup-failed'`
+  // and skip Pass 2 (the target file is unchanged).
+  // -------------------------------------------------------------------------
+
+  it('chmod 0o555 on parent dir surfaces backup-failed and does not call Pass 2', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const claudeDir = dirname(claudePath);
+
+    seedCanonicalConfig(env.xdgConfigHome, buildCanonicalConfigJson());
+
+    const claudeBeforeBytes = readFileSync(claudePath);
+
+    // Lock down the directory: no write perms → copyFile to .bak.* fails.
+    // Skip on Windows where chmod mode bits are not enforced the same way.
+    if (process.platform === 'win32') {
+      return;
+    }
+    const originalDirMode = statSync(claudeDir).mode & 0o777;
+    chmodSync(claudeDir, 0o555);
+
+    let code!: number;
+    let stdoutText!: string;
+    let stderrText!: string;
+    try {
+      const stdout = new BufferWriter();
+      const stderr = new BufferWriter();
+      code = await runApply([], stdout, stderr);
+      stdoutText = stdout.text();
+      stderrText = stderr.text();
+    } finally {
+      // Always restore perms so afterEach can rmSync.
+      chmodSync(claudeDir, originalDirMode);
+    }
+
+    // At least one agent (claude-code) reports backup-failed → exit 1.
+    expect(code).toBe(1);
+    const combined = `${stdoutText}${stderrText}`.toLowerCase();
+    expect(combined).toContain('backup');
+
+    // The target was NOT written (Pass 2 skipped).
+    expect(readFileSync(claudePath)).toEqual(claudeBeforeBytes);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 18 — `apply --dry-run` byte-identical regression; backupBeforeWrite
+  // is honored but `--dry-run` is read-only so no backup files exist.
+  // -------------------------------------------------------------------------
+
+  it('apply --dry-run is byte-identical and creates no .bak. files', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const opencodePath = seedOpencodeUserConfig(
+      env.xdgConfigHome,
+      opencodeConfigJsonc(),
+    );
+
+    seedCanonicalConfig(env.xdgConfigHome, buildCanonicalConfigJson());
+
+    const claudeBeforeBytes = readFileSync(claudePath);
+    const opencodeBeforeBytes = readFileSync(opencodePath);
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run'], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBe(0);
+
+    // Targets unchanged.
+    expect(readFileSync(claudePath)).toEqual(claudeBeforeBytes);
+    expect(readFileSync(opencodePath)).toEqual(opencodeBeforeBytes);
+
+    // No .bak.* files anywhere.
+    expect(findBackupFiles(dirname(claudePath), basename(claudePath))).toEqual(
+      [],
+    );
+    expect(
+      findBackupFiles(dirname(opencodePath), basename(opencodePath)),
+    ).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 19 — `apply --json` without `--dry-run` exits 2 (regression for
+  // F1 invalid-combination guard).
+  // -------------------------------------------------------------------------
+
+  it('apply --json without --dry-run exits 2 (invalid combination)', async () => {
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--json'], stdout, stderr);
+
+    expect(code).toBe(2);
+    expect(stderr.text().toLowerCase()).toContain('invalid');
+    expect(stdout.text()).toBe('');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 20 — unknown agent id surfaces as not-targetable.
+  // -------------------------------------------------------------------------
+
+  it('unknown agent id in sync.targets surfaces as not-targetable', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({ targets: ['nonexistent'] }),
+    );
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply([], stdout, stderr);
+
+    expect(code).toBe(1);
+    const out = stdout.text();
+    expect(out).toContain('not-targetable');
+    expect(out).toContain('nonexistent');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 21 — `disabledServers` excludes a server from BOTH Pass 1
+  // (dry-run discovery) and Pass 2 (real-write) inputs.
+  //
+  // We spy on the opencode writer to capture both calls. Both must show
+  // `b` but never `a`.
+  // -------------------------------------------------------------------------
+
+  it('disabledServers excludes the named server from both Pass 1 and Pass 2 writer inputs', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        mcpServers: {
+          a: { type: 'stdio', command: 'node' },
+          b: { type: 'stdio', command: 'node' },
+        },
+        targets: ['opencode'],
+        disabledServers: ['a'],
+      }),
+    );
+    seedOpencodeUserConfig(env.xdgConfigHome, opencodeConfigJsonc('b'));
+
+    const target: AgentDefinition | undefined = agentRegistry.find(
+      (a) => a.id === 'opencode',
+    );
+    expect(target).toBeDefined();
+    if (target === undefined) return;
+    const originalWrite = target.mcp.write;
+    if (originalWrite === undefined) return;
+
+    const capturedInputs: { servers: readonly { name: string }[] }[] = [];
+    const writeSpy = vi
+      .spyOn(target.mcp, 'write')
+      .mockImplementation(async (ctx, input) => {
+        capturedInputs.push({
+          servers: input.servers.map((s) => ({ name: s.name })),
+        });
+        return originalWrite(ctx, input);
+      });
+
+    try {
+      const stdout = new BufferWriter();
+      const stderr = new BufferWriter();
+      await runApply([], stdout, stderr);
+
+      // Two writer calls (Pass 1 dry-run + Pass 2 real-write).
+      expect(capturedInputs.length).toBeGreaterThanOrEqual(1);
+      for (const captured of capturedInputs) {
+        const names = captured.servers.map((s) => s.name);
+        expect(names).not.toContain('a');
+      }
+      // At least one captured input must contain `b`.
+      const lastInput = capturedInputs[capturedInputs.length - 1];
+      expect(lastInput?.servers.map((s) => s.name)).toContain('b');
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 22 — exit code 1 when at least one result is `backup-failed`.
+  // -------------------------------------------------------------------------
+
+  it('exit code is 1 when at least one agent result is backup-failed', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const claudeDir = dirname(claudePath);
+
+    seedCanonicalConfig(env.xdgConfigHome, buildCanonicalConfigJson());
+
+    if (process.platform === 'win32') return;
+    const originalDirMode = statSync(claudeDir).mode & 0o777;
+    chmodSync(claudeDir, 0o555);
+
+    let code!: number;
+    try {
+      const stdout = new BufferWriter();
+      const stderr = new BufferWriter();
+      code = await runApply([], stdout, stderr);
+    } finally {
+      chmodSync(claudeDir, originalDirMode);
+    }
+
+    expect(code).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 23 — Claude Code two-target backup.
+  //
+  // TODO: skipped — see `.omo/drafts/f2-apply-with-backups.md` Case 23.
+  //
+  // The Claude Code writer (`packages/agents/src/claude-code-write.ts`)
+  // calls `pickClaudeCodeTarget`, which returns at most ONE target
+  // (project `.mcp.json` wins if present; otherwise user-top or
+  // user-projects under `~/.claude.json`). It never writes to both
+  // `~/.claude.json` AND `<workspaceDir>/.mcp.json` in a single call,
+  // so a "two backups per agent" assertion cannot be made against the
+  // current writer surface. The end-to-end real-write guarantee is
+  // exercised instead by `node apps/cli/scripts/verify-package.mjs`,
+  // which performs a real `overture apply` against a tmpdir.
+  //
+  // (Adding the multi-target support is intentionally out of scope for
+  // F2; it would require widening `AgentMcpWriteResult.targetPaths[]`
+  // semantics beyond the writer's "first matching location" contract.)
+  // -------------------------------------------------------------------------
 });
 
 // ---------------------------------------------------------------------------
@@ -1054,10 +1639,13 @@ describe('formatHumanApplyDryRun', () => {
     }
   });
 
-  it('includes a "not yet implemented" advisory footer pointing at overture apply', () => {
+  it('includes a footer pointing at overture apply (no longer "not yet implemented" since F2)', () => {
     const text = formatHumanApplyDryRun(sampleEnvelope);
-    expect(text.toLowerCase()).toContain('not yet implemented');
     expect(text).toContain('overture apply');
+    // F1 used "not yet implemented" to flag the real-write path as
+    // future work; F2 lands the real-write path, so the dry-run footer
+    // now points operators at `overture apply` without the stub warning.
+    expect(text.toLowerCase()).not.toContain('not yet implemented');
   });
 
   it('does not include raw original or written config bytes', () => {

--- a/apps/cli/src/apply-command.spec.ts
+++ b/apps/cli/src/apply-command.spec.ts
@@ -1013,13 +1013,20 @@ describe('runApply (F2 real-write contract)', () => {
   // -------------------------------------------------------------------------
   // Case 14 — real-write happy path.
   //
-  // Seeds Claude with a `command: 'old'` so its writer plans an update
-  // (the seeded Claude content must differ from canonical; otherwise the
-  // writer classifies as `no-change` and no backup is created). OpenCode's
-  // seeded content already differs from canonical (type: 'local' vs
-  // 'stdio', command shape), so it always plans an update. The test
-  // asserts both targets are written and both backups exist, byte-identical
-  // to the pre-write seed.
+  // Seeds BOTH Claude and OpenCode configs that differ from canonical so
+  // each writer plans an update. Canonical uses a remote filesystem
+  // (`type: 'remote'`, url + headers) because the OpenCode writer's
+  // existing-entry update path is only correct for remote canonicals;
+  // stdio canonicals trigger a planEdits round-trip through the
+  // local → remote fallthrough (see `packages/agents/src/opencode-write.ts`
+  // `toOpenCodeMcpServer` + `planEdits`). Per-writer correctness is locked
+  // by the unit-specs in
+  // `packages/agents/src/{claude-code,opencode,...}.write.spec.ts`; this
+  // case covers the F2 orchestrator's two-pass + backup surface, not
+  // per-writer byte fidelity.
+  //
+  // Claude converts remote → `{ type: 'http', url, headers }`.
+  // OpenCode passes remote through unchanged.
   // -------------------------------------------------------------------------
 
   it('apply (no flag) writes the target and creates a byte-identical timestamped backup', async () => {
@@ -1028,10 +1035,8 @@ describe('runApply (F2 real-write contract)', () => {
     applyEnv(env);
     seedAllFakeBins(env.pathDir);
 
-    // Claude seeded with `command: 'old'` so the writer plans an update
-    // (not no-change). Single-target setup so the test focuses on F2's
-    // two-pass + backup orchestration; opencode + multi-target backup is
-    // exercised separately by `verify-package.mjs`.
+    // Claude seeded with a stdio `filesystem` so the writer plans an
+    // update (remote canonical differs from stdio seed).
     const claudePath = seedClaudeUserConfig(
       env.home,
       JSON.stringify(
@@ -1044,17 +1049,36 @@ describe('runApply (F2 real-write contract)', () => {
         2,
       ),
     );
+    // OpenCode seeded with `type: 'local'` + `command: ['old']` so its
+    // writer plans an update (remote canonical differs from local seed
+    // in both transport and value).
+    const opencodePath = seedOpencodeUserConfig(
+      env.xdgConfigHome,
+      `{
+  "mcp": {
+    "filesystem": {
+      "type": "local",
+      "command": ["old"]
+    }
+  }
+}
+`,
+    );
     seedCanonicalConfig(
       env.xdgConfigHome,
       buildCanonicalConfigJson({
-        targets: ['claude-code'],
         mcpServers: {
-          filesystem: { type: 'stdio', command: 'node' },
+          filesystem: {
+            type: 'remote',
+            url: 'https://mcp.example.com/filesystem',
+            headers: { Authorization: 'Bearer test-token' },
+          },
         },
       }),
     );
 
     const claudeBeforeBytes = readFileSync(claudePath);
+    const opencodeBeforeBytes = readFileSync(opencodePath);
 
     const stdout = new BufferWriter();
     const stderr = new BufferWriter();
@@ -1063,25 +1087,47 @@ describe('runApply (F2 real-write contract)', () => {
     expect(stderr.text()).toBe('');
     expect(code).toBe(0);
 
-    // Target was updated.
+    // Targets were updated.
     const claudeAfterBytes = readFileSync(claudePath);
+    const opencodeAfterBytes = readFileSync(opencodePath);
     expect(claudeAfterBytes).not.toEqual(claudeBeforeBytes);
+    expect(opencodeAfterBytes).not.toEqual(opencodeBeforeBytes);
 
-    // The canonical filesystem server name should appear in the updated bytes.
+    // The canonical filesystem server name should appear in both updated files.
     expect(claudeAfterBytes.toString('utf8')).toContain('filesystem');
+    expect(opencodeAfterBytes.toString('utf8')).toContain('filesystem');
 
-    // Backup exists adjacent to the target, byte-identical to the seed.
-    const claudeDir = dirname(claudePath);
-    const claudeBackups = findBackupFiles(claudeDir, basename(claudePath));
+    // The canonical URL should appear in both files (Claude writes
+    // `type: 'http'` + url + headers; OpenCode passes the remote form
+    // through unchanged).
+    expect(claudeAfterBytes.toString('utf8')).toContain(
+      'https://mcp.example.com/filesystem',
+    );
+    expect(opencodeAfterBytes.toString('utf8')).toContain(
+      'https://mcp.example.com/filesystem',
+    );
+
+    // Backups exist adjacent to each target, byte-identical to the seed.
+    const claudeBackups = findBackupFiles(
+      dirname(claudePath),
+      basename(claudePath),
+    );
+    const opencodeBackups = findBackupFiles(
+      dirname(opencodePath),
+      basename(opencodePath),
+    );
 
     expect(claudeBackups.length).toBeGreaterThanOrEqual(1);
     expect(readFileSync(claudeBackups[0])).toEqual(claudeBeforeBytes);
 
-    // Human-readable report must mention the backup path so the operator
-    // can find it.
+    expect(opencodeBackups.length).toBeGreaterThanOrEqual(1);
+    expect(readFileSync(opencodeBackups[0])).toEqual(opencodeBeforeBytes);
+
+    // Human-readable report must mention each backup path so the operator
+    // can find them.
     const out = stdout.text();
     expect(out).toMatch(/Apply \(changes written\)/);
-    for (const bp of claudeBackups) {
+    for (const bp of [...claudeBackups, ...opencodeBackups]) {
       expect(out).toContain(bp);
     }
   });

--- a/apps/cli/src/apply-command.ts
+++ b/apps/cli/src/apply-command.ts
@@ -1,5 +1,5 @@
 /**
- * F1 — `overture apply` subcommand.
+ * F1 + F2 — `overture apply` subcommand.
  *
  * Ships the gate-5 type surface (`ApplyDryRunResult`, `ApplyDryRunAgentResult`,
  * `RunApplyOptions`), the args-parsing + exit-code plumbing (`runApply`,
@@ -7,25 +7,29 @@
  * (`formatHumanApplyDryRun`), and the orchestration that wires the canonical
  * config to per-agent writers.
  *
- * Dry-run is the only supported mode in F1. Real writes (`overture apply`
- * without `--dry-run`) exit 2 with a "not yet implemented" advisory so
- * callers learn the difference between an invalid flag combination and a
- * not-yet-supported feature. The `--json` flag requires `--dry-run` (mirror
- * bootstrap's invalid-combination guard).
+ * F1 ships the `--dry-run` preview path. F2 adds the real-write path with
+ * adjacent timestamped backups: two-pass per writer (dryRun: true → backup
+ * snapshot → dryRun: false). The backup-before-write gate is controlled by
+ * `settings.backupBeforeWrite` (default `true`); when `false`, the
+ * orchestrator skips the backup step but still performs the write.
  *
  * Exit codes:
  *   - `0` — orchestration completed and every per-agent result is clean
- *           (`would-update` or `no-change`).
+ *           (`would-update` / `updated` / `no-change`).
  *   - `1` — orchestration completed but at least one per-agent result is a
  *           refusal (`not-targetable`, `parse-error`, `unsupported-shape`,
- *           `unsupported-format`), OR the canonical config is absent
- *           (no `overture.jsonc` to apply). The JSON envelope is still
- *           emitted to stdout before the non-zero exit so consumers can
- *           read the failure model.
- *   - `2` — usage errors (unknown flags, `--json` without `--dry-run`,
- *           `apply` without `--dry-run`), unknown profile name, or any
- *           orchestration failure that prevents the model from being built.
+ *           `unsupported-format`, `backup-failed`), OR the canonical config
+ *           is absent. The JSON / human envelope is still emitted so callers
+ *           can read the failure model.
+ *   - `2` — usage errors (unknown flags, `--json` without `--dry-run`),
+ *           unknown profile name, or any orchestration failure that prevents
+ *           the model from being built.
  */
+import { randomBytes } from 'node:crypto';
+import { readdirSync } from 'node:fs';
+import { copyFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join } from 'node:path';
+
 import {
   defaultOverturePaths,
   loadOvertureConfig,
@@ -96,23 +100,93 @@ export interface ApplyDryRunResult {
   readonly results: readonly ApplyDryRunAgentResult[];
 }
 
-/**
- * Injection seam for tests and production. F1 ships it empty: the F1 slice
- * never wires a real prompt or path-context factory because writers are
- * called directly with `dryRun: true`. F2 / F3 may add fields
- * (e.g. `pathContextFactory`, `prompt`); keeping the interface exported
- * lets future tests reference it without churn.
- */
+// ---------------------------------------------------------------------------
+// F2 — Apply real-write output types.
+// ---------------------------------------------------------------------------
 
+/**
+ * Per-agent outcome of a real-write.
+ *
+ * - `updated`           — Pass 2 (real-write) succeeded and modified the
+ *                         target file.
+ * - `no-change`         — Pass 1 (dry-run discovery) returned `changed: false`
+ *                         OR Pass 2 reported `changed: false`; nothing to do.
+ * - `backup-failed`     — `fs.copyFile` failed for one or more target paths
+ *                         during the backup step; Pass 2 was skipped.
+ * - `not-targetable`    — unknown agent id OR missing `mcp.write` OR writer
+ *                         returned `reason: 'not-targetable'`.
+ * - `parse-error`       — writer returned `reason: 'parse-error'`.
+ * - `unsupported-shape` — writer returned `reason: 'unsupported-shape'`.
+ * - `unsupported-format`— writer returned `reason: 'unsupported-format'`.
+ */
+export type ApplyStatus =
+  | 'updated'
+  | 'no-change'
+  | 'backup-failed'
+  | 'not-targetable'
+  | 'parse-error'
+  | 'unsupported-shape'
+  | 'unsupported-format';
+
+/** Single per-agent entry in an {@link ApplyResult}. */
+export interface ApplyAgentResult {
+  readonly agentId: string;
+  readonly displayName: string;
+  readonly status: ApplyStatus;
+  /**
+   * The writer envelope returned by `agent.mcp.write`. For clean updates,
+   * this is the real-write (Pass 2) envelope. For refusals / no-change, it
+   * is the Pass 1 dry-run envelope (Pass 2 was skipped).
+   */
+  readonly result: AgentMcpWriteResult;
+  /**
+   * Absolute paths of the backup files created before Pass 2. Empty when
+   * no backups were created (either `backupBeforeWrite: false` or Pass 2
+   * was skipped due to a refusal / no-change).
+   */
+  readonly backupPaths: readonly string[];
+  /**
+   * Optional human-readable reason. Populated when the writer omitted a
+   * `reason` (e.g. unknown agent id, missing `mcp.write` slot) or when the
+   * backup step failed and Pass 2 was skipped.
+   */
+  readonly reasonDetail?: string;
+}
+
+/** Top-level envelope emitted by `overture apply` (no `--dry-run`). */
+export interface ApplyResult {
+  readonly profile: string;
+  readonly configPath: string;
+  readonly disabledServers: readonly string[];
+  /** Echo of the effective `settings.backupBeforeWrite` value. */
+  readonly backupBeforeWrite: boolean;
+  readonly results: readonly ApplyAgentResult[];
+}
+
+/**
+ * Injection seam for tests and production. The F2 slice adds `now` so
+ * deterministic-timestamp tests can pin the backup timestamp without
+ * relying on `vi.setSystemTime`. The `prompt` field is reserved for future
+ * interactive flows; F1 ships it as `unknown` so callers can reference it
+ * without churn.
+ */
 export interface RunApplyOptions {
   readonly prompt?: unknown;
+  /**
+   * Optional fixed clock for the backup step. When `undefined`, the
+   * orchestrator uses `new Date()` (real wall clock).
+   */
+  readonly now?: Date;
 }
 
 // ---------------------------------------------------------------------------
 // Constants.
 // ---------------------------------------------------------------------------
 
-export const APPLY_USAGE = 'Usage: overture apply --dry-run [--json]\n';
+export const APPLY_USAGE = 'Usage: overture apply [--dry-run] [--json]\n';
+
+/** Number of retries when picking a unique backup path. */
+const BACKUP_COLLISION_RETRIES = 3;
 
 // ---------------------------------------------------------------------------
 // Pure helpers.
@@ -142,6 +216,115 @@ export function exitCodeForApplyDryRun(
 }
 
 /**
+ * Decide the exit code for a successful real-write based on per-agent
+ * outcomes. Refusal set adds `backup-failed` to the dry-run refusal set;
+ * clean statuses (`updated`, `no-change`) exit 0.
+ */
+export function exitCodeForApply(results: readonly ApplyAgentResult[]): 0 | 1 {
+  const refusalStatuses: ReadonlySet<ApplyStatus> = new Set([
+    'backup-failed',
+    'not-targetable',
+    'parse-error',
+    'unsupported-shape',
+    'unsupported-format',
+  ]);
+  return results.some((r) => refusalStatuses.has(r.status)) ? 1 : 0;
+}
+
+/**
+ * Format `date` as `YYYYMMDD-HHmmssSSS` using UTC components. Lexically
+ * sortable; matches the openclaw-style backup timestamp proposed in the
+ * F2 plan (gate F2-2). Pure function — no `Date.now()` calls.
+ */
+export function formatBackupTimestamp(date: Date): string {
+  const pad2 = (n: number): string => n.toString().padStart(2, '0');
+  const pad3 = (n: number): string => n.toString().padStart(3, '0');
+  const datePart =
+    date.getUTCFullYear().toString() +
+    pad2(date.getUTCMonth() + 1) +
+    pad2(date.getUTCDate());
+  const timePart =
+    pad2(date.getUTCHours()) +
+    pad2(date.getUTCMinutes()) +
+    pad2(date.getUTCSeconds());
+  return `${datePart}-${timePart}${pad3(date.getUTCMilliseconds())}`;
+}
+
+/**
+ * Pick a unique backup path for `targetPath`. Returns
+ * `<target>.bak.<YYYYMMDD-HHmmssSSS>` by default. If that candidate is in
+ * the `existing` set, append `-<randomHex(4)>` (Node
+ * `crypto.randomBytes(2).toString('hex')`) and retry up to
+ * {@link BACKUP_COLLISION_RETRIES} times. After the retry budget is
+ * exhausted, returns the most recent candidate (the caller decides what
+ * to do with it; the orchestrator returns `backup-failed`).
+ *
+ * Pure: filesystem presence is consulted through the optional `existing`
+ * parameter so callers can pre-list the directory and pass results.
+ */
+export function backupPathFor(
+  targetPath: string,
+  now: Date,
+  existing: readonly string[] = [],
+): string {
+  const base = `${targetPath}.bak.${formatBackupTimestamp(now)}`;
+  const collisionSet = new Set(existing);
+  let candidate = base;
+  for (let i = 0; i < BACKUP_COLLISION_RETRIES; i++) {
+    if (!collisionSet.has(candidate)) return candidate;
+    candidate = `${base}-${randomBytes(2).toString('hex')}`;
+  }
+  return candidate;
+}
+
+/**
+ * Tagged error thrown by {@link copyFileWithClassification}. `backup-failed`
+ * is a CLI-local status (per project memory 112): it never appears in
+ * `WriteReason`, only in the {@link ApplyStatus} union.
+ */
+export interface BackupFailedError extends Error {
+  readonly kind: 'backup-failed';
+  readonly code: NodeJS.ErrnoException['code'];
+  readonly sourcePath: string;
+  readonly backupPath: string;
+}
+
+/**
+ * Wrap `fs.copyFile` so a per-target backup failure surfaces as a tagged
+ * error the orchestrator can map to `status: 'backup-failed'`. Other
+ * (non-ErrnoException) errors propagate unchanged — they are unexpected
+ * programming bugs, not user-actionable filesystem states.
+ */
+export async function copyFileWithClassification(
+  src: string,
+  dest: string,
+): Promise<void> {
+  try {
+    await copyFile(src, dest);
+  } catch (err) {
+    const code: NodeJS.ErrnoException['code'] =
+      typeof err === 'object' &&
+      err !== null &&
+      typeof (err as Record<string, unknown>).code === 'string'
+        ? ((err as Record<string, unknown>)
+            .code as NodeJS.ErrnoException['code'])
+        : undefined;
+    const tagged: BackupFailedError = Object.assign(
+      new Error(
+        `backup failed: copyFile(${src} -> ${dest}): ${err instanceof Error ? err.message : String(err)}`,
+      ),
+      {
+        kind: 'backup-failed' as const,
+        code,
+        sourcePath: src,
+        backupPath: dest,
+      },
+    );
+    throw tagged;
+  }
+}
+
+/**
  * Render an {@link ApplyDryRunResult} as a human-readable report.
  *
  * Gate-5 layout (per `docs/overture-implementation-slices.md` and the
@@ -157,7 +340,7 @@ export function exitCodeForApplyDryRun(
  *        sourced from `reasonDetail` (preferred) or the writer's
  *        `reason` fallback.
  *   4. Summary line counting each status bucket.
- *   5. F2 advisory footer pointing at `overture apply`.
+ *   5. Footer pointing at `overture apply`.
  *
  * Plain text only — no ANSI colors. Resolved target paths come from
  * `result.targetPaths[0].path` (preferred) or `result.resolvedPath`;
@@ -224,8 +407,103 @@ export function formatHumanApplyDryRun(result: ApplyDryRunResult): string {
       `${String(counts.noChange)} no-change, ` +
       `${String(counts.refusals)} refusal(s).`,
   );
+  lines.push('Run `overture apply` to write the planned changes.');
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Render an {@link ApplyResult} as a human-readable report.
+ *
+ * Layout (per F2 gate F2-4 — human-only):
+ *
+ *   1. Heading — `Apply (changes written)` when any agent is `updated`,
+ *      otherwise `Apply (no changes written)`.
+ *   2. Profile, config path, `disabledServers`, and `backup` echo lines.
+ *   3. One section per agent:
+ *      - clean statuses (`updated`, `no-change`) — `target`,
+ *        `backup` (only when `backupPaths.length > 0`), `changed`,
+ *        `bytes` (signed), and `servers` lines.
+ *      - refusal statuses (`backup-failed`, `not-targetable`,
+ *        `parse-error`, `unsupported-shape`, `unsupported-format`) —
+ *        `reason` line sourced from `reasonDetail` (preferred) or the
+ *        writer's `reason` fallback.
+ *   4. Summary line counting each status bucket.
+ *   5. Footer pointing at `overture apply --dry-run`.
+ *
+ * Plain text only — no ANSI colors. Raw original/written bytes are never
+ * embedded (F1 carry-over).
+ */
+export function formatHumanApply(result: ApplyResult): string {
+  const lines: string[] = [];
+  const anyUpdated = result.results.some((r) => r.status === 'updated');
   lines.push(
-    'Run `overture apply` to write the planned changes (not yet implemented).',
+    anyUpdated ? 'Apply (changes written)' : 'Apply (no changes written)',
+  );
+  lines.push(`Profile: ${result.profile}`);
+  lines.push(`Config:  ${result.configPath}`);
+  lines.push(
+    `Disabled: ${
+      result.disabledServers.length === 0
+        ? '[]'
+        : result.disabledServers.join(', ')
+    }`,
+  );
+  lines.push(`Backup:   ${result.backupBeforeWrite ? 'enabled' : 'disabled'}`);
+  lines.push('');
+
+  const isCleanStatus = (
+    status: ApplyStatus,
+  ): status is 'updated' | 'no-change' =>
+    status === 'updated' || status === 'no-change';
+
+  for (const agent of result.results) {
+    lines.push(`[${agent.agentId}]`);
+    lines.push(`  status:    ${agent.status}`);
+    if (isCleanStatus(agent.status)) {
+      const target = agent.result.targetPaths[0];
+      const targetPath =
+        target?.path ?? agent.result.resolvedPath ?? '(unknown)';
+      lines.push(`  target:    ${targetPath}`);
+      if (agent.backupPaths.length > 0) {
+        for (const bp of agent.backupPaths) {
+          lines.push(`  backup:    ${bp}`);
+        }
+      }
+      lines.push(`  changed:   ${String(agent.result.changed)}`);
+      const bytes = agent.result.bytesChanged ?? 0;
+      const sign = bytes > 0 && agent.result.changed ? '+' : '';
+      lines.push(`  bytes:     ${sign}${bytes}`);
+      if (agent.result.serversWritten.length > 0) {
+        lines.push(`  servers:   ${agent.result.serversWritten.join(', ')}`);
+      }
+    } else {
+      const reason = agent.reasonDetail ?? agent.result.reason ?? '(no reason)';
+      lines.push(`  reason:    ${reason}`);
+    }
+    lines.push('');
+  }
+
+  const counts = {
+    updated: result.results.filter((r) => r.status === 'updated').length,
+    noChange: result.results.filter((r) => r.status === 'no-change').length,
+    refusals: result.results.filter(
+      (r) =>
+        r.status === 'backup-failed' ||
+        r.status === 'not-targetable' ||
+        r.status === 'parse-error' ||
+        r.status === 'unsupported-shape' ||
+        r.status === 'unsupported-format',
+    ).length,
+  };
+  const total = result.results.length;
+  lines.push(
+    `Summary: ${String(total)} agent${total === 1 ? '' : 's'}, ` +
+      `${String(counts.updated)} updated, ` +
+      `${String(counts.noChange)} no-change, ` +
+      `${String(counts.refusals)} refusal(s).`,
+  );
+  lines.push(
+    'Run `overture apply --dry-run` to preview changes without writing.',
   );
   return `${lines.join('\n')}\n`;
 }
@@ -274,13 +552,112 @@ function statusFromWriterResult(
 }
 
 /**
+ * Map a writer's {@link AgentMcpWriteResult} to the F2 {@link ApplyStatus}.
+ * Mirrors {@link statusFromWriterResult} but maps `would-update` →
+ * `updated`. Pass 2 (`dryRun: false`) writers always set `changed: true`
+ * when they actually wrote, so the plannedUpdate OR signals reduce to a
+ * `changed` check.
+ */
+function statusFromRealWriterResult(result: AgentMcpWriteResult): ApplyStatus {
+  const reason = result.reason;
+  if (reason === 'parse-error') return 'parse-error';
+  if (reason === 'unsupported-shape') return 'unsupported-shape';
+  if (reason === 'unsupported-format') return 'unsupported-format';
+  if (reason === 'not-targetable') return 'not-targetable';
+  const plannedUpdate =
+    result.changed ||
+    result.written > 0 ||
+    result.serversWritten.length > 0 ||
+    (result.bytesChanged !== undefined && result.bytesChanged > 0);
+  return plannedUpdate ? 'updated' : 'no-change';
+}
+
+/**
+ * Build the canonical-filtered server list shared by both Pass 1 (dry-run
+ * discovery) and Pass 2 (real-write). Keeping the filter in one helper
+ * guarantees the disabled-server invariant holds across both passes.
+ */
+function buildFilteredServers(
+  profile: OvertureProfile,
+): readonly AgentMcpWriteServer[] {
+  return Object.entries(profile.mcpServers)
+    .filter(([name]) => !profile.sync.disabledServers.includes(name))
+    .map(([name, server]) => ({ name, server }));
+}
+
+/** Inferred shape of a single entry in `AgentMcpWriteResult.targetPaths`. */
+type WriteTargetPath = AgentMcpWriteResult['targetPaths'][number];
+
+/**
+ * Resolve a `WriteTargetPath` to its absolute path on disk given a
+ * `PathResolutionContext`. Mirrors `apps/cli/src/platforms/detect.ts`'s
+ * `resolveMcpLocationPath` so the orchestrator agrees with the writers
+ * about where the file lives.
+ *
+ * Writer convention diverges: OpenCode / Codex emit `targetPaths[*].path`
+ * as the raw `loc.relativePath` (relative — e.g. `opencode/opencode.json`),
+ * while Claude / Copilot emit the fully-resolved absolute path. We detect
+ * the absolute-vs-relative distinction here and resolve once, so `fs.copyFile`
+ * always sees an absolute path. The `base` field is a hint for relative
+ * paths; absolute paths bypass it.
+ */
+function resolveTargetBase(
+  base: WriteTargetPath['base'],
+  filePath: string,
+  ctx: PathResolutionContext,
+): string {
+  if (isAbsolute(filePath)) return filePath;
+  switch (base) {
+    case 'home':
+      return join(ctx.homeDir, filePath);
+    case 'config':
+      return join(ctx.configDir, filePath);
+    case 'workspace':
+      return join(ctx.workspaceDir, filePath);
+    case 'absolute':
+      return filePath;
+  }
+}
+
+/**
+ * Collect the absolute target paths a writer intends to back up. Dedupes
+ * across `targetPaths[*]` (resolved via the writer's `base` field) and
+ * the legacy `resolvedPath` fallback so a writer that emits both does not
+ * double-back-up the same file. `targetPaths[*].path` is treated as a
+ * relative path against its declared `base` — the writer surfaces only the
+ * raw `loc.relativePath` there (see `packages/agents/src/opencode-write.ts`
+ * line 435 for the convention), so resolving it here is required for
+ * `fs.copyFile` to find the source.
+ */
+function collectBackupTargets(
+  result: AgentMcpWriteResult,
+  ctx: PathResolutionContext,
+): readonly string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const tp of result.targetPaths) {
+    if (tp.path.length === 0) continue;
+    const absolute = resolveTargetBase(tp.base, tp.path, ctx);
+    if (!seen.has(absolute)) {
+      seen.add(absolute);
+      out.push(absolute);
+    }
+  }
+  if (result.resolvedPath !== undefined && !seen.has(result.resolvedPath)) {
+    seen.add(result.resolvedPath);
+    out.push(result.resolvedPath);
+  }
+  return out;
+}
+
+/**
  * Run a single per-agent dry-run write for the named target. Synthesizes a
  * `not-targetable` envelope when the agent id is unknown or the writer
  * slot is absent so the orchestrator can record every target in the report
  * (per plan decision point 2: "unknown agent id is a refusal, not a hard
  * error").
  */
-async function applyToAgent(
+async function applyToAgentDryRun(
   ctx: PathResolutionContext,
   profile: OvertureProfile,
   agentId: string,
@@ -320,11 +697,7 @@ async function applyToAgent(
     };
   }
 
-  const servers: readonly AgentMcpWriteServer[] = Object.entries(
-    profile.mcpServers,
-  )
-    .filter(([name]) => !profile.sync.disabledServers.includes(name))
-    .map(([name, server]) => ({ name, server }));
+  const servers = buildFilteredServers(profile);
 
   const writerResult = await entry.mcp.write(ctx, {
     servers,
@@ -340,8 +713,160 @@ async function applyToAgent(
   };
 }
 
+/**
+ * Two-pass per-agent write: Pass 1 (dry-run discovery) → backup snapshot
+ * (when `backupBeforeWrite` is `true` and Pass 1 plans an update) → Pass 2
+ * (real-write). Synthesizes `not-targetable` envelopes for unknown / missing
+ * writers so the orchestrator records every target.
+ *
+ * Backup failure short-circuits to `status: 'backup-failed'` and skips
+ * Pass 2; the target file is left untouched (the writer's atomic-rename
+ * rename path never runs). The seeded filesystem stays intact so the
+ * operator can investigate.
+ */
+async function applyToAgentReal(
+  ctx: PathResolutionContext,
+  profile: OvertureProfile,
+  agentId: string,
+  options: {
+    readonly backupBeforeWrite: boolean;
+    readonly now: Date;
+  },
+): Promise<ApplyAgentResult> {
+  const entry = agentRegistry.find((a) => a.id === agentId);
+  if (entry === undefined) {
+    return {
+      agentId,
+      displayName: agentId,
+      status: 'not-targetable',
+      result: {
+        written: 0,
+        changed: false,
+        dryRun: true,
+        serversWritten: [],
+        targetPaths: [],
+        reason: 'not-targetable',
+      },
+      backupPaths: [],
+      reasonDetail: `unknown agent id '${agentId}' in profile.sync.targets`,
+    };
+  }
+
+  if (entry.mcp.write === undefined) {
+    return {
+      agentId,
+      displayName: entry.displayName,
+      status: 'not-targetable',
+      result: {
+        written: 0,
+        changed: false,
+        dryRun: true,
+        serversWritten: [],
+        targetPaths: [],
+        reason: 'not-targetable',
+      },
+      backupPaths: [],
+      reasonDetail: 'no writer registered',
+    };
+  }
+
+  const servers = buildFilteredServers(profile);
+
+  // Pass 1 — dry-run discovery.
+  const dryResult = await entry.mcp.write(ctx, {
+    servers,
+    dryRun: true,
+    pathContext: ctx,
+  });
+  const dryStatus = statusFromWriterResult(dryResult);
+  // Refusal / no-change / parse-error / unsupported-* → no backup, no Pass 2.
+  if (dryStatus !== 'would-update') {
+    return {
+      agentId,
+      displayName: entry.displayName,
+      status:
+        dryStatus === 'no-change'
+          ? 'no-change'
+          : mapDryRefusalToApply(dryStatus),
+      result: dryResult,
+      backupPaths: [],
+    };
+  }
+
+  // Pass 1 says we should write. Optionally back up each target first.
+  const backupPaths: string[] = [];
+  if (options.backupBeforeWrite) {
+    const targets = collectBackupTargets(dryResult, ctx);
+    for (const target of targets) {
+      // Resolve the candidate path against any existing backups on disk.
+      // We can't synchronously readdir here (async caller) — instead, scan
+      // the parent directory lazily and feed the result to backupPathFor.
+      const dir = dirname(target);
+      const base = basename(target);
+      const existing: readonly string[] = (() => {
+        try {
+          return readdirSync(dir)
+            .filter((entry) => entry.startsWith(`${base}.bak.`))
+            .map((entry) => `${dir}/${entry}`);
+        } catch {
+          return [];
+        }
+      })();
+      const bp = backupPathFor(target, options.now, existing);
+      try {
+        await copyFileWithClassification(target, bp);
+        backupPaths.push(bp);
+      } catch (err) {
+        const detail = messageForError(err);
+        return {
+          agentId,
+          displayName: entry.displayName,
+          status: 'backup-failed',
+          result: dryResult,
+          backupPaths: [...backupPaths],
+          reasonDetail: `backup failed for ${target}: ${detail}`,
+        };
+      }
+    }
+  }
+
+  // Pass 2 — real write.
+  const realResult = await entry.mcp.write(ctx, {
+    servers,
+    dryRun: false,
+    pathContext: ctx,
+  });
+  return {
+    agentId,
+    displayName: entry.displayName,
+    status: statusFromRealWriterResult(realResult),
+    result: realResult,
+    backupPaths,
+  };
+}
+
+/** Map a dry-run refusal status to the equivalent F2 {@link ApplyStatus}. */
+function mapDryRefusalToApply(status: ApplyDryRunStatus): ApplyStatus {
+  switch (status) {
+    case 'parse-error':
+      return 'parse-error';
+    case 'unsupported-shape':
+      return 'unsupported-shape';
+    case 'unsupported-format':
+      return 'unsupported-format';
+    case 'not-targetable':
+      return 'not-targetable';
+    case 'no-change':
+      return 'no-change';
+    case 'would-update':
+      // Caller never reaches here for would-update (handled above), but
+      // satisfy the exhaustive switch.
+      return 'updated';
+  }
+}
+
 /** Build the gate-5 envelope from a validated profile + per-agent results. */
-function buildApplyResult(args: {
+function buildApplyDryRunResult(args: {
   readonly profileName: string;
   readonly profile: OvertureProfile;
   readonly configPath: string;
@@ -351,6 +876,23 @@ function buildApplyResult(args: {
     profile: args.profileName,
     configPath: args.configPath,
     disabledServers: [...args.profile.sync.disabledServers],
+    results: args.agentResults,
+  };
+}
+
+/** Build the F2 envelope from a validated profile + per-agent results. */
+function buildApplyResult(args: {
+  readonly profileName: string;
+  readonly profile: OvertureProfile;
+  readonly configPath: string;
+  readonly backupBeforeWrite: boolean;
+  readonly agentResults: readonly ApplyAgentResult[];
+}): ApplyResult {
+  return {
+    profile: args.profileName,
+    configPath: args.configPath,
+    disabledServers: [...args.profile.sync.disabledServers],
+    backupBeforeWrite: args.backupBeforeWrite,
     results: args.agentResults,
   };
 }
@@ -420,20 +962,21 @@ async function loadAndValidateProfile(paths: OverturePaths): Promise<
 // ---------------------------------------------------------------------------
 
 /**
- * Dispatch `overture apply` with the gate-5 type surface.
+ * Dispatch `overture apply` with the gate-5 + F2 type surface.
  *
- * Parses args, loads + validates the canonical config, picks the profile
- * named by `settings.defaultProfile`, filters `disabledServers`, iterates
- * `sync.targets`, and calls each agent's `mcp.write` with `dryRun: true`.
- * The `--json` path emits the gate-5 envelope; the default path emits the
- * human-readable report. The non-dry-run `apply` branch exits 2 with a
- * "not yet implemented" advisory; F2 will replace it.
+ * F1: `--dry-run [--json]` (preview path).
+ * F2: `apply` (no flag) → real-write path with per-target backups.
+ *
+ * Both paths share the same loader (canonical config + profile + disabled
+ * server filter) and the same registry iteration. The only divergence is
+ * which writer call mode (`dryRun: true` vs `dryRun: false`) and whether
+ * the backup step runs.
  */
 export async function runApply(
   args: readonly string[],
   stdout: StringWriter,
   stderr: StringWriter,
-  _options: RunApplyOptions = {},
+  options: RunApplyOptions = {},
 ): Promise<number> {
   if (args.includes('--help') || args.includes('-h')) {
     stdout.write(APPLY_USAGE);
@@ -450,19 +993,11 @@ export async function runApply(
   const hasDryRun = args.includes('--dry-run');
   const hasJson = args.includes('--json');
 
-  // Mirror bootstrap: explicit invalid-combination message wins over the
-  // generic "not yet implemented" so callers learn the difference between
-  // `apply --json` (invalid) and `apply` (valid shape, not yet supported).
+  // F1 carry-over: `--json` without `--dry-run` is reserved for the
+  // dry-run JSON envelope (per F2 gate F2-4 — no real-write JSON shape).
   if (hasJson && !hasDryRun) {
     stderr.write(
       `Invalid flag combination: --json requires --dry-run.\n${APPLY_USAGE}`,
-    );
-    return 2;
-  }
-
-  if (!hasDryRun) {
-    stderr.write(
-      `overture apply is not yet implemented; use --dry-run to preview.\n${APPLY_USAGE}`,
     );
     return 2;
   }
@@ -484,27 +1019,50 @@ export async function runApply(
   // here). Writers that take an explicit `ctx` arg still see it via
   // the first arg; `pathContext` mirrors it for self-contained writers.
   const ctx = defaultPathResolutionContext();
-  const agentResults: ApplyDryRunAgentResult[] = [];
-  for (const agentId of validated.profile.sync.targets) {
-    agentResults.push(await applyToAgent(ctx, validated.profile, agentId));
+  const backupBeforeWrite = validated.config.settings.backupBeforeWrite ?? true;
+  const now = options.now ?? new Date();
+
+  if (hasDryRun) {
+    // ----- F1 — preview path ---------------------------------------------
+    const agentResults: ApplyDryRunAgentResult[] = [];
+    for (const agentId of validated.profile.sync.targets) {
+      agentResults.push(
+        await applyToAgentDryRun(ctx, validated.profile, agentId),
+      );
+    }
+    const result = buildApplyDryRunResult({
+      profileName: validated.profileName,
+      profile: validated.profile,
+      configPath: validated.configPath,
+      agentResults,
+    });
+    if (hasJson) {
+      stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } else {
+      stdout.write(formatHumanApplyDryRun(result));
+    }
+    return exitCodeForApplyDryRun(agentResults);
   }
 
+  // ----- F2 — real-write path -------------------------------------------
+  const agentResults: ApplyAgentResult[] = [];
+  for (const agentId of validated.profile.sync.targets) {
+    agentResults.push(
+      await applyToAgentReal(ctx, validated.profile, agentId, {
+        backupBeforeWrite,
+        now,
+      }),
+    );
+  }
   const result = buildApplyResult({
     profileName: validated.profileName,
     profile: validated.profile,
     configPath: validated.configPath,
+    backupBeforeWrite,
     agentResults,
   });
-
-  if (hasJson) {
-    stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-  } else {
-    // The formatter already emits a trailing newline; mirror the
-    // bootstrap-command convention (which also calls
-    // `formatHumanBootstrapProposal` / `formatHumanInteractiveResult`
-    // directly via `stdout.write`, no extra `\n`).
-    stdout.write(formatHumanApplyDryRun(result));
-  }
-
-  return exitCodeForApplyDryRun(agentResults);
+  // F2 gate F2-4: real-write emits the human report only. `--json` is
+  // reserved for the dry-run envelope (validated above).
+  stdout.write(formatHumanApply(result));
+  return exitCodeForApply(agentResults);
 }

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -130,7 +130,7 @@ const USAGE =
   '  config show       Print the resolved user-level overture config.\n' +
   '  scan [--json]     Build the installed MCP server matrix.\n' +
   '  bootstrap [--dry-run] [--json]   Preview the canonical config that D3 would write.\n' +
-  '  apply --dry-run [--json]   Preview per-agent MCP writes from the canonical config (F1; real apply is F2).\n';
+  '  apply [--dry-run] [--json]   Apply canonical MCP intent to per-agent configs. Backups are created before each write (use --dry-run to preview without writing).\n';
 
 async function runDetect(flags: readonly string[]): Promise<number> {
   if (flags.includes('--help') || flags.includes('-h')) {

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -394,6 +394,26 @@ Then apply only the canonical MCP entries to the target MCP subtree.
 
 Expected result: real write behavior with backup creation.
 
+**Status: completed on feat/f2-apply-with-backups (this slice).** Delivered
+the `overture apply` real-write path with adjacent timestamped backups.
+Each per-agent write runs in two passes: Pass 1 (`dryRun: true`) discovers
+the target paths and change decision; if Pass 1 plans an update, the
+orchestrator snapshots each target via `fs.copyFile` to
+`<target>.bak.<YYYYMMDD-HHmmssSSS>` with a `-<randomHex(4)>` collision
+suffix (3 retries); only then does Pass 2 (`dryRun: false`) perform the
+real write. `settings.backupBeforeWrite` (default `true`) gates the
+backup step — when `false`, Pass 2 runs without a snapshot. Refusal
+statuses (`not-targetable`, `parse-error`, `unsupported-shape`,
+`unsupported-format`) skip both the backup step and Pass 2. Backup
+failures surface as a CLI-local `status: 'backup-failed'` (never widening
+`WriteReason` in `@overture/agents`). The new `ApplyResult` envelope
+(profile, configPath, disabledServers, backupBeforeWrite, results) is
+human-only per gate F2-4 — `--json` stays dry-run-only. The four writers
+in `@overture/agents` are untouched; the E1 preservation harness and
+E2/E3/E4 byte-splice semantics carry over for free. Conflict refusal
+(F3) and the G-track (state file + restore + human logs) remain future
+work.
+
 ### F3. Refuse settings conflicts during apply
 
 If a target agent already has the same server name with different settings,

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -408,11 +408,31 @@ statuses (`not-targetable`, `parse-error`, `unsupported-shape`,
 failures surface as a CLI-local `status: 'backup-failed'` (never widening
 `WriteReason` in `@overture/agents`). The new `ApplyResult` envelope
 (profile, configPath, disabledServers, backupBeforeWrite, results) is
-human-only per gate F2-4 — `--json` stays dry-run-only. The four writers
-in `@overture/agents` are untouched; the E1 preservation harness and
-E2/E3/E4 byte-splice semantics carry over for free. Conflict refusal
+human-only per gate F2-4 — `--json` stays dry-run-only. Conflict refusal
 (F3) and the G-track (state file + restore + human logs) remain future
 work.
+
+> **Retroactive fixes shipped alongside this slice.** Restoring the
+> Case 14 real-write happy path to cover both Claude and OpenCode
+> surfaced two latent bugs in the OpenCode writer + E1 preservation
+> harness that the F1 dry-run contract masked:
+>
+> 1. `packages/agents/src/opencode-write.ts::findServerPropertyRange`
+>    returned a range that covered the entire property (key + value +
+>    trailing comma), and the caller spliced `JSON.stringify(value)`
+>    over it — so the property key was dropped on every existing-entry
+>    update, leaving the document malformed. Narrowed the range to the
+>    value node only (matches the E3 sibling `jsonc-map-write.ts`).
+>    Also added a `local` branch to `toOpenCodeMcpServer` so a stdio
+>    canonical pre-converted to `{type: 'local', command: [...]}` is
+>    not re-classified as `remote` when `planEdits` re-invokes the
+>    helper for extension preservation.
+> 2. `packages/agents/src/writer-preservation/checks.ts::compareContainerKeyOrder`
+>    computed `expected = common.map((_, i) => i)` (ascending indices),
+>    which only fires when the relative order of common keys changes —
+>    not when the relative order is preserved but the position within a
+>    larger container shifts. Now `expected = common.map((k) => origKeys.indexOf(k))`,
+>    matching the original parsed order.
 
 ### F3. Refuse settings conflicts during apply
 

--- a/packages/agents/src/opencode-write.ts
+++ b/packages/agents/src/opencode-write.ts
@@ -41,7 +41,7 @@ const CANONICAL_FIELD_NAMES = new Set<string>([
 ]);
 
 export function toOpenCodeMcpServer(
-  server: OvertureMcpServer,
+  server: OvertureMcpServer | OpenCodeMcpServer,
   existing?: OpenCodeWritableMcpServer,
 ): OpenCodeWritableMcpServer {
   const extensions = collectExtensions(existing);
@@ -52,6 +52,23 @@ export function toOpenCodeMcpServer(
       type: 'local',
       command: [server.command, ...(server.args ?? [])],
       ...(server.env === undefined ? {} : { environment: server.env }),
+    };
+  }
+
+  // OpenCode native `local` entry: the caller pre-converted the canonical
+  // server via `toOpenCodeMcpServer` before handing it to `planEdits`, and
+  // the planner re-invokes this helper for extension preservation. Without
+  // this branch the function fell through to the `remote` branch below and
+  // emitted `{ type: 'remote' }` for any stdio canonical updating an
+  // existing local entry (see F2 / Case 14 regression).
+  if (server.type === 'local') {
+    return {
+      ...extensions,
+      type: 'local',
+      command: [...server.command],
+      ...(server.environment === undefined
+        ? {}
+        : { environment: server.environment }),
     };
   }
 
@@ -201,17 +218,21 @@ function findServerPropertyRange(
     if (property.type !== 'property' || property.children === undefined)
       continue;
     const keyNode = property.children[0];
+    const valueNode = property.children[1];
     if (keyNode === undefined || keyNode.value !== serverName) continue;
-    let end = property.offset + property.length;
-    while (end < text.length && /[ \t]/.test(text[end]!)) {
-      end++;
-    }
-    if (text[end] === ',') end++;
-    let start = property.offset;
-    while (start > 0 && /[ \t]/.test(text[start - 1]!)) {
-      start--;
-    }
-    return { start, end };
+    if (valueNode === undefined) continue;
+    // Return the value-node range ONLY so the caller can splice in
+    // JSON.stringify(value, null, 2) without dropping the property key
+    // (see F2 / Case 14 regression: a stdio canonical updating an
+    // existing local entry used to splice over the entire property and
+    // produce `{\n  "type": "remote"\n}` in place of the value, leaving
+    // the JSON malformed). The key, surrounding whitespace, and any
+    // trailing comma stay in place — same approach as the sibling
+    // E3 helper `jsonc-map-write.ts::editJsoncMap`.
+    return {
+      start: valueNode.offset,
+      end: valueNode.offset + valueNode.length,
+    };
   }
   return null;
 }

--- a/packages/agents/src/opencode.write.spec.ts
+++ b/packages/agents/src/opencode.write.spec.ts
@@ -377,6 +377,71 @@ describe('E1 — opencode.mcp.write preserves OpenCode JSONC', () => {
     ).toBe(true);
   });
 
+  // Regression for the F2 / Case 14 key-drop bug. The historical
+  // `findServerPropertyRange` returned a range that covered the WHOLE
+  // property (key + value + trailing comma); the replacement
+  // (`renderServer(next)` = JSON.stringify(value, null, 2)) was value-only,
+  // so the property key vanished on update. A stdio canonical updating
+  // an existing local entry produced `{\n  "type": "remote"\n}` in
+  // place of the value, leaving the JSON malformed. The fix narrows
+  // the range to the value node only; this test pins the new contract
+  // with a direct fs-level assertion (independent of the harness) so
+  // a regression cannot hide behind harness lenience.
+  it('opencode writer: existing local entry updated by stdio canonical preserves the property key', async () => {
+    const ctx = makeCtx();
+    const fixturePath = join(ctx.configDir, 'opencode', 'opencode.json');
+    await mkdir(join(ctx.configDir, 'opencode'), { recursive: true });
+    await writeFile(
+      fixturePath,
+      JSON.stringify(
+        {
+          mcp: {
+            filesystem: { type: 'local', command: ['old'] },
+            context7: { type: 'local', command: ['ctx'] },
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    await opencode.mcp.write(ctx, {
+      servers: [
+        {
+          name: 'filesystem',
+          server: {
+            type: 'stdio',
+            command: 'node',
+            args: ['/tmp/foo'],
+          },
+        },
+      ],
+    });
+
+    const written = await readFile(fixturePath, 'utf8');
+    // The property key must still be present (regression of the F2
+    // key-drop: writer was splicing over the entire property).
+    expect(written).toContain('"filesystem"');
+    expect(written).toContain('"context7"');
+    // Re-parse the written file to assert it's still valid JSON
+    // (the historical bug left the document malformed).
+    expect(() => JSON.parse(written)).not.toThrow();
+    const parsed = JSON.parse(written) as {
+      mcp: Record<string, unknown>;
+    };
+    expect(parsed.mcp).toHaveProperty('filesystem');
+    expect(parsed.mcp).toHaveProperty('context7');
+    // The filesystem entry should now reflect the canonical stdio →
+    // local conversion: command vector = ['node', '/tmp/foo'].
+    const fs = parsed.mcp.filesystem as {
+      type: string;
+      command: string[];
+    };
+    expect(fs.type).toBe('local');
+    expect(fs.command).toEqual(['node', '/tmp/foo']);
+  });
+
   it('preserves OpenCode JSONC: adding a new remote server target path fails rawBytes (insert case)', async () => {
     const ctx = makeCtx();
     const newRemote: OvertureMcpServer = {

--- a/packages/agents/src/writer-preservation/checks.ts
+++ b/packages/agents/src/writer-preservation/checks.ts
@@ -680,8 +680,12 @@ function compareContainerKeyOrder(
   const origKeys = Object.keys(orig);
   const writtenKeys = Object.keys(written);
   const common = origKeys.filter((k) => k in written);
+  // FIX: derive expected position indices from the ORIGINAL key order,
+  // not from ascending [0, 1, 2, ...]. Without this fix the check is a
+  // silent pass for any key reorder (project memory 93 surfaced the bug;
+  // F2 / Case 14 restoration revealed it).
   const writtenOrder = common.map((k) => writtenKeys.indexOf(k));
-  const expected = common.map((_, i) => i);
+  const expected = common.map((k) => origKeys.indexOf(k));
   if (JSON.stringify(writtenOrder) !== JSON.stringify(expected)) {
     diffs.push(
       `${path}: expected [${expected}], got [${writtenOrder}] (keys: ${JSON.stringify(common)})`,


### PR DESCRIPTION
## Summary

Adds the F2 slice: `overture apply` with real writes + adjacent timestamped backups. `apply --dry-run` preview is preserved.

## Commits

- `ee5d3e18` — `feat(cli): add overture apply with backups`
- `cc31dec5` — `docs(cli): record F2 apply with backups completion`
- `baf809ce` — `fix(cli): restore OpenCode to F2 Case 14 happy path`
- `4ff90a5e` — `fix(agents): repair opencode writer key-drop and E1 keyOrder check`

## F2 surface

- `overture apply` (no flag) — real-write, two-pass per agent: Pass 1 `dryRun: true` discovers target paths + change decision; backup via `fs.copyFile` to `<target>.bak.<YYYYMMDD-HHmmssSSS>` with `-<randomHex4>` collision suffix (3 retries max); Pass 2 `dryRun: false` only after backup.
- `overture apply --dry-run` — preview only (F1 contract preserved, byte-identical guarantees).
- `overture apply --json` requires `--dry-run` (F1 invalid-combination guard preserved).
- `overture apply --help` — exit 0, prints `APPLY_USAGE`.
- Honors `settings.backupBeforeWrite` (default `true`). When `false`, skips backups but still writes.
- New `ApplyResult` envelope + `ApplyStatus` union (`updated | no-change | backup-failed | not-targetable | parse-error | unsupported-shape | unsupported-format`).
- `backup-failed` is CLI-local — `WriteReason` union stays stable.

## Latent E2-era bugs fixed (retroactive)

F2's byte-level assertions surfaced two pre-existing bugs that the E1 preservation harness had silently missed:

1. **`packages/agents/src/opencode-write.ts:findServerPropertyRange`** returned the full-property range (key + colon + value + trailing comma), but the caller at line 345 replaced it with `JSON.stringify(value, null, 2)` (value only, no key). Every existing-entry update silently dropped the property key. Now returns the value-node range only.
2. **`packages/agents/src/opencode-write.ts:toOpenCodeMcpServer`** had no `local` branch. The orchestrator pre-converts stdio → local at line 508 before passing to `planEdits`; `planEdits` re-invokes the helper at line 349 with the pre-converted shape, which fell through to the `remote` branch and emitted `{ type: 'remote' }` for any stdio canonical. Added a `local` branch.
3. **`packages/agents/src/writer-preservation/checks.ts:compareContainerKeyOrder`** had `expected = common.map((_, i) => i)` which always matched `writtenOrder` (silent pass). Now derives from `origKeys.indexOf(k)`. The `keyOrder` harness check has been broken since E2/E3/E4 landed; both bugs above were masked by it.

Added a direct fs-based regression test in `opencode.write.spec.ts` that doesn't rely on the harness.

## Verification

```
yarn nx test @overture/agents --skip-nx-cache  →  pass (442 tests)
yarn nx test @jander99/overture --skip-nx-cache  →  pass (252 tests)
yarn nx build @jander99/overture --skip-nx-cache  →  pass
yarn nx lint @jander99/overture --skip-nx-cache  →  pass
yarn prettier --check .  →  clean
node apps/cli/scripts/verify-package.mjs  →  PASS (incl. new apply real-write smoke)
```

## Out of scope

- Writers other than `opencode-write.ts` untouched (E3 claude-code/github-copilot-cli and E4 openai-codex verified clean).
- `WriteReason` union stable (memory).
- F3 (conflict refusal during apply) — future.
- G1/G2/G3 (apply state file, restore logs, restore helper) — future.

## Plan

Draft: `.omo/drafts/f2-apply-with-backups.md`.