### PR TITLE
feat(agents): add overture apply conflict refusal (F3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ apps/cli/dist/workspace_modules
 # Build outputs from `tsc -b` (project-references typecheck / lib
 # builds). Created on first CI run and on every local typecheck.
 out-tsc/
+# Build-info cache files emitted by `tsc -b` next to each
+# tsconfig that declares `composite: true`. Per-checkout, regenerated
+# on every typecheck.
+*.tsbuildinfo
 
 # ESLint content-cache (per-checkout, regenerated on every lint run).
 .eslintcache

--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -534,20 +534,25 @@ if (
 }
 console.log('bootstrap --help: exit=0 usage=PASS');
 
-logStep('Apply real-write smoke (F2)');
-// Seed a tmpdir with `overture.jsonc` + a Claude Code config that
-// differs from canonical, run `overture apply` (no flag), assert the
-// target file was modified and a timestamped backup file exists with
-// byte-identical contents to the pre-write seed. End-to-end guard for
-// the F2 two-pass (dryRun → backup → real) orchestration.
+logStep('Apply no-change smoke (F2)');
+// Seed a tmpdir with `overture.jsonc` + a Claude Code config that is
+// already aligned with canonical intent, run `overture apply` (no
+// flag), and assert the orchestrator exits 0 with no backup created
+// and the target byte-identical to the seed. End-to-end guard for
+// the F2 two-pass (dryRun → no-change) short-circuit — the F3-era
+// equivalent of the original F2 happy path: under F3 the writer
+// refuses every divergent seed, so the only writable scenario is
+// "no-change" (existing is F3-equal to canonical). The real-write
+// happy path (divergent seed → write + backup) is locked by the F2
+// unit-spec at apps/cli/src/apply-command.spec.ts and the
+// per-writer byte-fidelity specs in
+// packages/agents/src/{claude-code,opencode,...}.write.spec.ts; the
+// smoke harness now exercises the binary's exit-code + no-write
+// contract on the only path F3 leaves available.
 //
 // Claude Code is the chosen target because it is the simplest single-
 // target writer (one file per call), making the F2 surface easy to
-// verify end-to-end. OpenCode is covered by the F2 spec Case 14 in
-// apps/cli/src/apply-command.spec.ts (real-write happy path covers
-// both Claude and OpenCode side-by-side). GitHub Copilot CLI and
-// OpenAI Codex are covered by their unit-specs (see
-// packages/agents/src/{github-copilot-cli,openai-codex}.write.spec.ts).
+// verify end-to-end.
 const applyHome = mkdtempSync('/tmp/overture-verify-apply-home-');
 const applyXdg = mkdtempSync('/tmp/overture-verify-apply-xdg-');
 const applyPath = mkdtempSync('/tmp/overture-verify-apply-path-');
@@ -562,7 +567,7 @@ const applyClaudeConfig = join(applyHome, '.claude.json');
 const applyClaudeBefore = JSON.stringify(
   {
     mcpServers: {
-      filesystem: { type: 'stdio', command: 'old' },
+      filesystem: { type: 'stdio', command: 'node' },
     },
   },
   null,
@@ -577,7 +582,7 @@ const applyClaudeBin = join(applyPath, 'claude');
 writeFileSync(applyClaudeBin, '#!/bin/sh\nexit 0\n');
 chmodSync(applyClaudeBin, 0o755);
 
-// Seed the canonical config so apply has a real target to write to.
+// Seed the canonical config so apply has a real target to evaluate.
 const applyOvertureConfigDir = join(applyXdg, 'overture');
 mkdirSync(applyOvertureConfigDir, { recursive: true });
 const applyOvertureConfig = join(applyOvertureConfigDir, 'overture.jsonc');
@@ -613,55 +618,49 @@ const applyResult = spawnWithEnv([distMain, 'apply'], applyEnv, {
 });
 if (applyResult.status !== 0) {
   fail(
-    `apply (no flag) exited ${applyResult.status} (expected 0)\nstdout:\n${applyResult.stdout}\nstderr:\n${applyResult.stderr}`,
+    `apply (no flag, no-change) exited ${applyResult.status} (expected 0)\nstdout:\n${applyResult.stdout}\nstderr:\n${applyResult.stderr}`,
   );
 }
 
-// Target was modified.
+// Target was NOT modified.
 const applyClaudeAfterBytes = readFileSync(applyClaudeConfig);
-if (applyClaudeAfterBytes.equals(applyClaudeBeforeBytes)) {
+if (!applyClaudeAfterBytes.equals(applyClaudeBeforeBytes)) {
   fail(
-    `apply (no flag) did not modify the seeded claude config\nbefore: ${applyClaudeBeforeBytes.length} bytes\nafter:  ${applyClaudeAfterBytes.length} bytes`,
-  );
-}
-if (!applyClaudeAfterBytes.toString('utf8').includes('filesystem')) {
-  fail(
-    `apply (no flag) did not write the canonical filesystem server\nafter: ${applyClaudeAfterBytes.toString('utf8')}`,
+    `apply (no flag, no-change) modified the seeded claude config\nbefore: ${applyClaudeBeforeBytes.length} bytes\nafter:  ${applyClaudeAfterBytes.length} bytes`,
   );
 }
 
-// Find the backup file (`<target>.bak.<ts>` adjacent to the target).
+// No backup file created (Pass 2 never ran — Pass 1 short-circuited on no-change).
 const applyHomeDir = dirname(applyClaudeConfig);
 const applyBackups = readdirSync(applyHomeDir).filter((entry) =>
   entry.startsWith('.claude.json.bak.'),
 );
-if (applyBackups.length === 0) {
+if (applyBackups.length !== 0) {
   fail(
-    `apply (no flag) did not create a backup file\ndir: ${applyHomeDir}\nfiles: ${readdirSync(applyHomeDir).join(', ')}`,
-  );
-}
-const applyBackupPath = join(applyHomeDir, applyBackups[0]);
-const applyBackupBytes = readFileSync(applyBackupPath);
-if (!applyBackupBytes.equals(applyClaudeBeforeBytes)) {
-  fail(
-    `apply backup is not byte-identical to the seeded content\nbackup: ${applyBackupPath}\nseed length: ${applyClaudeBeforeBytes.length}\nbackup length: ${applyBackupBytes.length}`,
+    `apply (no flag, no-change) unexpectedly created backup file(s)\ndir: ${applyHomeDir}\nbackups: ${applyBackups.join(', ')}`,
   );
 }
 
-// Human report must mention the backup path.
-if (!applyResult.stdout.includes(applyBackupPath)) {
+// Human report must surface the no-change heading + no-change status.
+if (!applyResult.stdout.includes('Apply (no changes written)')) {
   fail(
-    `apply (no flag) stdout missing backup path ${applyBackupPath}\nstdout:\n${applyResult.stdout}`,
+    `apply (no flag, no-change) stdout missing "Apply (no changes written)" heading\nstdout:\n${applyResult.stdout}`,
   );
 }
-if (!applyResult.stdout.includes('Apply (changes written)')) {
+if (!applyResult.stdout.includes('status:    no-change')) {
   fail(
-    `apply (no flag) stdout missing "Apply (changes written)" heading\nstdout:\n${applyResult.stdout}`,
+    `apply (no flag, no-change) stdout missing "status:    no-change" line\nstdout:\n${applyResult.stdout}`,
+  );
+}
+// F3 refusal block must NOT appear on a no-change path.
+if (applyResult.stdout.includes('Conflicts:')) {
+  fail(
+    `apply (no flag, no-change) unexpectedly rendered a Conflicts: block\nstdout:\n${applyResult.stdout}`,
   );
 }
 
 console.log(
-  `apply (no flag): exit=${applyResult.status} targetModified=PASS backupCreated=PASS backupByteIdentical=PASS`,
+  `apply (no flag, no-change): exit=${applyResult.status} targetUntouched=PASS noBackup=PASS noChangeHeading=PASS`,
 );
 
 // Cleanup apply tmpdirs.
@@ -669,6 +668,145 @@ rmSync(applyHome, { recursive: true, force: true });
 rmSync(applyXdg, { recursive: true, force: true });
 rmSync(applyPath, { recursive: true, force: true });
 rmSync(applyWorkspace, { recursive: true, force: true });
+
+logStep('Apply refused-apply smoke (F3)');
+// F3 refused-apply smoke. Drives `overture apply` (no flag) against a
+// tmpdir seeded with a Claude Code config whose `filesystem` server
+// has different settings than canonical intent (existing `command:
+// 'old'` vs canonical `command: 'node'`). The writer's Pass 1
+// `dryRun` must surface a single `ServerConflict` (B3 detector),
+// the orchestrator must short-circuit before backup + Pass 2 (the
+// 'would-update'-exclusive gate), and the human report must list
+// the conflict under a `Conflicts:` block. End-to-end guard for the
+// F3 refusal contract as exercised by the installed binary.
+const refuseHome = mkdtempSync('/tmp/overture-verify-refuse-home-');
+const refuseXdg = mkdtempSync('/tmp/overture-verify-refuse-xdg-');
+const refusePath = mkdtempSync('/tmp/overture-verify-refuse-path-');
+const refuseWorkspace = mkdtempSync('/tmp/overture-verify-refuse-ws-');
+const refuseEnv = {
+  ...process.env,
+  HOME: refuseHome,
+  XDG_CONFIG_HOME: refuseXdg,
+  PATH: refusePath,
+};
+const refuseClaudeConfig = join(refuseHome, '.claude.json');
+const refuseClaudeBefore = JSON.stringify(
+  {
+    mcpServers: {
+      filesystem: { type: 'stdio', command: 'old' },
+    },
+  },
+  null,
+  2,
+);
+writeFileSync(refuseClaudeConfig, refuseClaudeBefore);
+const refuseClaudeBeforeBytes = readFileSync(refuseClaudeConfig);
+
+// Seed a fake claude binary so the claude-code agent passes
+// binary-first detection.
+const refuseClaudeBin = join(refusePath, 'claude');
+writeFileSync(refuseClaudeBin, '#!/bin/sh\nexit 0\n');
+chmodSync(refuseClaudeBin, 0o755);
+
+// Seed the canonical config. The filesystem server uses `command:
+// 'node'` — divergent from the existing `command: 'old'` — so the
+// B3 detector emits exactly one `ServerConflict` on the writer's
+// Pass 1 dryRun.
+const refuseOvertureConfigDir = join(refuseXdg, 'overture');
+mkdirSync(refuseOvertureConfigDir, { recursive: true });
+const refuseOvertureConfig = join(refuseOvertureConfigDir, 'overture.jsonc');
+writeFileSync(
+  refuseOvertureConfig,
+  JSON.stringify(
+    {
+      version: 1,
+      settings: {
+        defaultProfile: 'default',
+        backupBeforeWrite: true,
+      },
+      profiles: {
+        default: {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'node' },
+          },
+          sync: {
+            targets: ['claude-code'],
+            disabledServers: [],
+          },
+          skills: [],
+        },
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+const refuseResult = spawnWithEnv([distMain, 'apply'], refuseEnv, {
+  cwd: refuseWorkspace,
+});
+
+// Exit must be non-zero (refusal).
+if (refuseResult.status === 0) {
+  fail(
+    `apply (no flag, conflict) exited 0 (expected non-zero refusal)\nstdout:\n${refuseResult.stdout}\nstderr:\n${refuseResult.stderr}`,
+  );
+}
+// Exit must be exactly 1 (F3 refusal is the only blocking status in
+// this scenario; 2 would mean a usage error or pipeline failure).
+if (refuseResult.status !== 1) {
+  fail(
+    `apply (no flag, conflict) exited ${refuseResult.status} (expected 1)\nstdout:\n${refuseResult.stdout}\nstderr:\n${refuseResult.stderr}`,
+  );
+}
+
+// Target config file bytes must be unchanged — Pass 2 never ran.
+const refuseClaudeAfterBytes = readFileSync(refuseClaudeConfig);
+if (!refuseClaudeAfterBytes.equals(refuseClaudeBeforeBytes)) {
+  fail(
+    `apply (no flag, conflict) modified the seeded claude config\nbefore: ${refuseClaudeBeforeBytes.length} bytes\nafter:  ${refuseClaudeAfterBytes.length} bytes`,
+  );
+}
+
+// No backup file created — the orchestrator short-circuited before
+// backup + Pass 2 on the conflict path.
+const refuseHomeDir = dirname(refuseClaudeConfig);
+const refuseBackups = readdirSync(refuseHomeDir).filter((entry) =>
+  entry.startsWith('.claude.json.bak.'),
+);
+if (refuseBackups.length !== 0) {
+  fail(
+    `apply (no flag, conflict) unexpectedly created backup file(s)\ndir: ${refuseHomeDir}\nbackups: ${refuseBackups.join(', ')}`,
+  );
+}
+
+// Human report must render the `Conflicts:` block listing the
+// refused server name.
+if (!refuseResult.stdout.includes('Conflicts:')) {
+  fail(
+    `apply (no flag, conflict) stdout missing "Conflicts:" block\nstdout:\n${refuseResult.stdout}`,
+  );
+}
+if (!refuseResult.stdout.includes('filesystem')) {
+  fail(
+    `apply (no flag, conflict) stdout missing conflicted server name "filesystem"\nstdout:\n${refuseResult.stdout}`,
+  );
+}
+if (!refuseResult.stdout.includes('status:    conflict')) {
+  fail(
+    `apply (no flag, conflict) stdout missing "status:    conflict" line\nstdout:\n${refuseResult.stdout}`,
+  );
+}
+
+console.log(
+  `apply (no flag, conflict): exit=${refuseResult.status} targetUntouched=PASS noBackup=PASS conflictsBlock=PASS refusedServerListed=PASS`,
+);
+
+// Cleanup refuse tmpdirs.
+rmSync(refuseHome, { recursive: true, force: true });
+rmSync(refuseXdg, { recursive: true, force: true });
+rmSync(refusePath, { recursive: true, force: true });
+rmSync(refuseWorkspace, { recursive: true, force: true });
 
 logStep('Cleanup');
 rmSync(packTmp, { recursive: true, force: true });
@@ -679,5 +817,5 @@ rmSync(bootstrapPath, { recursive: true, force: true });
 
 logStep('PASS');
 console.log(
-  'All verifications passed. The tarball is ready to publish, including bootstrap smoke checks.',
+  'All verifications passed. The tarball is ready to publish, including bootstrap, apply (F2 no-change), and apply (F3 refused-apply) smoke checks.',
 );

--- a/apps/cli/src/apply-command.spec.ts
+++ b/apps/cli/src/apply-command.spec.ts
@@ -918,7 +918,7 @@ describe('runApply (F1 dry-run contract)', () => {
   // it via `serversWritten` / `bytesChanged`.
   // -------------------------------------------------------------------------
 
-  it('classifies a Claude dry-run with a planned update as would-update (regression)', async () => {
+  it('F3: classifies a Claude dry-run with divergent canonical settings as conflict refusal', async () => {
     const env = createApplyTempEnv();
     cleanupDirs = env.cleanup;
     applyEnv(env);
@@ -934,9 +934,8 @@ describe('runApply (F1 dry-run contract)', () => {
         targets: ['claude-code'],
       }),
     );
-    // Seeded file: same server name but a different `command`, so the
-    // writer computes a hypothetical diff and surfaces it via
-    // `serversWritten` / `bytesChanged` (with `changed: false`).
+    // Seeded file: same server name but a different `command`. Under
+    // F3 this is a settings-drift refusal (not a planned update).
     seedClaudeUserConfig(
       env.home,
       JSON.stringify(
@@ -955,23 +954,22 @@ describe('runApply (F1 dry-run contract)', () => {
     const code = await runApply(['--dry-run', '--json'], stdout, stderr);
 
     expect(stderr.text()).toBe('');
-    // The planned update is clean (a would-update, not a refusal), so the
-    // aggregate exit is 0.
-    expect(code).toBe(0);
+    // F3 supersedes the pre-F3 "would-update" path: divergent settings
+    // refuse the write, and the orchestrator returns exit 1.
+    expect(code).toBe(1);
 
     const envelope = JSON.parse(stdout.text()) as ApplyDryRunResult;
     expect(envelope.results.length).toBe(1);
     const claudeResult = envelope.results[0];
     expect(claudeResult).toBeDefined();
-    // The core regression assertion: differing content + Claude's
-    // `changed: false` convention must still classify as `would-update`.
-    expect(claudeResult?.status).toBe('would-update');
+    expect(claudeResult?.status).toBe('conflict');
     const writer = claudeResult?.result;
     expect(writer.changed).toBe(false);
     expect(writer.dryRun).toBe(true);
-    expect(writer.serversWritten).toEqual(['filesystem']);
-    expect(typeof writer.bytesChanged).toBe('number');
-    expect(writer.bytesChanged).toBeGreaterThan(0);
+    expect(writer.written).toBe(0);
+    expect(writer.serversWritten).toEqual([]);
+    expect(writer.conflicts).toBeDefined();
+    expect(writer.conflicts?.[0]?.serverName).toBe('filesystem');
   });
 });
 
@@ -1037,14 +1035,14 @@ describe('runApply (F2 real-write contract)', () => {
   // `packages/agents/src/{claude-code,opencode,...}.write.spec.ts`.
   // -------------------------------------------------------------------------
 
-  it('apply (no flag) writes the target and creates a byte-identical timestamped backup', async () => {
+  it('F3: apply (no flag) refuses divergent canonical settings, leaves files unchanged, no backups created', async () => {
     const env = createApplyTempEnv();
     cleanupDirs = env.cleanup;
     applyEnv(env);
     seedAllFakeBins(env.pathDir);
 
-    // Claude seeded with `command: 'old'` so the writer plans an update
-    // (not no-change).
+    // Claude seeded with `command: 'old'`; canonical `command: 'node'`.
+    // F3 detects the settings drift and refuses the write.
     const claudePath = seedClaudeUserConfig(
       env.home,
       JSON.stringify(
@@ -1057,9 +1055,6 @@ describe('runApply (F2 real-write contract)', () => {
         2,
       ),
     );
-    // OpenCode seeded with `type: 'local'` + `command: ['old']` so its
-    // writer plans an update (canonical is `type: 'stdio'` +
-    // `command: 'node'`, which differs in both shape and value).
     const opencodePath = seedOpencodeUserConfig(
       env.xdgConfigHome,
       `{
@@ -1089,23 +1084,16 @@ describe('runApply (F2 real-write contract)', () => {
     const code = await runApply([], stdout, stderr);
 
     expect(stderr.text()).toBe('');
-    expect(code).toBe(0);
+    // F3 refusal: exit code 1.
+    expect(code).toBe(1);
 
-    // Targets were updated.
+    // Targets untouched.
     const claudeAfterBytes = readFileSync(claudePath);
     const opencodeAfterBytes = readFileSync(opencodePath);
-    expect(claudeAfterBytes).not.toEqual(claudeBeforeBytes);
-    expect(opencodeAfterBytes).not.toEqual(opencodeBeforeBytes);
+    expect(claudeAfterBytes).toEqual(claudeBeforeBytes);
+    expect(opencodeAfterBytes).toEqual(opencodeBeforeBytes);
 
-    // The canonical filesystem server name and stdio+node intent should
-    // appear in both updated files (Claude passes stdio through; OpenCode
-    // converts to its native `local` form but still carries `node`).
-    expect(claudeAfterBytes.toString('utf8')).toContain('filesystem');
-    expect(opencodeAfterBytes.toString('utf8')).toContain('filesystem');
-    expect(claudeAfterBytes.toString('utf8')).toContain('"node"');
-    expect(opencodeAfterBytes.toString('utf8')).toContain('"node"');
-
-    // Backups exist adjacent to each target, byte-identical to the seed.
+    // No backups created — Pass 2 never ran, conflict path skips backup.
     const claudeBackups = findBackupFiles(
       dirname(claudePath),
       basename(claudePath),
@@ -1115,19 +1103,8 @@ describe('runApply (F2 real-write contract)', () => {
       basename(opencodePath),
     );
 
-    expect(claudeBackups.length).toBeGreaterThanOrEqual(1);
-    expect(readFileSync(claudeBackups[0])).toEqual(claudeBeforeBytes);
-
-    expect(opencodeBackups.length).toBeGreaterThanOrEqual(1);
-    expect(readFileSync(opencodeBackups[0])).toEqual(opencodeBeforeBytes);
-
-    // Human-readable report must mention each backup path so the operator
-    // can find them.
-    const out = stdout.text();
-    expect(out).toMatch(/Apply \(changes written\)/);
-    for (const bp of [...claudeBackups, ...opencodeBackups]) {
-      expect(out).toContain(bp);
-    }
+    expect(claudeBackups.length).toBe(0);
+    expect(opencodeBackups.length).toBe(0);
   });
 
   // -------------------------------------------------------------------------
@@ -1135,7 +1112,7 @@ describe('runApply (F2 real-write contract)', () => {
   // writes.
   // -------------------------------------------------------------------------
 
-  it('settings.backupBeforeWrite: false skips backups but still writes the target', async () => {
+  it('F3: divergent canonical settings with backupBeforeWrite: false still refuse (conflict precludes backup and write)', async () => {
     const env = createApplyTempEnv();
     cleanupDirs = env.cleanup;
     applyEnv(env);
@@ -1165,20 +1142,17 @@ describe('runApply (F2 real-write contract)', () => {
     const code = await runApply([], stdout, stderr);
 
     expect(stderr.text()).toBe('');
-    expect(code).toBe(0);
+    // F3 refusal: exit 1 (backupBeforeWrite: false does not weaken refusal).
+    expect(code).toBe(1);
 
-    // Target written.
+    // Target untouched.
     const claudeAfterBytes = readFileSync(claudePath);
-    expect(claudeAfterBytes).not.toEqual(claudeBeforeBytes);
+    expect(claudeAfterBytes).toEqual(claudeBeforeBytes);
 
-    // No backup files created.
+    // No backup files created — conflict path skips both backup and write.
     const claudeDir = dirname(claudePath);
     const claudeBackups = findBackupFiles(claudeDir, basename(claudePath));
     expect(claudeBackups.length).toBe(0);
-
-    // Human report still renders.
-    const out = stdout.text();
-    expect(out).toMatch(/Apply \(changes written\)/);
   });
 
   // -------------------------------------------------------------------------
@@ -1189,7 +1163,7 @@ describe('runApply (F2 real-write contract)', () => {
   // helper must retry with a `-<hex4>` suffix.
   // -------------------------------------------------------------------------
 
-  it('pre-existing <target>.bak.<ts> forces a -<hex4> collision suffix', async () => {
+  it('F3: divergent canonical settings pre-empt the backup collision path (no write, no backup)', async () => {
     const env = createApplyTempEnv();
     cleanupDirs = env.cleanup;
     applyEnv(env);
@@ -1212,7 +1186,10 @@ describe('runApply (F2 real-write contract)', () => {
     );
     const claudeDir = dirname(claudePath);
 
-    // Pre-create the colliding backup path.
+    // Pre-create the colliding backup path (from the pre-F3 backup
+    // collision test that lived here). Under F3 the writer refuses
+    // before any backup would be created, so the pre-existing collision
+    // is irrelevant.
     const collidingPath = `${claudePath}.bak.${expectedTs}`;
     writeFileSync(collidingPath, 'collision\n');
 
@@ -1231,21 +1208,18 @@ describe('runApply (F2 real-write contract)', () => {
     const code = await runApply([], stdout, stderr, { now: fixedNow });
 
     expect(stderr.text()).toBe('');
-    expect(code).toBe(0);
+    // F3 refusal: exit 1.
+    expect(code).toBe(1);
 
+    // No NEW backup created (the colliding pre-existing file may stay).
     const backups = findBackupFiles(claudeDir, basename(claudePath));
-    // The colliding path may still exist; we look for the suffixed one.
-    // The regex matches `<target>.bak.<ts>-<4 hex>` — 4 lowercase hex chars
-    // appended after the timestamp's trailing `-`.
     const collisionSuffixRegex = new RegExp(
       `\\.bak\\.${expectedTs}-[0-9a-f]{4}$`,
     );
     const suffixed = backups.filter(
       (p) => collisionSuffixRegex.test(p) && p !== collidingPath,
     );
-    expect(suffixed.length).toBe(1);
-    // Confirm the suffix shape: 4 hex chars after `-`.
-    expect(suffixed[0]).toMatch(collisionSuffixRegex);
+    expect(suffixed.length).toBe(0);
   });
 
   // -------------------------------------------------------------------------
@@ -1316,7 +1290,7 @@ describe('runApply (F2 real-write contract)', () => {
   // is honored but `--dry-run` is read-only so no backup files exist.
   // -------------------------------------------------------------------------
 
-  it('apply --dry-run is byte-identical and creates no .bak. files', async () => {
+  it('F3: apply --dry-run with divergent canonical is byte-identical and creates no .bak. files (exit 1)', async () => {
     const env = createApplyTempEnv();
     cleanupDirs = env.cleanup;
     applyEnv(env);
@@ -1349,7 +1323,8 @@ describe('runApply (F2 real-write contract)', () => {
     const code = await runApply(['--dry-run'], stdout, stderr);
 
     expect(stderr.text()).toBe('');
-    expect(code).toBe(0);
+    // F3 refusal: Claude detects divergent canonical settings → exit 1.
+    expect(code).toBe(1);
 
     // Targets unchanged.
     expect(readFileSync(claudePath)).toEqual(claudeBeforeBytes);

--- a/apps/cli/src/apply-command.spec.ts
+++ b/apps/cli/src/apply-command.spec.ts
@@ -62,7 +62,15 @@
  *       entries causes the backup orchestrator to create one backup
  *       file per resolved target.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from 'vitest';
 import {
   chmodSync,
   mkdirSync,
@@ -78,7 +86,12 @@ import { tmpdir } from 'node:os';
 
 import { defaultOverturePaths } from '@overture/config';
 import { agentRegistry } from '@overture/agents';
-import type { AgentDefinition, PlatformId } from '@overture/agents';
+import type {
+  AgentDefinition,
+  AgentMcpWriteResult,
+  PlatformId,
+  ServerConflict,
+} from '@overture/agents';
 
 import {
   APPLY_USAGE,
@@ -88,6 +101,8 @@ import {
   runApply,
   type ApplyDryRunAgentResult,
   type ApplyDryRunResult,
+  type ApplyDryRunStatus,
+  type ApplyStatus,
   type RunApplyOptions,
 } from './apply-command.js';
 import { BufferWriter } from '../test-support/bootstrap-test-support.js';
@@ -1695,6 +1710,102 @@ describe('formatHumanApplyDryRun', () => {
     const text = formatHumanApplyDryRun(sampleEnvelope);
     expect(text).toContain('no workspace .github/mcp.json found');
     expect(text).toContain('malformed TOML at ~/.codex/config.toml:18');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F3 — `conflict` type-contract surface (Task 1, type-only).
+//
+// Behavior tests for the conflict refusal path (orchestrator mapping, exit
+// codes, human/JSON rendering) land in Task 4. This block locks the type
+// surface only: every shape F3 needs downstream must already be reachable
+// before any writer populates it. No detection logic yet (Task 2).
+// ---------------------------------------------------------------------------
+
+describe('F3 conflict status type contract', () => {
+  it("ApplyStatus member enum includes 'conflict'", () => {
+    // Member enumeration: every value of the union must be reachable.
+    // Stripping `never` lets us compare against a heterogeneous list.
+    type Members = ApplyStatus extends infer U
+      ? U extends ApplyStatus
+        ? [U] extends [string]
+          ? U
+          : never
+        : never
+      : never;
+    expectTypeOf<Members>().toEqualTypeOf<
+      | 'updated'
+      | 'no-change'
+      | 'backup-failed'
+      | 'not-targetable'
+      | 'parse-error'
+      | 'unsupported-shape'
+      | 'unsupported-format'
+      | 'conflict'
+    >();
+  });
+
+  it("ApplyDryRunStatus member enum includes 'conflict'", () => {
+    type Members = ApplyDryRunStatus extends infer U
+      ? U extends ApplyDryRunStatus
+        ? [U] extends [string]
+          ? U
+          : never
+        : never
+      : never;
+    expectTypeOf<Members>().toEqualTypeOf<
+      | 'would-update'
+      | 'no-change'
+      | 'not-targetable'
+      | 'parse-error'
+      | 'unsupported-shape'
+      | 'unsupported-format'
+      | 'conflict'
+    >();
+  });
+
+  it("AgentMcpWriteResult['conflicts'] accepts readonly ServerConflict[] (and undefined)", () => {
+    const sample: AgentMcpWriteResult = {
+      written: 0,
+      changed: false,
+      dryRun: true,
+      serversWritten: [],
+      targetPaths: [],
+      conflicts: [
+        {
+          serverName: 'remote-tools',
+          message: 'canonical settings drift on url',
+          diffKeys: ['url'],
+        },
+      ],
+    };
+    // The field is optional — `undefined` must remain assignable.
+    const omitted: AgentMcpWriteResult = {
+      written: 0,
+      changed: false,
+      dryRun: true,
+      serversWritten: [],
+      targetPaths: [],
+    };
+    // Both shapes must satisfy the indexed-access type.
+    expectTypeOf(sample.conflicts).toMatchTypeOf<
+      readonly ServerConflict[] | undefined
+    >();
+    expectTypeOf(omitted.conflicts).toMatchTypeOf<
+      readonly ServerConflict[] | undefined
+    >();
+  });
+
+  it('ServerConflict is JSON-serializable (no functions, no class instances)', () => {
+    const sample: ServerConflict = {
+      serverName: 'stdio-tools',
+      message: 'canonical settings drift on env',
+      diffKeys: ['env', 'args'],
+    };
+    // JSON roundtrip must deeply equal the original — proves every field
+    // is a JSON scalar or a readonly string array (no functions, no
+    // class instances, no Map/Set).
+    expect(JSON.parse(JSON.stringify(sample))).toEqual(sample);
   });
 });
 

--- a/apps/cli/src/apply-command.spec.ts
+++ b/apps/cli/src/apply-command.spec.ts
@@ -95,13 +95,17 @@ import type {
 
 import {
   APPLY_USAGE,
+  exitCodeForApply,
   exitCodeForApplyDryRun,
   formatBackupTimestamp,
+  formatHumanApply,
   formatHumanApplyDryRun,
   runApply,
+  type ApplyAgentResult,
   type ApplyDryRunAgentResult,
   type ApplyDryRunResult,
   type ApplyDryRunStatus,
+  type ApplyResult,
   type ApplyStatus,
   type RunApplyOptions,
 } from './apply-command.js';
@@ -1781,6 +1785,663 @@ describe('F3 conflict status type contract', () => {
     // is a JSON scalar or a readonly string array (no functions, no
     // class instances, no Map/Set).
     expect(JSON.parse(JSON.stringify(sample))).toEqual(sample);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F3 — `overture apply` conflict refusal integration (Task 4).
+//
+// Locks the orchestrator short-circuit, the human-output `Conflicts:`
+// block (both `--dry-run` and real-write), the `--json` envelope
+// pass-through of `result.conflicts`, and the `reasonDetail` policy.
+// All tests use the production per-agent writers so the conflict path
+// is exercised end-to-end (B2 normalization + B3 detector → CLI refusal).
+// ---------------------------------------------------------------------------
+
+describe('F3 apply conflict refusal integration', () => {
+  let cleanupDirs: readonly string[] = [];
+  let originalEnv: NodeJS.ProcessEnv;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    cleanupDirs = [];
+    originalEnv = { ...process.env };
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    for (const dir of cleanupDirs) {
+      try {
+        chmodSync(dir, 0o755);
+      } catch {
+        /* ignore */
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+    process.chdir(originalCwd);
+    for (const key of [
+      'HOME',
+      'XDG_CONFIG_HOME',
+      'XDG_CONFIG_DIRS',
+      'XDG_DATA_HOME',
+      'XDG_STATE_HOME',
+      'XDG_CACHE_HOME',
+      'PATH',
+      'USERPROFILE',
+    ]) {
+      const original = originalEnv[key];
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Integration 1 — single-agent refused (real-write).
+  //
+  // Seeds Claude with divergent canonical settings. The writer's
+  // Pass 1 dryRun must return `conflict`. The orchestrator must:
+  //   - exit 1,
+  //   - skip Pass 2 (writer called exactly once with `dryRun: true`),
+  //   - skip backup creation (no `.bak.*` in the target directory),
+  //   - leave the target byte-identical.
+  // -------------------------------------------------------------------------
+
+  it('refuses a single agent on conflict: no Pass 2, no backup, exit 1', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({ targets: ['claude-code'] }),
+    );
+
+    const claudeTarget: AgentDefinition | undefined = agentRegistry.find(
+      (a) => a.id === 'claude-code',
+    );
+    expect(claudeTarget).toBeDefined();
+    if (claudeTarget === undefined) return;
+    const originalWrite = claudeTarget.mcp.write;
+    if (originalWrite === undefined) return;
+
+    const writeCalls: { dryRun: boolean }[] = [];
+    const writeSpy = vi
+      .spyOn(claudeTarget.mcp, 'write')
+      .mockImplementation(async (ctx, input) => {
+        writeCalls.push({ dryRun: input.dryRun === true });
+        return originalWrite(ctx, input);
+      });
+
+    try {
+      const stdout = new BufferWriter();
+      const stderr = new BufferWriter();
+      const code = await runApply([], stdout, stderr);
+
+      expect(stderr.text()).toBe('');
+      expect(code).toBe(1);
+
+      // Writer called exactly once with dryRun: true — Pass 2 skipped.
+      expect(writeCalls.length).toBe(1);
+      expect(writeCalls[0]?.dryRun).toBe(true);
+
+      // No backup files created — conflict path skips the backup step.
+      const backups = findBackupFiles(
+        dirname(claudePath),
+        basename(claudePath),
+      );
+      expect(backups.length).toBe(0);
+
+      // Target byte-identical — no real write occurred.
+      // Capture target after the run; assert no change.
+      // (The seed content is `{ type: 'stdio', command: 'old' }`; the
+      // canonical intent is `command: 'node'`. The writer never
+      // overwrote it.)
+      const claudeAfter = readFileSync(claudePath);
+      expect(claudeAfter.toString()).toContain('"command": "old"');
+      expect(claudeAfter.toString()).not.toContain('"command": "node"');
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Integration 2 — mixed run: one agent refused, another would-update.
+  //
+  // Seeds Claude with divergent settings (conflict) AND OpenCode with
+  // matching settings (would-update → real write). The orchestrator must:
+  //   - exit 1 (refusal wins over would-update),
+  //   - call Claude's writer exactly once (Pass 1 only — conflict skip),
+  //   - call OpenCode's writer twice (Pass 1 dryRun + Pass 2 real),
+  //   - create a backup for OpenCode (Pass 2 path),
+  //   - leave Claude byte-identical, OpenCode written.
+  // -------------------------------------------------------------------------
+
+  it('mixed run: conflict agent skipped, successful agent real-writes; overall exit 1', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    // Claude seeded with divergent settings (canonical: 'node', target: 'old').
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const claudeBefore = readFileSync(claudePath);
+    // OpenCode seeded with matching settings for `filesystem`. The
+    // canonical config adds a second server (`extra`) that does NOT
+    // exist in the OpenCode target — this is the only way to drive
+    // `planned.changed = true` for a writer that byte-preserves an
+    // existing equal entry: the planner still has to insert the new
+    // server name, so planned.changed is true and Pass 2 runs.
+    const opencodePath = seedOpencodeUserConfig(
+      env.xdgConfigHome,
+      opencodeConfigJsonc('filesystem'),
+    );
+    const opencodeBefore = readFileSync(opencodePath);
+
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        mcpServers: {
+          filesystem: { type: 'stdio', command: 'node' },
+          extra: { type: 'stdio', command: 'extra-cmd' },
+        },
+      }),
+    );
+
+    const claudeTarget: AgentDefinition | undefined = agentRegistry.find(
+      (a) => a.id === 'claude-code',
+    );
+    const opencodeTarget: AgentDefinition | undefined = agentRegistry.find(
+      (a) => a.id === 'opencode',
+    );
+    expect(claudeTarget).toBeDefined();
+    expect(opencodeTarget).toBeDefined();
+    if (claudeTarget === undefined || opencodeTarget === undefined) return;
+    const claudeOriginal = claudeTarget.mcp.write;
+    const opencodeOriginal = opencodeTarget.mcp.write;
+    if (claudeOriginal === undefined || opencodeOriginal === undefined) return;
+
+    const claudeCalls: { dryRun: boolean }[] = [];
+    const opencodeCalls: { dryRun: boolean }[] = [];
+    const claudeSpy = vi
+      .spyOn(claudeTarget.mcp, 'write')
+      .mockImplementation(async (ctx, input) => {
+        claudeCalls.push({ dryRun: input.dryRun === true });
+        return claudeOriginal(ctx, input);
+      });
+    const opencodeSpy = vi
+      .spyOn(opencodeTarget.mcp, 'write')
+      .mockImplementation(async (ctx, input) => {
+        opencodeCalls.push({ dryRun: input.dryRun === true });
+        return opencodeOriginal(ctx, input);
+      });
+
+    try {
+      const stdout = new BufferWriter();
+      const stderr = new BufferWriter();
+      const code = await runApply([], stdout, stderr);
+
+      expect(stderr.text()).toBe('');
+      // At least one refusal → exit 1.
+      expect(code).toBe(1);
+
+      // Claude (conflict): exactly one call, dryRun: true, no Pass 2.
+      expect(claudeCalls.length).toBe(1);
+      expect(claudeCalls[0]?.dryRun).toBe(true);
+
+      // OpenCode (would-update): exactly two calls — Pass 1 + Pass 2.
+      expect(opencodeCalls.length).toBe(2);
+      expect(opencodeCalls[0]?.dryRun).toBe(true);
+      expect(opencodeCalls[1]?.dryRun).toBe(false);
+
+      // OpenCode backup created (Pass 2 path includes backup step).
+      const opencodeBackups = findBackupFiles(
+        dirname(opencodePath),
+        basename(opencodePath),
+      );
+      expect(opencodeBackups.length).toBeGreaterThan(0);
+
+      // Claude: no backup, byte-identical.
+      const claudeBackups = findBackupFiles(
+        dirname(claudePath),
+        basename(claudePath),
+      );
+      expect(claudeBackups.length).toBe(0);
+      expect(readFileSync(claudePath)).toEqual(claudeBefore);
+
+      // OpenCode: written (bytes changed from the seeded form).
+      // The exact byte content is owned by the opencode writer's
+      // preservation tests; here we assert only that the file changed.
+      const opencodeAfter = readFileSync(opencodePath);
+      expect(opencodeAfter.equals(opencodeBefore)).toBe(false);
+    } finally {
+      claudeSpy.mockRestore();
+      opencodeSpy.mockRestore();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Integration 3 — `backupBeforeWrite: false` does not weaken conflict
+  // refusal.
+  //
+  // The setting only governs whether a backup is created when a write
+  // happens; the conflict path precludes both backup and write. With
+  // `backupBeforeWrite: false` the orchestrator still exits 1, never
+  // calls Pass 2, never creates a backup, never touches the target.
+  // -------------------------------------------------------------------------
+
+  it('backupBeforeWrite: false still refuses on conflict: no backup, no Pass 2, exit 1', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    const claudePath = seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        targets: ['claude-code'],
+        backupBeforeWrite: false,
+      }),
+    );
+
+    const claudeTarget: AgentDefinition | undefined = agentRegistry.find(
+      (a) => a.id === 'claude-code',
+    );
+    expect(claudeTarget).toBeDefined();
+    if (claudeTarget === undefined) return;
+    const originalWrite = claudeTarget.mcp.write;
+    if (originalWrite === undefined) return;
+
+    const writeCalls: { dryRun: boolean }[] = [];
+    const writeSpy = vi
+      .spyOn(claudeTarget.mcp, 'write')
+      .mockImplementation(async (ctx, input) => {
+        writeCalls.push({ dryRun: input.dryRun === true });
+        return originalWrite(ctx, input);
+      });
+
+    try {
+      const stdout = new BufferWriter();
+      const stderr = new BufferWriter();
+      const code = await runApply([], stdout, stderr);
+
+      expect(stderr.text()).toBe('');
+      expect(code).toBe(1);
+
+      // Writer called exactly once — Pass 2 still skipped on conflict,
+      // regardless of backupBeforeWrite.
+      expect(writeCalls.length).toBe(1);
+      expect(writeCalls[0]?.dryRun).toBe(true);
+
+      // No backup files — conflict path precludes backup entirely.
+      const backups = findBackupFiles(
+        dirname(claudePath),
+        basename(claudePath),
+      );
+      expect(backups.length).toBe(0);
+
+      // Target byte-identical.
+      const claudeAfter = readFileSync(claudePath);
+      expect(claudeAfter.toString()).toContain('"command": "old"');
+      expect(claudeAfter.toString()).not.toContain('"command": "node"');
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Integration 4 — `formatHumanApply` real-write output includes the
+  // structured `Conflicts:` block listing each conflicted server name.
+  // The block replaces the generic `reason:` line for the conflict
+  // refusal — server name appears verbatim so operators can identify
+  // the drift without parsing JSON.
+  // -------------------------------------------------------------------------
+
+  it('formatHumanApply includes a Conflicts: block listing each conflicted server name (real-write)', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({ targets: ['claude-code'] }),
+    );
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply([], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBe(1);
+
+    const out = stdout.text();
+    expect(out).toContain('Conflicts:');
+    expect(out).toContain('filesystem');
+    // B3-aligned wording carries the "Refusing to continue" phrase so
+    // operators see the canonical vocabulary without grepping for it.
+    expect(out).toContain('Refusing to continue');
+  });
+
+  // -------------------------------------------------------------------------
+  // Integration 5 — `formatHumanApplyDryRun` output includes the
+  // structured `Conflicts:` block plus the refusal-summary line. The
+  // summary count already includes conflict in `refusal(s)` after
+  // fix-3; this test pins the rendered shape.
+  // -------------------------------------------------------------------------
+
+  it('formatHumanApplyDryRun renders Conflicts: block + refusal-summary line', () => {
+    const envelope: ApplyDryRunResult = {
+      profile: 'default',
+      configPath: '/tmp/example/overture.jsonc',
+      disabledServers: [],
+      results: [
+        {
+          agentId: 'claude-code',
+          displayName: 'Claude Code',
+          status: 'conflict',
+          result: {
+            written: 0,
+            changed: false,
+            dryRun: true,
+            serversWritten: [],
+            targetPaths: [
+              {
+                scope: 'user',
+                base: 'home',
+                path: '/tmp/example/.claude.json',
+              },
+            ],
+            resolvedPath: '/tmp/example/.claude.json',
+            conflicts: [
+              {
+                serverName: 'filesystem',
+                message:
+                  'Refusing to continue for server "filesystem": ' +
+                  'canonical and agent settings differ. ' +
+                  'Update the canonical config or the agent config and retry.',
+                diffKeys: ['command'],
+              },
+            ],
+          },
+        },
+        {
+          agentId: 'opencode',
+          displayName: 'OpenCode',
+          status: 'no-change',
+          result: {
+            written: 0,
+            changed: false,
+            dryRun: true,
+            serversWritten: [],
+            targetPaths: [
+              {
+                scope: 'user',
+                base: 'config',
+                path: '/tmp/example/.config/opencode/opencode.jsonc',
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const text = formatHumanApplyDryRun(envelope);
+    expect(text).toContain('Conflicts:');
+    expect(text).toContain('filesystem');
+    expect(text).toContain('Refusing to continue');
+    // Refusal summary line — 'conflict' is part of the refusal count.
+    expect(text).toMatch(/Summary:.*\d+ refusal\(s\)/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Integration 6 — `--json` dry-run envelope carries the `conflicts`
+  // field per agent result. Real-write JSON is intentionally NOT
+  // emitted (F2 gate F2-4) so we only assert the dry-run envelope.
+  // -------------------------------------------------------------------------
+
+  it('--json dry-run envelope carries result.conflicts per agent', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({ targets: ['claude-code'] }),
+    );
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run', '--json'], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBe(1);
+
+    const envelope = JSON.parse(stdout.text()) as ApplyDryRunResult;
+    expect(envelope.results.length).toBe(1);
+    const claudeResult = envelope.results[0];
+    expect(claudeResult).toBeDefined();
+    expect(claudeResult?.status).toBe('conflict');
+    expect(claudeResult?.result?.conflicts).toBeDefined();
+    expect(claudeResult?.result?.conflicts?.length).toBe(1);
+    expect(claudeResult?.result?.conflicts?.[0]?.serverName).toBe('filesystem');
+    expect(claudeResult?.result?.conflicts?.[0]?.message).toContain(
+      'Refusing to continue',
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Integration 7 — `reasonDetail` policy: stays empty for writer-driven
+  // conflict refusals, populated only for synthesized refusals.
+  // -------------------------------------------------------------------------
+
+  it('reasonDetail is empty for conflict refusal but populated for synthesized not-targetable', async () => {
+    const env = createApplyTempEnv();
+    cleanupDirs = env.cleanup;
+    applyEnv(env);
+    seedAllFakeBins(env.pathDir);
+
+    // Conflict path: divergent Claude settings. The writer drives the
+    // refusal; reasonDetail must stay empty.
+    seedClaudeUserConfig(
+      env.home,
+      JSON.stringify(
+        {
+          mcpServers: {
+            filesystem: { type: 'stdio', command: 'old' },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    seedCanonicalConfig(
+      env.xdgConfigHome,
+      buildCanonicalConfigJson({
+        // Mixed run: one conflict, one synthesized not-targetable. The
+        // synthesized branch proves reasonDetail still gets populated
+        // when the orchestrator — not the writer — owns the refusal.
+        targets: ['claude-code', 'ghost-agent'],
+      }),
+    );
+
+    const stdout = new BufferWriter();
+    const stderr = new BufferWriter();
+    const code = await runApply(['--dry-run', '--json'], stdout, stderr);
+
+    expect(stderr.text()).toBe('');
+    expect(code).toBe(1);
+
+    const envelope = JSON.parse(stdout.text()) as ApplyDryRunResult;
+    const claudeResult = envelope.results.find(
+      (r: ApplyDryRunAgentResult) => r.agentId === 'claude-code',
+    );
+    expect(claudeResult).toBeDefined();
+    expect(claudeResult?.status).toBe('conflict');
+    // Conflict refusal: reasonDetail stays empty — the structured
+    // `result.conflicts` channel is the canonical home for drift detail.
+    expect(claudeResult?.reasonDetail).toBeUndefined();
+
+    const ghostResult = envelope.results.find(
+      (r: ApplyDryRunAgentResult) => r.agentId === 'ghost-agent',
+    );
+    expect(ghostResult).toBeDefined();
+    expect(ghostResult?.status).toBe('not-targetable');
+    // Synthesized refusal: reasonDetail populated with the orchestrator-
+    // owned explanation. The reason field on the writer envelope also
+    // carries it; reasonDetail is the CLI-local channel for
+    // synthesized refusals.
+    expect(ghostResult?.reasonDetail).toContain('unknown agent id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F3 — pure-function contract locks for the human-formatter `Conflicts:`
+// block and the exit-code helpers.
+// ---------------------------------------------------------------------------
+
+describe('F3 pure-function contract: Conflicts block + exit codes', () => {
+  const sampleConflict: ServerConflict = {
+    serverName: 'remote-tools',
+    message:
+      'Refusing to continue for server "remote-tools": ' +
+      'canonical and agent settings differ. ' +
+      'Update the canonical config or the agent config and retry.',
+    diffKeys: ['url', 'headers'],
+  };
+
+  it('exitCodeForApplyDryRun returns 1 when any dry-run result is conflict', () => {
+    const result: ApplyDryRunAgentResult = {
+      agentId: 'claude-code',
+      displayName: 'Claude Code',
+      status: 'conflict',
+      result: {
+        written: 0,
+        changed: false,
+        dryRun: true,
+        serversWritten: [],
+        targetPaths: [],
+        conflicts: [sampleConflict],
+      },
+    };
+    expect(exitCodeForApplyDryRun([result])).toBe(1);
+  });
+
+  it('exitCodeForApply returns 1 when any real-write result is conflict', () => {
+    const result: ApplyAgentResult = {
+      agentId: 'claude-code',
+      displayName: 'Claude Code',
+      status: 'conflict',
+      result: {
+        written: 0,
+        changed: false,
+        dryRun: true,
+        serversWritten: [],
+        targetPaths: [],
+        conflicts: [sampleConflict],
+      },
+      backupPaths: [],
+    };
+    expect(exitCodeForApply([result])).toBe(1);
+  });
+
+  it('formatHumanApply renders the Conflicts: block in the real-write envelope', () => {
+    const envelope: ApplyResult = {
+      profile: 'default',
+      configPath: '/tmp/example/overture.jsonc',
+      disabledServers: [],
+      backupBeforeWrite: true,
+      results: [
+        {
+          agentId: 'claude-code',
+          displayName: 'Claude Code',
+          status: 'conflict',
+          result: {
+            written: 0,
+            changed: false,
+            dryRun: true,
+            serversWritten: [],
+            targetPaths: [
+              {
+                scope: 'user',
+                base: 'home',
+                path: '/tmp/example/.claude.json',
+              },
+            ],
+            resolvedPath: '/tmp/example/.claude.json',
+            conflicts: [sampleConflict],
+          },
+          backupPaths: [],
+        },
+      ],
+    };
+    const text = formatHumanApply(envelope);
+    expect(text).toContain('Conflicts:');
+    expect(text).toContain('remote-tools');
+    expect(text).toContain('Refusing to continue');
   });
 });
 

--- a/apps/cli/src/apply-command.ts
+++ b/apps/cli/src/apply-command.ts
@@ -86,9 +86,15 @@ export interface ApplyDryRunAgentResult {
   /** The writer envelope returned by `agent.mcp.write`, unchanged. */
   readonly result: AgentMcpWriteResult;
   /**
-   * Optional human-readable reason. Populated when the writer omitted a
-   * `reason` (e.g. unknown agent id, missing `mcp.write` slot) so the
-   * human/JSON envelope still explains the refusal.
+   * Optional human-readable reason. Populated ONLY when the refusal is
+   * synthesized in the orchestrator (unknown agent id, missing
+   * `mcp.write` slot). For writer-driven refusals (parse-error,
+   * unsupported-shape, unsupported-format, conflict) the writer's
+   * `result.reason` / `result.conflicts` are the canonical channel —
+   * do NOT mirror them here. F3 in particular pins that the structured
+   * `Conflicts:` block (sourced from `result.conflicts`) is the only
+   * home for canonical-settings-drift detail; `reasonDetail` stays
+   * empty so future consumers cannot conflate the two channels.
    */
   readonly reasonDetail?: string;
 }
@@ -148,9 +154,16 @@ export interface ApplyAgentResult {
    */
   readonly backupPaths: readonly string[];
   /**
-   * Optional human-readable reason. Populated when the writer omitted a
-   * `reason` (e.g. unknown agent id, missing `mcp.write` slot) or when the
-   * backup step failed and Pass 2 was skipped.
+   * Optional human-readable reason. Populated ONLY when the refusal is
+   * synthesized in the orchestrator (unknown agent id, missing
+   * `mcp.write` slot) or when the backup step failed before Pass 2 ran.
+   * For writer-driven refusals the writer's `result.reason` /
+   * `result.conflicts` are the canonical channel — do NOT mirror them
+   * here. F3 in particular pins that the structured `Conflicts:` block
+   * (sourced from `result.conflicts`) is the only home for
+   * canonical-settings-drift detail; `reasonDetail` stays empty for
+   * conflict refusals so future consumers cannot conflate the two
+   * channels.
    */
   readonly reasonDetail?: string;
 }
@@ -386,8 +399,25 @@ export function formatHumanApplyDryRun(result: ApplyDryRunResult): string {
         lines.push(`  servers:   ${agent.result.serversWritten.join(', ')}`);
       }
     } else {
-      const reason = agent.reasonDetail ?? agent.result.reason ?? '(no reason)';
-      lines.push(`  reason:    ${reason}`);
+      // F3: when the writer populates `result.conflicts`, surface the
+      // structured `Conflicts:` block in place of the generic `reason:`
+      // line. The structured channel is the canonical home for
+      // canonical-settings-drift detail — `reasonDetail` is reserved
+      // for synthesized / non-writer refusals and is NOT the conflict
+      // channel (see the doc comment on `ApplyDryRunAgentResult.reasonDetail`).
+      if (
+        agent.result.conflicts !== undefined &&
+        agent.result.conflicts.length > 0
+      ) {
+        lines.push('  Conflicts:');
+        for (const c of agent.result.conflicts) {
+          lines.push(`    - ${c.serverName}: ${c.message}`);
+        }
+      } else {
+        const reason =
+          agent.reasonDetail ?? agent.result.reason ?? '(no reason)';
+        lines.push(`  reason:    ${reason}`);
+      }
     }
     lines.push('');
   }
@@ -401,7 +431,8 @@ export function formatHumanApplyDryRun(result: ApplyDryRunResult): string {
         r.status === 'not-targetable' ||
         r.status === 'parse-error' ||
         r.status === 'unsupported-shape' ||
-        r.status === 'unsupported-format',
+        r.status === 'unsupported-format' ||
+        r.status === 'conflict',
     ).length,
   };
   const total = result.results.length;
@@ -481,8 +512,25 @@ export function formatHumanApply(result: ApplyResult): string {
         lines.push(`  servers:   ${agent.result.serversWritten.join(', ')}`);
       }
     } else {
-      const reason = agent.reasonDetail ?? agent.result.reason ?? '(no reason)';
-      lines.push(`  reason:    ${reason}`);
+      // F3: structured `Conflicts:` block in the real-write twin so the
+      // dry-run and real-write reports carry the same shape when a
+      // canonical-settings-drift conflict refuses the agent. The
+      // structured channel is the canonical home for that detail;
+      // `reasonDetail` is reserved for synthesized / non-writer
+      // refusals (see the doc comment on `ApplyAgentResult.reasonDetail`).
+      if (
+        agent.result.conflicts !== undefined &&
+        agent.result.conflicts.length > 0
+      ) {
+        lines.push('  Conflicts:');
+        for (const c of agent.result.conflicts) {
+          lines.push(`    - ${c.serverName}: ${c.message}`);
+        }
+      } else {
+        const reason =
+          agent.reasonDetail ?? agent.result.reason ?? '(no reason)';
+        lines.push(`  reason:    ${reason}`);
+      }
     }
     lines.push('');
   }
@@ -496,7 +544,8 @@ export function formatHumanApply(result: ApplyResult): string {
         r.status === 'not-targetable' ||
         r.status === 'parse-error' ||
         r.status === 'unsupported-shape' ||
-        r.status === 'unsupported-format',
+        r.status === 'unsupported-format' ||
+        r.status === 'conflict',
     ).length,
   };
   const total = result.results.length;
@@ -724,6 +773,12 @@ async function applyToAgentDryRun(
     pathContext: ctx,
   });
 
+  // F3: `reasonDetail` stays empty here. The writer's
+  // `result.reason` / `result.conflicts` are the canonical channel for
+  // writer-driven refusals (parse-error, unsupported-shape,
+  // unsupported-format, conflict); synthesizing a `reasonDetail` would
+  // let a future consumer conflate the two channels (see
+  // `ApplyDryRunAgentResult.reasonDetail` doc).
   return {
     agentId,
     displayName: entry.displayName,
@@ -798,8 +853,16 @@ async function applyToAgentReal(
     pathContext: ctx,
   });
   const dryStatus = statusFromWriterResult(dryResult);
-  // Refusal / no-change / parse-error / unsupported-* → no backup, no Pass 2.
+  // Refusal / no-change / parse-error / unsupported-* / conflict →
+  // no backup, no Pass 2. `backupBeforeWrite` is intentionally NOT
+  // consulted on this branch: refusal precludes both backup and write,
+  // so the setting only governs the would-update path below.
   if (dryStatus !== 'would-update') {
+    // F3: `reasonDetail` stays empty for writer-driven refusals. The
+    // structured conflict detail lives on `result.conflicts` (the
+    // canonical channel — see `ApplyAgentResult.reasonDetail` doc);
+    // other writer refusals live on `result.reason`. Synthesizing a
+    // `reasonDetail` here would let a future consumer conflate the two.
     return {
       agentId,
       displayName: entry.displayName,

--- a/apps/cli/src/apply-command.ts
+++ b/apps/cli/src/apply-command.ts
@@ -75,7 +75,8 @@ export type ApplyDryRunStatus =
   | 'not-targetable'
   | 'parse-error'
   | 'unsupported-shape'
-  | 'unsupported-format';
+  | 'unsupported-format'
+  | 'conflict';
 
 /** Single per-agent entry in an {@link ApplyDryRunResult}. */
 export interface ApplyDryRunAgentResult {
@@ -126,7 +127,8 @@ export type ApplyStatus =
   | 'not-targetable'
   | 'parse-error'
   | 'unsupported-shape'
-  | 'unsupported-format';
+  | 'unsupported-format'
+  | 'conflict';
 
 /** Single per-agent entry in an {@link ApplyResult}. */
 export interface ApplyAgentResult {
@@ -858,6 +860,12 @@ function mapDryRefusalToApply(status: ApplyDryRunStatus): ApplyStatus {
       return 'not-targetable';
     case 'no-change':
       return 'no-change';
+    case 'conflict':
+      // Identity map — `'conflict'` is a CLI-local status that pairs across
+      // the dry-run and real-write envelopes. Unreachable today (Task 4
+      // wires the `AgentMcpWriteResult.conflicts` → status mapping) but
+      // required by `noImplicitReturns` once the union is widened.
+      return 'conflict';
     case 'would-update':
       // Caller never reaches here for would-update (handled above), but
       // satisfy the exhaustive switch.

--- a/apps/cli/src/apply-command.ts
+++ b/apps/cli/src/apply-command.ts
@@ -213,6 +213,7 @@ export function exitCodeForApplyDryRun(
     'parse-error',
     'unsupported-shape',
     'unsupported-format',
+    'conflict',
   ]);
   return results.some((r) => refusalStatuses.has(r.status)) ? 1 : 0;
 }
@@ -229,6 +230,7 @@ export function exitCodeForApply(results: readonly ApplyAgentResult[]): 0 | 1 {
     'parse-error',
     'unsupported-shape',
     'unsupported-format',
+    'conflict',
   ]);
   return results.some((r) => refusalStatuses.has(r.status)) ? 1 : 0;
 }
@@ -540,6 +542,15 @@ function messageForError(err: unknown): string {
 function statusFromWriterResult(
   result: AgentMcpWriteResult,
 ): ApplyDryRunStatus {
+  // F3: divergent canonical settings produce a `conflicts` array on the
+  // writer result. Surface that as the CLI-local `'conflict'` status
+  // BEFORE the plannedUpdate / no-change inference, so refusal short-
+  // circuits before any byte-level decision. Writers populate
+  // `result.conflicts`; the orchestrator is the only place that maps
+  // it to `ApplyDryRunStatus`. `WriteReason` stays unchanged.
+  if (result.conflicts !== undefined && result.conflicts.length > 0) {
+    return 'conflict';
+  }
   const reason = result.reason;
   if (reason === 'parse-error') return 'parse-error';
   if (reason === 'unsupported-shape') return 'unsupported-shape';
@@ -561,6 +572,12 @@ function statusFromWriterResult(
  * `changed` check.
  */
 function statusFromRealWriterResult(result: AgentMcpWriteResult): ApplyStatus {
+  // F3: same conflict-first mapping as the dry-run twin. The real-
+  // write path also short-circuits before Pass 2; Task 4 wires the
+  // backup-skip / Pass 2-skip branches off this status.
+  if (result.conflicts !== undefined && result.conflicts.length > 0) {
+    return 'conflict';
+  }
   const reason = result.reason;
   if (reason === 'parse-error') return 'parse-error';
   if (reason === 'unsupported-shape') return 'unsupported-shape';

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -441,6 +441,26 @@ refuse instead of overwriting.
 
 Expected result: apply never silently picks a winner.
 
+**Status: completed on feat/f3-conflict-refusal (this slice).** Delivered
+F3's `overture apply` settings-drift refusal. New CLI-local `'conflict'`
+member on `ApplyStatus` / `ApplyDryRunStatus` (`WriteReason` in
+`@overture/agents` unchanged); the `ServerConflict` shape lives in
+`@overture/agents/types.ts` and is exported via `@overture/agents/index.ts`;
+the `detectCanonicalSettingsDrift` helper in
+`packages/agents/src/parse-mcp-servers.ts` compares two
+`ReadonlyMap<serverName, AgentNormalizedMcpServer>` snapshots and is wired
+into all four production per-agent writers (OpenCode, Claude Code with its
+workspace-nested `projects[workspaceDir].mcpServers`, GitHub Copilot CLI,
+OpenAI Codex). The orchestrator short-circuits before backup + Pass 2 via
+the existing `'would-update'`-exclusive gate; `formatHumanApply` and
+`formatHumanApplyDryRun` render a `Conflicts:` block; the dry-run JSON
+envelope carries `AgentMcpWriteResult.conflicts`; `reasonDetail` policy
+pinned to synthesized refusals only. Five commits on
+`feat/f3-conflict-refusal` (`2397d82d` type contract,
+`684079fb` detector, `f8e3eb08` writer integration, `1e060a4b` orchestrator
+refusal, slice-doc/smoke commit). Plan:
+`.omo/plans/f3-conflict-refusal.md`.
+
 ## Track G: undo and auditability
 
 Undo should be human-recoverable, not dependent on hidden state.

--- a/packages/agents/src/claude-code-write.ts
+++ b/packages/agents/src/claude-code-write.ts
@@ -18,9 +18,17 @@ import {
   type ParseError,
 } from 'jsonc-parser/lib/esm/main.js';
 import type { OvertureMcpServer } from '@overture/config';
+import {
+  normalizeClaudeCodeMcpServers,
+  type ClaudeCodeMcpConfig,
+} from './claude-code.js';
+import { normalized } from './normalize-mcp-config.js';
+import { detectCanonicalSettingsDrift } from './parse-mcp-servers.js';
 import type {
+  AgentMcpReadResult,
   AgentMcpWriteInput,
   AgentMcpWriteResult,
+  AgentNormalizedMcpServer,
   McpLocationFormat,
   PathResolutionContext,
   StringMap,
@@ -224,6 +232,71 @@ function validateContainer(
 }
 
 // ---------------------------------------------------------------------------
+// F3 existing-map construction (Claude Code)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the F3 existing-server map for Claude Code by combining the
+ * top-level `mcpServers` with the workspace-nested
+ * `projects[workspaceDir].mcpServers` entries. Workspace entries win
+ * on name collision. The merged map is funneled through the B2
+ * `normalizeClaudeCodeMcpServers` normalizer (synthetic
+ * `ClaudeCodeMcpConfig` wrapper, no public contract change) so both
+ * sides of the detector run on the same canonical normalized shape.
+ *
+ * Returns an empty map when `parsed` is not an object, when no
+ * workspace dir is supplied, or when neither container is present.
+ */
+function buildClaudeCodeExistingMap(
+  parsed: unknown,
+  workspaceDir: string,
+): ReadonlyMap<string, AgentNormalizedMcpServer> {
+  if (!isObject(parsed)) {
+    return new Map();
+  }
+
+  const topServers: Record<string, unknown> = isObject(parsed['mcpServers'])
+    ? (parsed['mcpServers'] as Record<string, unknown>)
+    : {};
+
+  let workspaceServers: Record<string, unknown> = {};
+  if (workspaceDir.length > 0) {
+    const projects = parsed['projects'];
+    if (isObject(projects)) {
+      const project = (projects as Record<string, unknown>)[workspaceDir];
+      if (isObject(project)) {
+        const nested = (project as Record<string, unknown>)['mcpServers'];
+        if (isObject(nested)) {
+          workspaceServers = nested as Record<string, unknown>;
+        }
+      }
+    }
+  }
+
+  // Workspace wins on collision. The spread order places workspace
+  // entries last so they overwrite top-level entries with the same key.
+  const merged: Record<string, unknown> = {
+    ...topServers,
+    ...workspaceServers,
+  };
+  if (Object.keys(merged).length === 0) {
+    return new Map();
+  }
+
+  const syntheticConfig: ClaudeCodeMcpConfig = {
+    mcpServers: merged as ClaudeCodeMcpConfig['mcpServers'],
+  };
+  const syntheticRead: AgentMcpReadResult<ClaudeCodeMcpConfig> = {
+    config: syntheticConfig,
+    nonEmpty: true,
+  };
+  const normalizedRecord = normalizeClaudeCodeMcpServers(syntheticRead);
+  return new Map<string, AgentNormalizedMcpServer>(
+    Object.entries(normalizedRecord),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Writer
 // ---------------------------------------------------------------------------
 
@@ -341,6 +414,35 @@ export async function writeClaudeCodeMcpConfig(
   let container: unknown = parsed;
   for (const seg of segments) {
     container = (container as Record<string, unknown>)[seg];
+  }
+
+  // F3 conflict detection: build the existing normalized map from
+  // BOTH top-level `mcpServers` AND `projects[workspaceDir].mcpServers`
+  // (workspace wins on collision), compare against the canonical
+  // input, and refuse when any same-name pair differs in normalized
+  // shape. Detector invocation order is fixed per the F3 design
+  // contract: read → normalize → compare → refuse-or-proceed. Runs
+  // AFTER shape validation and BEFORE any per-server patch building
+  // so the writer never reads-then-rewrites a divergent entry.
+  const existingMap = buildClaudeCodeExistingMap(
+    parsed,
+    typeof ctx.workspaceDir === 'string' ? ctx.workspaceDir : '',
+  );
+  const canonicalMap = new Map<string, AgentNormalizedMcpServer>(
+    input.servers.map((s) => [s.name, normalized(s.server)]),
+  );
+  const conflicts = detectCanonicalSettingsDrift(existingMap, canonicalMap);
+  if (conflicts.length > 0) {
+    return {
+      written: 0,
+      changed: false,
+      dryRun,
+      serversWritten: [],
+      targetPaths: [targetPathFor(target)],
+      resolvedPath,
+      format: 'jsonc' as McpLocationFormat,
+      conflicts,
+    };
   }
 
   // Build per-server patches: check existence and read existing native entries.

--- a/packages/agents/src/claude-code.write.spec.ts
+++ b/packages/agents/src/claude-code.write.spec.ts
@@ -448,7 +448,7 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
       );
     });
 
-    it('E3: project .mcp.json update returns changed:true, written:1, format:jsonc', async () => {
+    it('F3: project .mcp.json divergent canonical triggers conflict refusal', async () => {
       const ctx = makeCtx();
       const projectPath = join(ctx.workspaceDir, '.mcp.json');
       const { writeFile, mkdir } = await import('node:fs/promises');
@@ -468,13 +468,20 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
         servers: [{ name: 'filesystem', server: filesystemServer }],
       });
 
-      // RED phase: stub returns parse-error; these assertions prove the wiring
-      expect(result.changed).toBe(true);
-      expect(result.written).toBe(1);
+      // F3: divergent settings refuse the write before byte-level
+      // planning. The target resolution (project .mcp.json) still
+      // surfaces; only the write is refused.
+      expect(result.changed).toBe(false);
+      expect(result.written).toBe(0);
+      expect(result.serversWritten).toEqual([]);
       expect(result.format).toBe('jsonc');
-      expect(result.serversWritten).toContain('filesystem');
       expect(result.resolvedPath).toBe(projectPath);
-      expect(result.bytesChanged).toBeGreaterThan(0);
+      expect(result.targetPaths).toContainEqual(
+        expect.objectContaining({ scope: 'project', base: 'workspace' }),
+      );
+      expect(result.conflicts).toBeDefined();
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts?.[0]?.serverName).toBe('filesystem');
     });
   });
 
@@ -501,7 +508,7 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
       );
     });
 
-    it('E3: user-top update returns full metadata envelope', async () => {
+    it('F3: user-top divergent canonical triggers conflict refusal', async () => {
       const ctx = makeCtx();
       const userPath = join(ctx.homeDir, '.claude.json');
       const { writeFile, mkdir } = await import('node:fs/promises');
@@ -521,14 +528,15 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
         servers: [{ name: 'filesystem', server: filesystemServer }],
       });
 
-      expect(result.changed).toBe(true);
-      expect(result.written).toBe(1);
+      expect(result.changed).toBe(false);
+      expect(result.written).toBe(0);
       expect(result.dryRun).toBe(false);
-      expect(result.serversWritten).toContain('filesystem');
+      expect(result.serversWritten).toEqual([]);
       expect(result.format).toBe('jsonc');
       expect(result.resolvedPath).toBe(userPath);
-      expect(result.bytesChanged).toBeGreaterThan(0);
       expect(result.targetPaths).toHaveLength(1);
+      expect(result.conflicts).toBeDefined();
+      expect(result.conflicts?.[0]?.serverName).toBe('filesystem');
     });
   });
 
@@ -560,7 +568,7 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
       );
     });
 
-    it('E3: user-projects update exercises projects[workspaceKey].mcpServers path', async () => {
+    it('F3: user-projects divergent canonical triggers conflict refusal', async () => {
       const ctx = makeCtx();
       const userPath = join(ctx.homeDir, '.claude.json');
       const { writeFile, mkdir } = await import('node:fs/promises');
@@ -584,18 +592,20 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
         servers: [{ name: 'filesystem', server: filesystemServer }],
       });
 
-      // RED phase: stub returns parse-error; wiring is confirmed via targetPaths
-      expect(result.changed).toBe(true);
-      expect(result.written).toBe(1);
-      expect(result.serversWritten).toContain('filesystem');
+      // F3: target resolved (user-projects path), but divergent
+      // settings refuse the write before byte-level planning.
+      expect(result.changed).toBe(false);
+      expect(result.written).toBe(0);
+      expect(result.serversWritten).toEqual([]);
       expect(result.format).toBe('jsonc');
-      expect(result.bytesChanged).toBeGreaterThan(0);
+      expect(result.conflicts).toBeDefined();
+      expect(result.conflicts?.[0]?.serverName).toBe('filesystem');
     });
   });
 
-  // ----- METADATA ENVELOPE: changed update -----
-  describe('metadata envelope: changed update', () => {
-    it('returns written:1, changed:true, dryRun:false, serversWritten, bytesChanged>0, format:jsonc, targetPaths, resolvedPath', async () => {
+  // ----- METADATA ENVELOPE: F3 conflict refusal -----
+  describe('metadata envelope: F3 conflict refusal', () => {
+    it('returns written:0, changed:false, dryRun:false, conflicts populated, targetPaths, resolvedPath', async () => {
       const ctx = makeCtx();
       const projectPath = join(ctx.workspaceDir, '.mcp.json');
       const { writeFile, mkdir } = await import('node:fs/promises');
@@ -611,14 +621,19 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
         servers: [{ name: 'filesystem', server: filesystemServer }],
       });
 
-      expect(result.written).toBe(1);
-      expect(result.changed).toBe(true);
+      // F3 supersedes the pre-F3 "changed update" envelope: divergent
+      // settings now refuse the write before byte-level planning.
+      expect(result.written).toBe(0);
+      expect(result.changed).toBe(false);
       expect(result.dryRun).toBe(false);
-      expect(result.serversWritten).toEqual(['filesystem']);
+      expect(result.serversWritten).toEqual([]);
       expect(result.targetPaths).toHaveLength(1);
       expect(result.format).toBe('jsonc');
-      expect(result.bytesChanged).toBeGreaterThan(0);
       expect(result.resolvedPath).toBe(projectPath);
+      expect(result.conflicts).toBeDefined();
+      expect(result.conflicts?.[0]?.serverName).toBe('filesystem');
+      expect(result.conflicts?.[0]?.message).toContain('canonical and agent');
+      expect(result.conflicts?.[0]?.diffKeys).toContain('args');
     });
   });
 
@@ -654,7 +669,7 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
 
   // ----- METADATA ENVELOPE: dry-run -----
   describe('metadata envelope: dry-run', () => {
-    it('returns planned metadata and leaves disk unchanged', async () => {
+    it('F3 dry-run: divergent canonical triggers conflict refusal with dryRun flag, leaves disk unchanged', async () => {
       const ctx = makeCtx();
       const projectPath = join(ctx.workspaceDir, '.mcp.json');
       const { writeFile, mkdir, readFile } = await import('node:fs/promises');
@@ -680,7 +695,8 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
       expect(result.dryRun).toBe(true);
       expect(result.changed).toBe(false);
       expect(result.written).toBe(0); // no disk write occurred
-      expect(result.serversWritten).toContain('filesystem');
+      expect(result.conflicts).toBeDefined();
+      expect(result.conflicts?.[0]?.serverName).toBe('filesystem');
       expect(result.format).toBe('jsonc');
       expect(result.resolvedPath).toBe(projectPath);
 
@@ -1205,6 +1221,145 @@ describe('claudeCode.mcp.write (E3 byte-splice)', () => {
       } finally {
         writeSpy.mockRestore();
       }
+    });
+  });
+
+  // ----- F3: conflict refusal across top-level + workspace scopes -----
+  describe('F3: claudeCode.mcp.write conflict detection (workspace scope)', () => {
+    /**
+     * Build a Claude Code config fixture that has workspace-nested
+     * `projects[workspaceDir].mcpServers` (no top-level mcpServers).
+     */
+    function workspaceOnlyFixture(workspaceDir: string): string {
+      return JSON.stringify({
+        numStartups: 42,
+        hasCompletedOnboarding: true,
+        projects: {
+          [workspaceDir]: {
+            mcpServers: {
+              context7: {
+                command: 'npx',
+                args: ['-y', '@upstash/context7-mcp@latest'],
+                env: { CONTEXT7_API_KEY: 'placeholder' },
+              },
+            },
+          },
+        },
+      });
+    }
+
+    it('F3: workspace-only divergent context7 triggers conflict refusal', async () => {
+      const ctx = makeCtx();
+      const userPath = join(ctx.homeDir, '.claude.json');
+      const { writeFile, mkdir } = await import('node:fs/promises');
+      await mkdir(join(userPath, '..'), { recursive: true });
+      await writeFile(
+        userPath,
+        workspaceOnlyFixture(ctx.workspaceDir),
+        'utf-8',
+      );
+
+      const result = await claudeCode.mcp.write(ctx, {
+        servers: [
+          {
+            name: 'context7',
+            server: {
+              type: 'stdio',
+              command: 'npx',
+              args: ['-y', 'something-else'],
+            },
+          },
+        ],
+      });
+
+      expect(result.written).toBe(0);
+      expect(result.changed).toBe(false);
+      expect(result.conflicts).toBeDefined();
+      expect(result.conflicts?.[0]?.serverName).toBe('context7');
+      expect(result.conflicts?.[0]?.diffKeys).toContain('args');
+    });
+
+    it('F3: workspace overrides top-level on collision for the existing map', async () => {
+      // The same server name lives in both top-level and workspace-nested
+      // maps with divergent normalized shapes. The conflict check must
+      // compare canonical against the WORKSPACE entry (which wins on
+      // collision) — i.e., the workspace-divergent shape is what fires
+      // the conflict, not the top-level one.
+      const ctx = makeCtx();
+      const userPath = join(ctx.homeDir, '.claude.json');
+      const { writeFile, mkdir } = await import('node:fs/promises');
+      await mkdir(join(userPath, '..'), { recursive: true });
+      const fixtureBody = JSON.stringify({
+        numStartups: 42,
+        mcpServers: {
+          shared: {
+            command: 'top-cmd',
+            args: ['top'],
+          },
+        },
+        projects: {
+          [ctx.workspaceDir]: {
+            mcpServers: {
+              shared: {
+                command: 'ws-cmd',
+                args: ['ws-1', 'ws-2'],
+              },
+            },
+          },
+        },
+      });
+      await writeFile(userPath, fixtureBody, 'utf-8');
+
+      // Canonical matches the TOP-LEVEL entry exactly. With workspace-
+      // overrides-top-level, the existing map uses ws-cmd; canonical
+      // differs from ws-cmd (but matches top-cmd) → conflict fires
+      // against the workspace entry.
+      const result = await claudeCode.mcp.write(ctx, {
+        servers: [
+          {
+            name: 'shared',
+            server: { type: 'stdio', command: 'top-cmd', args: ['top'] },
+          },
+        ],
+      });
+
+      expect(result.conflicts).toBeDefined();
+      expect(result.conflicts?.[0]?.serverName).toBe('shared');
+      // workspace entry has command 'ws-cmd' vs canonical 'top-cmd' →
+      // command + args both differ.
+      expect(result.conflicts?.[0]?.diffKeys).toContain('command');
+    });
+
+    it('F3: top-level matching canonical proceeds byte-level (no-change)', async () => {
+      const ctx = makeCtx();
+      const projectPath = join(ctx.workspaceDir, '.mcp.json');
+      const { writeFile, mkdir } = await import('node:fs/promises');
+      await mkdir(join(projectPath, '..'), { recursive: true });
+      const matchingFixture = JSON.stringify({
+        mcpServers: {
+          filesystem: {
+            command: 'npx',
+            args: ['-y', '@scope/server'],
+          },
+        },
+      });
+      await writeFile(projectPath, matchingFixture, 'utf-8');
+
+      const result = await claudeCode.mcp.write(ctx, {
+        servers: [
+          {
+            name: 'filesystem',
+            server: {
+              type: 'stdio',
+              command: 'npx',
+              args: ['-y', '@scope/server'],
+            },
+          },
+        ],
+      });
+
+      expect(result.conflicts).toBeUndefined();
+      expect(result.reason).toBe('no-change');
     });
   });
 });

--- a/packages/agents/src/github-copilot-cli-write.ts
+++ b/packages/agents/src/github-copilot-cli-write.ts
@@ -16,18 +16,26 @@ import {
   type ParseError,
 } from 'jsonc-parser/lib/esm/main.js';
 import type { OvertureMcpServer } from '@overture/config';
-import { editJsoncMap } from './jsonc-map-write.js';
 import {
-  pickCopilotWriteTarget,
-  targetPathFor,
-} from './github-copilot-cli-write-helpers.js';
+  normalizeGitHubCopilotCliMcpServers,
+  type GitHubCopilotCliMcpConfig,
+} from './github-copilot-cli.js';
+import { editJsoncMap } from './jsonc-map-write.js';
+import { normalized } from './normalize-mcp-config.js';
+import { detectCanonicalSettingsDrift } from './parse-mcp-servers.js';
 import type {
+  AgentMcpReadResult,
   AgentMcpWriteInput,
   AgentMcpWriteResult,
+  AgentNormalizedMcpServer,
   McpLocationFormat,
   PathResolutionContext,
   WriteReason,
 } from './types.js';
+import {
+  pickCopilotWriteTarget,
+  targetPathFor,
+} from './github-copilot-cli-write-helpers.js';
 
 // ---------------------------------------------------------------------------
 // Types and converter
@@ -248,6 +256,41 @@ export async function writeGitHubCopilotCliMcpConfig(
   }
 
   const mcpServersObj = mcpServers as Record<string, unknown>;
+
+  // F3 conflict detection: build the existing normalized map from
+  // the read mcpServers container, compare against the canonical
+  // input, and refuse when any same-name pair differs in normalized
+  // shape. Detector invocation order is fixed per the F3 design
+  // contract: read → normalize → compare → refuse-or-proceed. Runs
+  // AFTER shape validation and BEFORE any per-server patch building
+  // so the writer never reads-then-rewrites a divergent entry.
+  const existingRead: AgentMcpReadResult<GitHubCopilotCliMcpConfig> = {
+    config: {
+      mcpServers: mcpServersObj as GitHubCopilotCliMcpConfig['mcpServers'],
+    },
+    nonEmpty: Object.keys(mcpServersObj).length > 0,
+  };
+  const existingNormalizedRecord =
+    normalizeGitHubCopilotCliMcpServers(existingRead);
+  const existingMap = new Map<string, AgentNormalizedMcpServer>(
+    Object.entries(existingNormalizedRecord),
+  );
+  const canonicalMap = new Map<string, AgentNormalizedMcpServer>(
+    input.servers.map((s) => [s.name, normalized(s.server)]),
+  );
+  const conflicts = detectCanonicalSettingsDrift(existingMap, canonicalMap);
+  if (conflicts.length > 0) {
+    return {
+      written: 0,
+      changed: false,
+      dryRun,
+      serversWritten: [],
+      targetPaths: [targetPathFor(target)],
+      resolvedPath: targetPath,
+      format: 'jsonc' as McpLocationFormat,
+      conflicts,
+    };
+  }
 
   // Check all requested servers exist in the container (update-only: no creation)
   for (const entry of input.servers) {

--- a/packages/agents/src/github-copilot-cli.write.spec.ts
+++ b/packages/agents/src/github-copilot-cli.write.spec.ts
@@ -555,7 +555,7 @@ describe('githubCopilotCli.mcp.write (E3 byte-splice)', () => {
   // Metadata envelope — changed update
   // -------------------------------------------------------------------------
 
-  it('changed update returns written:1, changed:true, dryRun:false, serversWritten, targetPaths, resolvedPath, format:jsonc, bytesChanged > 0', async () => {
+  it('F3: divergent canonical triggers conflict refusal with written:0, changed:false, conflicts populated', async () => {
     const home = await tmp();
     const ws = await tmp();
     try {
@@ -573,14 +573,17 @@ describe('githubCopilotCli.mcp.write (E3 byte-splice)', () => {
       const res = await githubCopilotCli.mcp.write(ctx, {
         servers: [{ name: 'filesystem', server: updatedFs }],
       });
-      expect(res.written).toBe(1);
-      expect(res.changed).toBe(true);
+      // F3 supersedes the pre-F3 "changed update" envelope: divergent
+      // settings refuse the write before byte-level planning.
+      expect(res.written).toBe(0);
+      expect(res.changed).toBe(false);
       expect(res.dryRun).toBe(false);
-      expect(res.serversWritten).toEqual(['filesystem']);
+      expect(res.serversWritten).toEqual([]);
       expect(res.targetPaths).toHaveLength(1);
       expect(res.resolvedPath).toContain('.github/mcp.json');
       expect(res.format).toBe('jsonc');
-      expect(res.bytesChanged).toBeGreaterThan(0);
+      expect(res.conflicts).toBeDefined();
+      expect(res.conflicts?.[0]?.serverName).toBe('filesystem');
     } finally {
       await rm(home, { recursive: true, force: true });
       await rm(ws, { recursive: true, force: true });
@@ -627,7 +630,7 @@ describe('githubCopilotCli.mcp.write (E3 byte-splice)', () => {
   // Metadata envelope — dry-run
   // -------------------------------------------------------------------------
 
-  it('dry-run returns planned metadata and leaves disk unchanged', async () => {
+  it('F3: dry-run divergent canonical triggers conflict refusal and leaves disk unchanged', async () => {
     const home = await tmp();
     const ws = await tmp();
     try {
@@ -645,12 +648,12 @@ describe('githubCopilotCli.mcp.write (E3 byte-splice)', () => {
         dryRun: true,
       });
       expect(res.dryRun).toBe(true);
-      expect(res.written).toBe(1);
-      expect(res.changed).toBe(true);
-      expect(res.serversWritten).toEqual(['filesystem']);
+      expect(res.written).toBe(0);
+      expect(res.changed).toBe(false);
+      expect(res.conflicts).toBeDefined();
+      expect(res.conflicts?.[0]?.serverName).toBe('filesystem');
       expect(res.targetPaths).toHaveLength(1);
       expect(res.format).toBe('jsonc');
-      expect(res.bytesChanged).toBeGreaterThan(0);
       const after = await readFile(fixturePath, 'utf-8');
       expect(after).toBe(before);
     } finally {
@@ -663,7 +666,7 @@ describe('githubCopilotCli.mcp.write (E3 byte-splice)', () => {
   // Extension preservation
   // -------------------------------------------------------------------------
 
-  it('native extension fields tools and cwd are preserved across a server value update', async () => {
+  it('F3: divergent canonical with native extension fields triggers conflict refusal (extensions not overwritten)', async () => {
     const home = await tmp();
     const ws = await tmp();
     try {
@@ -683,7 +686,9 @@ describe('githubCopilotCli.mcp.write (E3 byte-splice)', () => {
       const res = await githubCopilotCli.mcp.write(ctx, {
         servers: [{ name: 'filesystem', server: updatedFs }],
       });
-      expect(res.changed).toBe(true);
+      // F3 refuses divergent settings — extension fields stay on disk.
+      expect(res.changed).toBe(false);
+      expect(res.conflicts).toBeDefined();
       const fixturePath = join(ws, '.github', 'mcp.json');
       const written = JSON.parse(await readFile(fixturePath, 'utf-8'));
       const fsEntry = written.mcpServers['filesystem'];
@@ -695,7 +700,7 @@ describe('githubCopilotCli.mcp.write (E3 byte-splice)', () => {
     }
   });
 
-  it('unknown JSON-compatible extension keys inside a server entry are preserved', async () => {
+  it('F3: divergent canonical with unknown JSON-compatible extensions triggers conflict refusal (extensions preserved on disk)', async () => {
     const home = await tmp();
     const ws = await tmp();
     try {
@@ -714,7 +719,9 @@ describe('githubCopilotCli.mcp.write (E3 byte-splice)', () => {
       const res = await githubCopilotCli.mcp.write(ctx, {
         servers: [{ name: 'context7', server: updatedCtx7 }],
       });
-      expect(res.changed).toBe(true);
+      // F3 refuses divergent settings — unknown extensions stay on disk.
+      expect(res.changed).toBe(false);
+      expect(res.conflicts).toBeDefined();
       const fixturePath = join(ws, '.github', 'mcp.json');
       const written = JSON.parse(await readFile(fixturePath, 'utf-8'));
       const ctx7Entry = written.mcpServers['context7'];
@@ -970,6 +977,62 @@ describe('githubCopilotCli.mcp.write (E3 byte-splice)', () => {
       } finally {
         writeSpy.mockRestore();
       }
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // F3: conflict refusal + matching-case spec
+  // -------------------------------------------------------------------------
+
+  it('F3: divergent canonical triggers conflict refusal (written:0, changed:false, conflicts populated)', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedWorkspaceFixture(ws);
+      const ctx = makeCtx(home, ws);
+      const divergentFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'pnpm',
+        args: ['-y', 'different-server'],
+      };
+      const res = await githubCopilotCli.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: divergentFs }],
+      });
+      expect(res.written).toBe(0);
+      expect(res.changed).toBe(false);
+      expect(res.serversWritten).toEqual([]);
+      expect(res.conflicts).toBeDefined();
+      expect(res.conflicts?.[0]?.serverName).toBe('filesystem');
+      expect(res.conflicts?.[0]?.diffKeys).toContain('command');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('F3: matching canonical proceeds byte-level (no-change)', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedWorkspaceFixture(ws);
+      const ctx = makeCtx(home, ws);
+      const matchingFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'npx',
+        args: [
+          '-y',
+          '@modelcontextprotocol/server-filesystem',
+          '/home/user/projects',
+        ],
+      };
+      const res = await githubCopilotCli.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: matchingFs }],
+      });
+      expect(res.conflicts).toBeUndefined();
+      expect(res.reason).toBe('no-change');
     } finally {
       await rm(home, { recursive: true, force: true });
       await rm(ws, { recursive: true, force: true });

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -59,6 +59,7 @@ export type {
   PlatformRegistryEntry,
   PathResolutionContext,
   HostPlatform,
+  ServerConflict,
 } from './types.js';
 
 export {

--- a/packages/agents/src/openai-codex-write.ts
+++ b/packages/agents/src/openai-codex-write.ts
@@ -22,6 +22,12 @@
  *    range the splice helper computes.
  */
 import type { OvertureMcpServer } from '@overture/config';
+import {
+  normalizeOpenAICodexMcpServers,
+  type OpenAICodexMcpConfig,
+} from './openai-codex.js';
+import { normalized } from './normalize-mcp-config.js';
+import { detectCanonicalSettingsDrift } from './parse-mcp-servers.js';
 
 // ---------------------------------------------------------------------------
 // Sentinel for unsupported extension shapes
@@ -459,8 +465,10 @@ import {
   type CodexWriteTarget,
 } from './openai-codex-write-helpers.js';
 import type {
+  AgentMcpReadResult,
   AgentMcpWriteInput,
   AgentMcpWriteResult,
+  AgentNormalizedMcpServer,
   McpLocationFormat,
   PathResolutionContext,
   WriteReason,
@@ -800,6 +808,42 @@ export async function writeOpenAICodexMcpConfig(
   }
 
   const mcpServersObj = mcpServers as Record<string, unknown>;
+
+  // F3 conflict detection: build the existing normalized map from
+  // the parsed `[mcp_servers.<name>]` TOML tables, compare against
+  // the canonical input, and refuse when any same-name pair differs
+  // in normalized shape. Detector invocation order is fixed per the
+  // F3 design contract: read → parse / shape-validate → normalize →
+  // compare → refuse-or-proceed. Runs AFTER TOML parse + shape
+  // validation and the update-only existence check, BEFORE any
+  // per-server patch building so the writer never reads-then-rewrites
+  // a divergent entry.
+  const existingRead: AgentMcpReadResult<OpenAICodexMcpConfig> = {
+    config: {
+      mcp_servers: mcpServersObj as OpenAICodexMcpConfig['mcp_servers'],
+    },
+    nonEmpty: Object.keys(mcpServersObj).length > 0,
+  };
+  const existingNormalizedRecord = normalizeOpenAICodexMcpServers(existingRead);
+  const existingMap = new Map<string, AgentNormalizedMcpServer>(
+    Object.entries(existingNormalizedRecord),
+  );
+  const canonicalMap = new Map<string, AgentNormalizedMcpServer>(
+    input.servers.map((s) => [s.name, normalized(s.server)]),
+  );
+  const conflicts = detectCanonicalSettingsDrift(existingMap, canonicalMap);
+  if (conflicts.length > 0) {
+    return {
+      written: 0,
+      changed: false,
+      dryRun,
+      serversWritten: [],
+      targetPaths: [targetPathFor(target)],
+      resolvedPath: target.path,
+      format: 'toml' as McpLocationFormat,
+      conflicts,
+    };
+  }
 
   // Update-only: every requested server must already exist in the
   // target document. Missing names are rejected with not-targetable

--- a/packages/agents/src/openai-codex.write.spec.ts
+++ b/packages/agents/src/openai-codex.write.spec.ts
@@ -383,7 +383,7 @@ describe('openaiCodex.mcp.write (E4 byte-splice)', () => {
   // Metadata envelope — dry-run
   // -------------------------------------------------------------------------
 
-  it('dry-run leaves disk unchanged', async () => {
+  it('F3: dry-run divergent canonical triggers conflict refusal and leaves disk unchanged', async () => {
     const home = await tmp();
     const ws = await tmp();
     try {
@@ -401,12 +401,12 @@ describe('openaiCodex.mcp.write (E4 byte-splice)', () => {
         dryRun: true,
       });
       expect(res.dryRun).toBe(true);
-      expect(res.written).toBe(1);
-      expect(res.changed).toBe(true);
-      expect(res.serversWritten).toEqual(['filesystem']);
+      expect(res.written).toBe(0);
+      expect(res.changed).toBe(false);
+      expect(res.conflicts).toBeDefined();
+      expect(res.conflicts?.[0]?.serverName).toBe('filesystem');
       expect(res.targetPaths).toHaveLength(1);
       expect(res.format).toBe('toml');
-      expect(res.bytesChanged).toBeGreaterThan(0);
       const after = await readFile(fixturePath, 'utf-8');
       expect(after).toBe(before);
     } finally {
@@ -455,7 +455,7 @@ describe('openaiCodex.mcp.write (E4 byte-splice)', () => {
   // Metadata envelope — changed update (stdio)
   // -------------------------------------------------------------------------
 
-  it('changed stdio update returns full metadata (format: toml)', async () => {
+  it('F3: divergent stdio update triggers conflict refusal (format: toml)', async () => {
     const home = await tmp();
     const ws = await tmp();
     try {
@@ -473,14 +473,16 @@ describe('openaiCodex.mcp.write (E4 byte-splice)', () => {
       const res = await openaiCodex.mcp.write(ctx, {
         servers: [{ name: 'filesystem', server: updatedFs }],
       });
-      expect(res.written).toBe(1);
-      expect(res.changed).toBe(true);
+      expect(res.written).toBe(0);
+      expect(res.changed).toBe(false);
       expect(res.dryRun).toBe(false);
-      expect(res.serversWritten).toEqual(['filesystem']);
+      expect(res.serversWritten).toEqual([]);
       expect(res.targetPaths).toHaveLength(1);
       expect(res.resolvedPath).toContain('.codex/config.toml');
       expect(res.format).toBe('toml');
-      expect(res.bytesChanged).toBeGreaterThan(0);
+      expect(res.conflicts).toBeDefined();
+      expect(res.conflicts?.[0]?.serverName).toBe('filesystem');
+      expect(res.conflicts?.[0]?.diffKeys).toContain('args');
     } finally {
       await rm(home, { recursive: true, force: true });
       await rm(ws, { recursive: true, force: true });
@@ -491,7 +493,7 @@ describe('openaiCodex.mcp.write (E4 byte-splice)', () => {
   // Metadata envelope — changed update (remote)
   // -------------------------------------------------------------------------
 
-  it('changed remote update returns full metadata (format: toml)', async () => {
+  it('F3: divergent remote update (transport switch) triggers conflict refusal', async () => {
     const home = await tmp();
     const ws = await tmp();
     try {
@@ -505,13 +507,16 @@ describe('openaiCodex.mcp.write (E4 byte-splice)', () => {
       const res = await openaiCodex.mcp.write(ctx, {
         servers: [{ name: 'filesystem', server: updatedRemote }],
       });
-      expect(res.written).toBe(1);
-      expect(res.changed).toBe(true);
-      expect(res.dryRun).toBe(false);
-      expect(res.serversWritten).toEqual(['filesystem']);
+      // Transport switch is a multi-key drift (type, command, args,
+      // url, headers). F3 refuses this before byte-level planning.
+      expect(res.written).toBe(0);
+      expect(res.changed).toBe(false);
+      expect(res.serversWritten).toEqual([]);
       expect(res.targetPaths).toHaveLength(1);
       expect(res.format).toBe('toml');
-      expect(res.bytesChanged).toBeGreaterThan(0);
+      expect(res.conflicts).toBeDefined();
+      expect(res.conflicts?.[0]?.serverName).toBe('filesystem');
+      expect(res.conflicts?.[0]?.diffKeys).toContain('type');
     } finally {
       await rm(home, { recursive: true, force: true });
       await rm(ws, { recursive: true, force: true });
@@ -641,7 +646,7 @@ describe('openaiCodex.mcp.write (E4 byte-splice)', () => {
   // Non-contiguous descendant layout
   // -------------------------------------------------------------------------
 
-  it('non-contiguous descendant layout returns unsupported-shape', async () => {
+  it('non-contiguous descendant layout returns unsupported-shape (matching canonical)', async () => {
     const home = await tmp();
     const ws = await tmp();
     try {
@@ -665,15 +670,24 @@ FOO_API_KEY = "\${FOO_API_KEY}"
 `;
       await seedUserConfig(home, nestedToml);
       const ctx = makeCtx(home, ws);
+      // Canonical MUST match existing's normalized shape (foo carries
+      // the FOO_API_KEY env var) so F3 passes; the non-contiguous
+      // check then catches the layout as unsupported-shape.
       const res = await openaiCodex.mcp.write(ctx, {
         servers: [
           {
             name: 'foo',
-            server: { type: 'stdio', command: 'npx', args: ['-y', 'foo-mcp'] },
+            server: {
+              type: 'stdio',
+              command: 'npx',
+              args: ['-y', 'foo-mcp'],
+              env: { FOO_API_KEY: '\${FOO_API_KEY}' },
+            },
           },
         ],
       });
       expect(res.reason).toBe('unsupported-shape');
+      expect(res.conflicts).toBeUndefined();
     } finally {
       await rm(home, { recursive: true, force: true });
       await rm(ws, { recursive: true, force: true });
@@ -684,7 +698,7 @@ FOO_API_KEY = "\${FOO_API_KEY}"
   // Transport switch drops incompatible fields
   // -------------------------------------------------------------------------
 
-  it('transport switch drops incompatible fields', async () => {
+  it('F3: transport switch is a multi-key drift and triggers conflict refusal', async () => {
     const home = await tmp();
     const ws = await tmp();
     try {
@@ -699,18 +713,79 @@ FOO_API_KEY = "\${FOO_API_KEY}"
       const res = await openaiCodex.mcp.write(ctx, {
         servers: [{ name: 'filesystem', server: remoteServer }],
       });
-      expect(res.changed).toBe(true);
-      expect(res.written).toBe(1);
-      // After transport switch, the written entry should have url but not command/args
+      // F3 refuses the transport switch before byte-level planning;
+      // the original stdio entry stays on disk.
+      expect(res.changed).toBe(false);
+      expect(res.written).toBe(0);
+      expect(res.conflicts).toBeDefined();
+      expect(res.conflicts?.[0]?.serverName).toBe('filesystem');
+      expect(res.conflicts?.[0]?.diffKeys).toEqual(
+        expect.arrayContaining(['type', 'command', 'args', 'url']),
+      );
+      // The original stdio entry stays on disk.
       const fixturePath = join(home, '.codex', 'config.toml');
       const written = await readFile(fixturePath, 'utf-8');
-      expect(written).toContain('url');
-      // Verify the filesystem block specifically has no command = (not just any server in the file)
       const filesystemBlock =
         written
           .split('[mcp_servers.filesystem]')[1]
           ?.split(/\[mcp_servers\.\w+\]/)[0] ?? '';
-      expect(filesystemBlock).not.toMatch(/^\s*command\s*=/m);
+      expect(filesystemBlock).not.toMatch(/^\s*url\s*=/m);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // F3: conflict refusal + matching-case spec
+  // -------------------------------------------------------------------------
+
+  it('F3: divergent canonical triggers conflict refusal (written:0, changed:false, conflicts populated)', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const divergentFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'pnpm',
+        args: ['-y', 'different-server'],
+      };
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: divergentFs }],
+      });
+      expect(res.written).toBe(0);
+      expect(res.changed).toBe(false);
+      expect(res.serversWritten).toEqual([]);
+      expect(res.conflicts).toBeDefined();
+      expect(res.conflicts?.[0]?.serverName).toBe('filesystem');
+      expect(res.conflicts?.[0]?.diffKeys).toContain('command');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it('F3: matching canonical proceeds byte-level (no-change)', async () => {
+    const home = await tmp();
+    const ws = await tmp();
+    try {
+      await seedUserConfig(home, CODEX_FIXTURE);
+      const ctx = makeCtx(home, ws);
+      const matchingFs: OvertureMcpServer = {
+        type: 'stdio',
+        command: 'npx',
+        args: [
+          '-y',
+          '@modelcontextprotocol/server-filesystem',
+          '/home/user/projects',
+        ],
+      };
+      const res = await openaiCodex.mcp.write(ctx, {
+        servers: [{ name: 'filesystem', server: matchingFs }],
+      });
+      expect(res.conflicts).toBeUndefined();
+      expect(res.reason).toBe('no-change');
     } finally {
       await rm(home, { recursive: true, force: true });
       await rm(ws, { recursive: true, force: true });

--- a/packages/agents/src/opencode-write.ts
+++ b/packages/agents/src/opencode-write.ts
@@ -214,6 +214,66 @@ function safeParseNodeValue(text: string, node: Node): unknown {
   }
 }
 
+/**
+ * Parsed view of the on-disk target. The byte-level planner
+ * (`planEdits`) and the F3 conflict detector both consume this shape,
+ * which guarantees the detector sees exactly the same `existingServers`
+ * map that the planner later writes. The F3 design contract fixes the
+ * order — read → normalize → compare → refuse-or-proceed — so the
+ * detector must run BEFORE `planEdits`.
+ */
+interface ParsedTarget {
+  readonly root: Node;
+  readonly mcpNode: Node | undefined;
+  readonly existingServers: Readonly<Record<string, OpenCodeMcpServer>>;
+}
+
+/**
+ * Parse the on-disk JSONC target and lift the existing server entries
+ * out of the `mcp` map. Returns `{ parseError: true }` when the
+ * document is unparseable or not a top-level object (the F3 design
+ * contract emits `reason: 'parse-error'` for both shapes; the planner
+ * never runs in that case).
+ *
+ * `existingServers` is the same `Record<string, OpenCodeMcpServer>`
+ * shape `planEdits` previously produced internally; lifting it here
+ * lets the detector see exactly what the planner will see.
+ */
+function parseTarget(
+  text: string,
+  mcpKey: string,
+): ParsedTarget | { readonly parseError: true } {
+  const errors: ParseError[] = [];
+  const root = parseTree(text, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  if (errors.length > 0 || root === undefined || root.type !== 'object') {
+    return { parseError: true };
+  }
+  const mcpProperty = findChildProperty(root, mcpKey);
+  const mcpNode =
+    mcpProperty !== undefined && mcpProperty.children !== undefined
+      ? mcpProperty.children[1]
+      : undefined;
+
+  const existingServers: Record<string, OpenCodeMcpServer> = {};
+  if (mcpNode !== undefined && mcpNode.type === 'object') {
+    for (const prop of mcpNode.children ?? []) {
+      if (prop.type !== 'property' || prop.children === undefined) continue;
+      const keyNode = prop.children[0];
+      const valueNode = prop.children[1];
+      if (keyNode === undefined || valueNode === undefined) continue;
+      const name = String(keyNode.value);
+      const parsed = safeParseNodeValue(text, valueNode);
+      if (parsed !== undefined && isObject(parsed)) {
+        existingServers[name] = parsed as unknown as OpenCodeMcpServer;
+      }
+    }
+  }
+  return { root, mcpNode, existingServers };
+}
+
 function findServerPropertyRange(
   mcpNode: Node,
   text: string,
@@ -304,52 +364,18 @@ interface PlanResult {
   readonly written: string;
   readonly changed: boolean;
   readonly touched: readonly string[];
-  /**
-   * Native existing-server map parsed out of the on-disk target.
-   * Returned alongside the plan so the F3 conflict detector can
-   * normalize both sides (existing + canonical) before byte-level
-   * planning runs. `undefined` when no `mcp` value node existed in
-   * the target.
-   */
-  readonly existingServers: Readonly<Record<string, OpenCodeMcpServer>>;
 }
 
 function planEdits(args: {
   readonly text: string;
+  readonly parsed: ParsedTarget;
   readonly input: readonly {
     readonly name: string;
     readonly server: OpenCodeMcpServer;
   }[];
-  readonly mcpKey: string;
-}): PlanResult | { readonly parseError: true } {
-  const errors: ParseError[] = [];
-  const root = parseTree(args.text, errors, {
-    allowTrailingComma: true,
-    disallowComments: false,
-  });
-  if (errors.length > 0 || root === undefined || root.type !== 'object') {
-    return { parseError: true };
-  }
-  const mcpProperty = findChildProperty(root, args.mcpKey);
-  const mcpValueNode =
-    mcpProperty !== undefined && mcpProperty.children !== undefined
-      ? mcpProperty.children[1]
-      : undefined;
-
-  const existingServers: Record<string, OpenCodeMcpServer> = {};
-  if (mcpValueNode !== undefined && mcpValueNode.type === 'object') {
-    for (const prop of mcpValueNode.children ?? []) {
-      if (prop.type !== 'property' || prop.children === undefined) continue;
-      const keyNode = prop.children[0];
-      const valueNode = prop.children[1];
-      if (keyNode === undefined || valueNode === undefined) continue;
-      const name = String(keyNode.value);
-      const parsed = safeParseNodeValue(args.text, valueNode);
-      if (parsed !== undefined && isObject(parsed)) {
-        existingServers[name] = parsed as unknown as OpenCodeMcpServer;
-      }
-    }
-  }
+}): PlanResult {
+  const { root, mcpNode: mcpValueNode } = args.parsed;
+  const existingServers = args.parsed.existingServers;
 
   const edits: PlannedEdit[] = [];
   const touched: string[] = [];
@@ -396,9 +422,17 @@ function planEdits(args: {
       }
     }
   } else {
-    if (root.type !== 'object') return { parseError: true };
     const body = mcpObjectBodyRange(root, args.text);
-    if (body === null) return { parseError: true };
+    if (body === null) {
+      // Root was already validated by `parseTarget`; this branch only
+      // fires when the mcp container is missing. The byte-level splice
+      // is the same as before: synthesize an empty top-level body.
+      return {
+        written: args.text,
+        changed: false,
+        touched: [],
+      };
+    }
     const indent = detectIndent(args.text, root);
     const mcpObj: Record<string, OpenCodeMcpServer> = {};
     for (const entry of args.input) {
@@ -414,7 +448,7 @@ function planEdits(args: {
     }
     const rendered = renderServer(mcpObj);
     const indented = indentMultiLine(rendered, indent);
-    const spliceText = `${indent}${JSON.stringify(args.mcpKey)}: ${indented},\n`;
+    const spliceText = `${indent}${JSON.stringify('mcp')}: ${indented},\n`;
     const lastChild = root.children?.[root.children.length - 1];
     const insertAt = findInsertionPoint(args.text, body, lastChild);
     edits.push({ start: insertAt, end: insertAt, replacement: spliceText });
@@ -426,14 +460,12 @@ function planEdits(args: {
       written: args.text,
       changed: false,
       touched: [],
-      existingServers,
     };
   }
   return {
     written: applyEdits(args.text, edits),
     changed: true,
     touched,
-    existingServers,
   };
 }
 
@@ -517,20 +549,13 @@ export async function opencodeWriteMcpConfig(
     };
   }
 
-  // Convert the writer input into the canonical form the planner consumes.
-  // The planner only needs (name, server) pairs.
-  const planned = planEdits({
-    text: original,
-    mcpKey,
-    input: input.servers.map((s) => {
-      // toOpenCodeMcpServer is called inside the planner, but the planner
-      // doesn't have access to the raw canonical server — pre-compute the
-      // native shape here and pass it through. The planner still re-derives
-      // it for extension preservation against existing entries.
-      return { name: s.name, server: toOpenCodeMcpServer(s.server) };
-    }),
-  });
-  if ('parseError' in planned) {
+  // Parse the on-disk target first so the F3 detector sees the same
+  // existing-server map the byte-level planner will consume. The order
+  // is fixed per the F3 design contract: read → normalize → compare →
+  // refuse-or-proceed. Detection runs BEFORE `planEdits` so a divergent
+  // entry never reaches the byte-level splice path.
+  const parsed = parseTarget(original, mcpKey);
+  if ('parseError' in parsed) {
     return {
       written: 0,
       changed: false,
@@ -543,15 +568,9 @@ export async function opencodeWriteMcpConfig(
     };
   }
 
-  // F3: detect canonical settings drift BEFORE byte-level planning
-  // proceeds. `planEdits` already parsed the existing target entries;
-  // we reuse that work to build the existing normalized map, compare
-  // against the canonical input, and refuse when any same-name pair
-  // differs in normalized shape. The order is fixed per the F3 design
-  // contract: read → normalize → compare → refuse-or-proceed.
   const existingRead: AgentMcpReadResult<OpenCodeMcpConfig> = {
-    config: { mcp: planned.existingServers },
-    nonEmpty: Object.keys(planned.existingServers).length > 0,
+    config: { mcp: parsed.existingServers },
+    nonEmpty: Object.keys(parsed.existingServers).length > 0,
   };
   const existingNormalized = normalizeOpenCodeMcpServers(existingRead);
   const existingMap = new Map<string, AgentNormalizedMcpServer>(
@@ -573,6 +592,20 @@ export async function opencodeWriteMcpConfig(
       conflicts,
     };
   }
+
+  // Convert the writer input into the canonical form the planner consumes.
+  // The planner only needs (name, server) pairs.
+  const planned = planEdits({
+    text: original,
+    parsed,
+    input: input.servers.map((s) => {
+      // toOpenCodeMcpServer is called inside the planner, but the planner
+      // doesn't have access to the raw canonical server — pre-compute the
+      // native shape here and pass it through. The planner still re-derives
+      // it for extension preservation against existing entries.
+      return { name: s.name, server: toOpenCodeMcpServer(s.server) };
+    }),
+  });
 
   if (!planned.changed) {
     return {

--- a/packages/agents/src/opencode-write.ts
+++ b/packages/agents/src/opencode-write.ts
@@ -17,11 +17,19 @@ import {
   type ParseError,
 } from 'jsonc-parser/lib/esm/main.js';
 import type { OvertureMcpServer } from '@overture/config';
-import { opencode } from './opencode.js';
-import type { OpenCodeMcpServer } from './opencode.js';
+import {
+  normalizeOpenCodeMcpServers,
+  opencode,
+  type OpenCodeMcpConfig,
+  type OpenCodeMcpServer,
+} from './opencode.js';
+import { normalized } from './normalize-mcp-config.js';
+import { detectCanonicalSettingsDrift } from './parse-mcp-servers.js';
 import type {
+  AgentMcpReadResult,
   AgentMcpWriteInput,
   AgentMcpWriteResult,
+  AgentNormalizedMcpServer,
   McpLocation,
   McpLocationFormat,
   PathResolutionContext,
@@ -296,6 +304,14 @@ interface PlanResult {
   readonly written: string;
   readonly changed: boolean;
   readonly touched: readonly string[];
+  /**
+   * Native existing-server map parsed out of the on-disk target.
+   * Returned alongside the plan so the F3 conflict detector can
+   * normalize both sides (existing + canonical) before byte-level
+   * planning runs. `undefined` when no `mcp` value node existed in
+   * the target.
+   */
+  readonly existingServers: Readonly<Record<string, OpenCodeMcpServer>>;
 }
 
 function planEdits(args: {
@@ -406,12 +422,18 @@ function planEdits(args: {
   }
 
   if (edits.length === 0) {
-    return { written: args.text, changed: false, touched: [] };
+    return {
+      written: args.text,
+      changed: false,
+      touched: [],
+      existingServers,
+    };
   }
   return {
     written: applyEdits(args.text, edits),
     changed: true,
     touched,
+    existingServers,
   };
 }
 
@@ -518,6 +540,37 @@ export async function opencodeWriteMcpConfig(
       resolvedPath,
       format: loc.format,
       reason: 'parse-error',
+    };
+  }
+
+  // F3: detect canonical settings drift BEFORE byte-level planning
+  // proceeds. `planEdits` already parsed the existing target entries;
+  // we reuse that work to build the existing normalized map, compare
+  // against the canonical input, and refuse when any same-name pair
+  // differs in normalized shape. The order is fixed per the F3 design
+  // contract: read → normalize → compare → refuse-or-proceed.
+  const existingRead: AgentMcpReadResult<OpenCodeMcpConfig> = {
+    config: { mcp: planned.existingServers },
+    nonEmpty: Object.keys(planned.existingServers).length > 0,
+  };
+  const existingNormalized = normalizeOpenCodeMcpServers(existingRead);
+  const existingMap = new Map<string, AgentNormalizedMcpServer>(
+    Object.entries(existingNormalized),
+  );
+  const canonicalMap = new Map<string, AgentNormalizedMcpServer>(
+    input.servers.map((s) => [s.name, normalized(s.server)]),
+  );
+  const conflicts = detectCanonicalSettingsDrift(existingMap, canonicalMap);
+  if (conflicts.length > 0) {
+    return {
+      written: 0,
+      changed: false,
+      dryRun,
+      serversWritten: [],
+      targetPaths,
+      resolvedPath,
+      format: loc.format,
+      conflicts,
     };
   }
 

--- a/packages/agents/src/opencode.write.spec.ts
+++ b/packages/agents/src/opencode.write.spec.ts
@@ -377,36 +377,30 @@ describe('E1 — opencode.mcp.write preserves OpenCode JSONC', () => {
     ).toBe(true);
   });
 
-  // Regression for the F2 / Case 14 key-drop bug. The historical
-  // `findServerPropertyRange` returned a range that covered the WHOLE
-  // property (key + value + trailing comma); the replacement
-  // (`renderServer(next)` = JSON.stringify(value, null, 2)) was value-only,
-  // so the property key vanished on update. A stdio canonical updating
-  // an existing local entry produced `{\n  "type": "remote"\n}` in
-  // place of the value, leaving the JSON malformed. The fix narrows
-  // the range to the value node only; this test pins the new contract
-  // with a direct fs-level assertion (independent of the harness) so
-  // a regression cannot hide behind harness lenience.
-  it('opencode writer: existing local entry updated by stdio canonical preserves the property key', async () => {
+  // F3 conflict refusal: a divergent canonical entry refuses the write
+  // BEFORE any byte-level splice runs, so the original file is left
+  // untouched. The previous F2 regression test (key-drop bug) used the
+  // same divergent fixture shape; under F3 that scenario now produces
+  // a conflict refusal rather than a splice. The byte-level fix is
+  // still covered by the matching-case tests below and by the
+  // preservation harness against the OPENCODE_FIXTURE.
+  it('F3: opencode writer refuses divergent canonical settings and leaves the file untouched', async () => {
     const ctx = makeCtx();
     const fixturePath = join(ctx.configDir, 'opencode', 'opencode.json');
     await mkdir(join(ctx.configDir, 'opencode'), { recursive: true });
-    await writeFile(
-      fixturePath,
-      JSON.stringify(
-        {
-          mcp: {
-            filesystem: { type: 'local', command: ['old'] },
-            context7: { type: 'local', command: ['ctx'] },
-          },
+    const seededBody = JSON.stringify(
+      {
+        mcp: {
+          filesystem: { type: 'local', command: ['old'] },
+          context7: { type: 'local', command: ['ctx'] },
         },
-        null,
-        2,
-      ),
-      'utf8',
+      },
+      null,
+      2,
     );
+    await writeFile(fixturePath, seededBody, 'utf8');
 
-    await opencode.mcp.write(ctx, {
+    const result = await opencode.mcp.write(ctx, {
       servers: [
         {
           name: 'filesystem',
@@ -419,27 +413,63 @@ describe('E1 — opencode.mcp.write preserves OpenCode JSONC', () => {
       ],
     });
 
+    // F3 acceptance: conflict populated, no writes, no change.
+    expect(result.written).toBe(0);
+    expect(result.changed).toBe(false);
+    expect(result.serversWritten).toEqual([]);
+    expect(result.dryRun).toBe(false);
+    expect(result.conflicts).toBeDefined();
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts?.[0]?.serverName).toBe('filesystem');
+    expect(result.conflicts?.[0]?.diffKeys).toContain('command');
+
+    // File untouched: original bytes preserved, no .bak.* created.
     const written = await readFile(fixturePath, 'utf8');
-    // The property key must still be present (regression of the F2
-    // key-drop: writer was splicing over the entire property).
+    expect(written).toBe(seededBody);
     expect(written).toContain('"filesystem"');
     expect(written).toContain('"context7"');
-    // Re-parse the written file to assert it's still valid JSON
-    // (the historical bug left the document malformed).
-    expect(() => JSON.parse(written)).not.toThrow();
-    const parsed = JSON.parse(written) as {
-      mcp: Record<string, unknown>;
-    };
-    expect(parsed.mcp).toHaveProperty('filesystem');
-    expect(parsed.mcp).toHaveProperty('context7');
-    // The filesystem entry should now reflect the canonical stdio →
-    // local conversion: command vector = ['node', '/tmp/foo'].
-    const fs = parsed.mcp.filesystem as {
-      type: string;
-      command: string[];
-    };
-    expect(fs.type).toBe('local');
-    expect(fs.command).toEqual(['node', '/tmp/foo']);
+  });
+
+  // F3 matching case: when the canonical and existing normalize to the
+  // same shape, the byte-level plan proceeds normally. Here we set the
+  // existing entry to match the canonical-after-native-conversion
+  // exactly, so planEdits produces zero edits and the result is
+  // `no-change` (no real byte difference).
+  it('F3: opencode writer proceeds when canonical matches existing normalized shape (no-change)', async () => {
+    const ctx = makeCtx();
+    const fixturePath = join(ctx.configDir, 'opencode', 'opencode.json');
+    await mkdir(join(ctx.configDir, 'opencode'), { recursive: true });
+    const matchingFixture = JSON.stringify(
+      {
+        mcp: {
+          filesystem: {
+            type: 'local',
+            command: ['node', '/tmp/foo'],
+          },
+        },
+      },
+      null,
+      2,
+    );
+    await writeFile(fixturePath, matchingFixture, 'utf8');
+
+    const result = await opencode.mcp.write(ctx, {
+      servers: [
+        {
+          name: 'filesystem',
+          server: {
+            type: 'stdio',
+            command: 'node',
+            args: ['/tmp/foo'],
+          },
+        },
+      ],
+    });
+
+    expect(result.conflicts).toBeUndefined();
+    expect(result.written).toBe(0);
+    expect(result.changed).toBe(false);
+    expect(result.reason).toBe('no-change');
   });
 
   it('preserves OpenCode JSONC: adding a new remote server target path fails rawBytes (insert case)', async () => {

--- a/packages/agents/src/parse-mcp-servers.spec.ts
+++ b/packages/agents/src/parse-mcp-servers.spec.ts
@@ -6,7 +6,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { AgentNormalizedMcpServer } from './types.js';
 import {
+  detectCanonicalSettingsDrift,
   parseJsoncMcpServerMap,
   parseTomlMcpServerMap,
   parseYamlMcpServerList,
@@ -317,5 +319,369 @@ mcpServers:
 `,
     );
     expect(parseYamlMcpServerList(p, 'mcpServers')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectCanonicalSettingsDrift — pure helper (F3 conflict refusal).
+//
+// Both arguments are `ReadonlyMap<serverName, AgentNormalizedMcpServer>`
+// keyed by server name. The helper only emits conflicts for names
+// present in BOTH maps where both entries are normalized; missing
+// entries are the writer's problem (new-entry path).
+//
+// Comparator semantics (anti-silent-pass per F2 retro):
+// - `args` (readonly string[]): order is SIGNIFICANT.
+// - `env` / `headers` (Record<string,string>): order is INSIGNIFICANT.
+// - `undefined` vs `[]`/`{}` is a diff; `undefined` vs `undefined` is not.
+// - `null` vs `undefined` is distinct when both are legal.
+// - Numbers vs numeric strings are NOT coerced.
+// ---------------------------------------------------------------------------
+
+/** Build a normalized stdio entry fixture. */
+function stdio(server: {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}): AgentNormalizedMcpServer {
+  return { state: 'normalized', server: { type: 'stdio', ...server } };
+}
+
+/** Build a normalized remote entry fixture. */
+function remote(server: {
+  url: string;
+  headers?: Record<string, string>;
+}): AgentNormalizedMcpServer {
+  return { state: 'normalized', server: { type: 'remote', ...server } };
+}
+
+/** Build a shape-conflict fixture (normalized-to reason path). */
+function shapeConflict(): AgentNormalizedMcpServer {
+  return {
+    state: 'shape-conflict',
+    reason: 'Stdio command is missing or empty.',
+  };
+}
+
+describe('detectCanonicalSettingsDrift', () => {
+  it('returns [] when existing is empty', () => {
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx', args: ['-y', 'fs'] })],
+    ]);
+    expect(detectCanonicalSettingsDrift(new Map(), canonical)).toEqual([]);
+  });
+
+  it('returns [] when canonical is empty', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx', args: ['-y', 'fs'] })],
+    ]);
+    expect(detectCanonicalSettingsDrift(existing, new Map())).toEqual([]);
+  });
+
+  it('returns [] when both sides are empty', () => {
+    expect(detectCanonicalSettingsDrift(new Map(), new Map())).toEqual([]);
+  });
+
+  it('returns [] when names do not intersect (existing has keys canonical does not)', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx' })],
+      ['gh', remote({ url: 'https://example.com' })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['only-in-canonical', stdio({ command: 'npx' })],
+    ]);
+    expect(detectCanonicalSettingsDrift(existing, canonical)).toEqual([]);
+  });
+
+  it('returns [] when both sides are deeply equal normalized stdio entries', () => {
+    const left = stdio({
+      command: 'npx',
+      args: ['-y', '@scope/server-fs'],
+      env: { HOME: '/home/u', DEBUG: '1' },
+    });
+    const right = stdio({
+      command: 'npx',
+      args: ['-y', '@scope/server-fs'],
+      env: { HOME: '/home/u', DEBUG: '1' },
+    });
+    expect(
+      detectCanonicalSettingsDrift(
+        new Map([['fs', left]]),
+        new Map([['fs', right]]),
+      ),
+    ).toEqual([]);
+  });
+
+  it('returns [] when both sides are deeply equal normalized remote entries', () => {
+    const left = remote({
+      url: 'https://example.com/mcp',
+      headers: { Auth: 'token-a', 'X-Trace': '1' },
+    });
+    const right = remote({
+      url: 'https://example.com/mcp',
+      headers: { Auth: 'token-a', 'X-Trace': '1' },
+    });
+    expect(
+      detectCanonicalSettingsDrift(
+        new Map([['gh', left]]),
+        new Map([['gh', right]]),
+      ),
+    ).toEqual([]);
+  });
+
+  it('emits one conflict with single diff key when only command differs', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx' })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'pnpm' })],
+    ]);
+    expect(detectCanonicalSettingsDrift(existing, canonical)).toEqual([
+      {
+        serverName: 'fs',
+        message:
+          'Refusing to continue for server "fs": canonical and agent settings differ. Update the canonical config or the agent config and retry.',
+        diffKeys: ['command'],
+      },
+    ]);
+  });
+
+  it('emits one conflict with sorted diffKeys when multiple canonical fields differ', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      [
+        'fs',
+        stdio({
+          command: 'npx',
+          args: ['-y', 'fs'],
+          env: { DEBUG: '0' },
+        }),
+      ],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      [
+        'fs',
+        stdio({
+          command: 'pnpm',
+          args: ['dlx', 'fs'],
+          env: { DEBUG: '1' },
+        }),
+      ],
+    ]);
+    const conflicts = detectCanonicalSettingsDrift(existing, canonical);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.serverName).toBe('fs');
+    expect(conflicts[0]?.diffKeys).toEqual(['args', 'command', 'env']);
+  });
+
+  it('verifies diffKeys ascending sort across at least three keys', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      [
+        'gh',
+        remote({
+          url: 'https://old.example.com/mcp',
+          headers: { Auth: 'old' },
+        }),
+      ],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      [
+        'gh',
+        remote({
+          url: 'https://new.example.com/mcp',
+          headers: { Auth: 'new', Extra: '1' },
+        }),
+      ],
+    ]);
+    const conflicts = detectCanonicalSettingsDrift(existing, canonical);
+    expect(conflicts[0]?.diffKeys).toEqual(['headers', 'url']);
+    expect(conflicts[0]?.diffKeys).toEqual(
+      [...(conflicts[0]?.diffKeys ?? [])].sort(),
+    );
+  });
+
+  it('returns [] when existing has a key not in canonical (canonical is authoritative; extras are not a conflict)', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx' })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>();
+    expect(detectCanonicalSettingsDrift(existing, canonical)).toEqual([]);
+  });
+
+  it('emits a conflict when args order differs (order is significant for arrays)', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx', args: ['-y', 'fs', '--debug'] })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx', args: ['--debug', '-y', 'fs'] })],
+    ]);
+    const conflicts = detectCanonicalSettingsDrift(existing, canonical);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.diffKeys).toContain('args');
+  });
+
+  it('returns [] when only env key insertion order differs (order is insignificant for record maps)', () => {
+    const left = stdio({
+      command: 'npx',
+      env: { A: '1', B: '2', C: '3' },
+    });
+    const right = stdio({
+      command: 'npx',
+      env: { C: '3', A: '1', B: '2' },
+    });
+    expect(
+      detectCanonicalSettingsDrift(
+        new Map([['fs', left]]),
+        new Map([['fs', right]]),
+      ),
+    ).toEqual([]);
+  });
+
+  it('returns [] when only headers key insertion order differs (order is insignificant for record maps)', () => {
+    const left = remote({
+      url: 'https://example.com/mcp',
+      headers: { Auth: 'token', 'X-Trace': '1', 'X-Req': '2' },
+    });
+    const right = remote({
+      url: 'https://example.com/mcp',
+      headers: { 'X-Req': '2', 'X-Trace': '1', Auth: 'token' },
+    });
+    expect(
+      detectCanonicalSettingsDrift(
+        new Map([['gh', left]]),
+        new Map([['gh', right]]),
+      ),
+    ).toEqual([]);
+  });
+
+  it('emits a conflict when undefined vs [] are compared on canonical args', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx', args: ['-y', 'fs'] })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx' })], // args is undefined
+    ]);
+    const conflicts = detectCanonicalSettingsDrift(existing, canonical);
+    expect(conflicts[0]?.diffKeys).toContain('args');
+  });
+
+  it('does NOT flag undefined vs undefined on optional fields', () => {
+    const left = stdio({ command: 'npx' });
+    const right = stdio({ command: 'npx' });
+    expect(
+      detectCanonicalSettingsDrift(
+        new Map([['fs', left]]),
+        new Map([['fs', right]]),
+      ),
+    ).toEqual([]);
+  });
+
+  it('emits a conflict on transport switch (one stdio, one remote) with type in diffKeys', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['svc', stdio({ command: 'npx', args: ['svc'] })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['svc', remote({ url: 'https://svc.example.com/mcp' })],
+    ]);
+    const conflicts = detectCanonicalSettingsDrift(existing, canonical);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.serverName).toBe('svc');
+    // The transport-discriminator field MUST appear in diffKeys so
+    // the CLI can surface "type changed" to the user.
+    expect(conflicts[0]?.diffKeys).toContain('type');
+  });
+
+  it('skips entries with shape-conflict on either side (writer handles non-normalized cases)', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['broken', shapeConflict()],
+      ['ok', stdio({ command: 'npx' })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['broken', stdio({ command: 'npx' })],
+      ['ok', stdio({ command: 'npx' })],
+    ]);
+    expect(detectCanonicalSettingsDrift(existing, canonical)).toEqual([]);
+  });
+
+  it('is deterministic: two calls return deeply equal output for the same inputs', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx', args: ['-y'] })],
+      ['gh', remote({ url: 'https://a.example.com/mcp' })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'pnpm' })],
+      ['gh', remote({ url: 'https://b.example.com/mcp' })],
+    ]);
+    const first = detectCanonicalSettingsDrift(existing, canonical);
+    const second = detectCanonicalSettingsDrift(existing, canonical);
+    expect(second).toEqual(first);
+  });
+
+  it('returns conflicts sorted ascending by serverName', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['z', stdio({ command: 'npx' })],
+      ['a', stdio({ command: 'npx' })],
+      ['m', stdio({ command: 'npx' })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['z', stdio({ command: 'pnpm' })],
+      ['a', stdio({ command: 'pnpm' })],
+      ['m', stdio({ command: 'pnpm' })],
+    ]);
+    const conflicts = detectCanonicalSettingsDrift(existing, canonical);
+    expect(conflicts.map((c: { serverName: string }) => c.serverName)).toEqual([
+      'a',
+      'm',
+      'z',
+    ]);
+  });
+
+  it('output is JSON-serializable (round-trips through JSON.stringify)', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'npx', args: ['-y'], env: { A: '1' } })],
+      ['gh', remote({ url: 'https://gh.example.com/mcp' })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['fs', stdio({ command: 'pnpm', args: ['dlx'], env: { A: '2' } })],
+      ['gh', remote({ url: 'https://gh2.example.com/mcp' })],
+    ]);
+    const first = JSON.stringify(
+      detectCanonicalSettingsDrift(existing, canonical),
+    );
+    const second = JSON.stringify(
+      detectCanonicalSettingsDrift(existing, canonical),
+    );
+    expect(second).toBe(first);
+    // Sanity: round-trip parses and produces the same shape.
+    const parsed = JSON.parse(first) as readonly unknown[];
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(2);
+  });
+
+  it('output JSON has the B3-aligned serverName in message for each conflict', () => {
+    const existing = new Map<string, AgentNormalizedMcpServer>([
+      ['alpha', stdio({ command: 'npx' })],
+      ['beta', remote({ url: 'https://b.example.com/mcp' })],
+    ]);
+    const canonical = new Map<string, AgentNormalizedMcpServer>([
+      ['alpha', stdio({ command: 'pnpm' })],
+      ['beta', remote({ url: 'https://b2.example.com/mcp' })],
+    ]);
+    const conflicts = detectCanonicalSettingsDrift(existing, canonical);
+    expect(conflicts[0]?.message).toContain('"alpha"');
+    expect(conflicts[1]?.message).toContain('"beta"');
+  });
+
+  it('does not coerce numbers vs numeric strings on canonical fields', () => {
+    // OvertureMcpServer has no numeric fields today, but the
+    // comparator must not silently coerce type-mismatched values.
+    // Verify by constructing two entries where the only difference
+    // is the URL ends with "1" vs "01" (string vs visually-similar).
+    const left = new Map<string, AgentNormalizedMcpServer>([
+      ['gh', remote({ url: 'https://example.com/mcp?x=1' })],
+    ]);
+    const right = new Map<string, AgentNormalizedMcpServer>([
+      ['gh', remote({ url: 'https://example.com/mcp?x=01' })],
+    ]);
+    expect(detectCanonicalSettingsDrift(left, right)).toHaveLength(1);
   });
 });

--- a/packages/agents/src/parse-mcp-servers.ts
+++ b/packages/agents/src/parse-mcp-servers.ts
@@ -14,7 +14,12 @@ import {
   parse as parseJsonc,
   type ParseError,
 } from 'jsonc-parser/lib/esm/main.js';
-import type { McpServerEntry } from './types.js';
+import type { OvertureMcpServer } from '@overture/config';
+import type {
+  AgentNormalizedMcpServer,
+  McpServerEntry,
+  ServerConflict,
+} from './types.js';
 
 const localRequire = createRequire(__filename);
 // Load yaml the same way smol-toml is loaded in mcp-config-parser.ts:
@@ -271,4 +276,184 @@ export function parseOpenCodeMcpServerMap(
   resolvedPath: string,
 ): readonly McpServerEntry[] {
   return parseJsoncMcpServerMap(resolvedPath, 'mcp');
+}
+
+// ---------------------------------------------------------------------------
+// F3 canonical settings drift detection.
+//
+// `detectCanonicalSettingsDrift` is the pure helper that lifts the B3
+// 'canonical-settings-drift' classification into the write path. Each
+// per-agent writer invokes it during Pass 1 (after the existing target
+// read + B2 normalization completes, before byte-level planning) with
+// two `ReadonlyMap<serverName, AgentNormalizedMcpServer>` arguments:
+// - `existing`:  the existing target entries, already normalized
+//                (B2 funnel output, keyed by server name)
+// - `canonical`: the canonical intent entries, already normalized
+//                (B2 funnel output, keyed by server name)
+//
+// The helper returns ONE `ServerConflict` per same-name pair where the
+// normalized canonical fields differ. Missing entries (key present in
+// only one map) are NOT conflicts — the writer handles new-entry paths.
+// Entries with `state === 'shape-conflict'` are skipped here; their
+// refusal surfaces via the writer's existing `WriteReason` path, not F3.
+//
+// `AgentNormalizedMcpServer` itself carries NO server-name field
+// (memory 114), so the map key is the only authoritative identifier.
+// The helper never relies on array index order to identify a server
+// name (silent-pass risk per memory 113, F2 PR #133 retro).
+//
+// Pure: no fs, no async, no per-agent-specific imports.
+// Deterministic: same inputs produce deeply equal output.
+// JSON-serializable: no functions, no class instances in messages.
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two normalized MCP server maps and emit one
+ * `ServerConflict` per same-name pair whose canonical fields differ.
+ *
+ * Both arguments are `ReadonlyMap<serverName, AgentNormalizedMcpServer>`
+ * — the map key is the authoritative server name (memory 114).
+ * Output is sorted ascending by `serverName`; `diffKeys` is sorted
+ * ascending within each conflict.
+ *
+ * Comparator semantics (anti-silent-pass per memory 113):
+ * - `args` (string array): order is SIGNIFICANT.
+ * - `env` / `headers` (Record<string, string>): key insertion order
+ *   is INSIGNIFICANT — equivalent key→string maps compare equal.
+ * - `undefined` vs `undefined`: NOT a diff.
+ * - `undefined` vs `[]` / `{}`: IS a diff (missing vs empty).
+ * - No implicit coercion: numbers vs numeric strings are distinct;
+ *   `null` and `undefined` are distinct when both are legal.
+ *
+ * No `JSON.stringify` equality — would conflate `env` / `headers`
+ * insertion order with content (F2 retro silent-pass risk).
+ */
+export function detectCanonicalSettingsDrift(
+  existing: ReadonlyMap<string, AgentNormalizedMcpServer>,
+  canonical: ReadonlyMap<string, AgentNormalizedMcpServer>,
+): readonly ServerConflict[] {
+  // Iterate the intersection of keys, sorted ascending. We pick
+  // the smaller map's keys as the outer loop to avoid allocating
+  // the full intersection array, then sort the resulting array.
+  const intersectKeys: string[] = [];
+  const [outer, inner] =
+    existing.size <= canonical.size
+      ? [existing, canonical]
+      : [canonical, existing];
+  for (const name of outer.keys()) {
+    if (inner.has(name)) intersectKeys.push(name);
+  }
+  intersectKeys.sort();
+
+  const out: ServerConflict[] = [];
+  for (const serverName of intersectKeys) {
+    const leftEntry = existing.get(serverName);
+    const rightEntry = canonical.get(serverName);
+    // Defensive: the intersection loop already filters on `inner.has`,
+    // so both lookups must succeed. The `!` non-null assertion would
+    // be flagged by the lint config; fall through silently instead.
+    if (!leftEntry || !rightEntry) continue;
+    // Skip non-normalized entries on either side — their refusal
+    // surfaces via the writer's existing `WriteReason` path, not F3.
+    if (leftEntry.state !== 'normalized' || rightEntry.state !== 'normalized') {
+      continue;
+    }
+    const diffKeys = compareNormalizedServers(
+      leftEntry.server,
+      rightEntry.server,
+    );
+    if (diffKeys.length === 0) continue;
+    out.push({
+      serverName,
+      message:
+        `Refusing to continue for server "${serverName}": ` +
+        `canonical and agent settings differ. ` +
+        `Update the canonical config or the agent config and retry.`,
+      diffKeys,
+    });
+  }
+  return out;
+}
+
+/**
+ * Walk the canonical fields of two normalized server entries and
+ * return the sorted list of field names whose values differ. Order-
+ * significant for arrays (`args`); order-insignificant for record
+ * maps (`env`, `headers`).
+ */
+function compareNormalizedServers(
+  left: OvertureMcpServer,
+  right: OvertureMcpServer,
+): readonly string[] {
+  const diffs = new Set<string>();
+
+  // Discriminator is always present on both branches.
+  if (left.type !== right.type) diffs.add('type');
+
+  // Branch-specific fields. When the two sides pick different
+  // transports, the side that doesn't carry a branch-specific field
+  // contributes `undefined`, and the comparator flags the mismatch
+  // as a diff (a transport switch IS a multi-field drift).
+  const leftCommand = left.type === 'stdio' ? left.command : undefined;
+  const rightCommand = right.type === 'stdio' ? right.command : undefined;
+  if (leftCommand !== rightCommand) diffs.add('command');
+
+  const leftArgs = left.type === 'stdio' ? left.args : undefined;
+  const rightArgs = right.type === 'stdio' ? right.args : undefined;
+  if (!arraysEqualOrderSignificant(leftArgs, rightArgs)) diffs.add('args');
+
+  const leftEnv = left.type === 'stdio' ? left.env : undefined;
+  const rightEnv = right.type === 'stdio' ? right.env : undefined;
+  if (!recordEqualOrderInsignificant(leftEnv, rightEnv)) diffs.add('env');
+
+  const leftUrl = left.type === 'remote' ? left.url : undefined;
+  const rightUrl = right.type === 'remote' ? right.url : undefined;
+  if (leftUrl !== rightUrl) diffs.add('url');
+
+  const leftHeaders = left.type === 'remote' ? left.headers : undefined;
+  const rightHeaders = right.type === 'remote' ? right.headers : undefined;
+  if (!recordEqualOrderInsignificant(leftHeaders, rightHeaders)) {
+    diffs.add('headers');
+  }
+
+  return Array.from(diffs).sort();
+}
+
+/**
+ * Order-significant array equality. Treats two `undefined` values
+ * as equal (the canonical schema makes `args` optional). `null` and
+ * `undefined` are distinct.
+ */
+function arraysEqualOrderSignificant(left: unknown, right: unknown): boolean {
+  if (left === undefined && right === undefined) return true;
+  if (!Array.isArray(left) || !Array.isArray(right)) return false;
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Order-insignificant record equality. Treats two `undefined` values
+ * as equal (the canonical schema makes `env`/`headers` optional).
+ * Key insertion order does NOT affect equality.
+ */
+function recordEqualOrderInsignificant(left: unknown, right: unknown): boolean {
+  if (left === undefined && right === undefined) return true;
+  if (!isPlainRecord(left) || !isPlainRecord(right)) return false;
+  const lKeys = Object.keys(left).sort();
+  const rKeys = Object.keys(right).sort();
+  if (lKeys.length !== rKeys.length) return false;
+  for (let i = 0; i < lKeys.length; i++) {
+    const k = lKeys[i];
+    if (k === undefined || rKeys[i] === undefined) return false;
+    if (k !== rKeys[i]) return false;
+    if (left[k] !== right[k]) return false;
+  }
+  return true;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/agents/src/scope-guards.spec.ts
+++ b/packages/agents/src/scope-guards.spec.ts
@@ -1,0 +1,93 @@
+// F3 boundary guard — proves the new pure helper
+// `detectCanonicalSettingsDrift` (and its surrounding module) respects
+// the package-boundary rules locked in at scaffolding:
+//
+// 1. `packages/agents/src/parse-mcp-servers.ts` must NOT import
+//    `@overture/scan-matrix`. scan-matrix already imports from
+//    `@overture/agents` (it consumes `McpSupport` etc.), and the
+//    reverse direction would close a circular dependency (memory 111).
+//    The package-level "no scan-matrix import anywhere in agents"
+//    guard lives in `normalize-contract.spec.ts`; this file is the
+//    same assertion scoped to the F3 helper's home module, so a
+//    future drift in `parse-mcp-servers.ts` shows up here even if
+//    the broader guard is later refactored.
+//
+// 2. The new helper is a pure function. Its declaration must not
+//    reference `node:fs`, `readFile`, or `async` — the helper is
+//    expected to run inside the orchestrator's pre-write Pass 1 loop
+//    without touching the filesystem, and any future regression
+//    that introduces I/O would silently break the dry-run contract.
+//
+//    The pre-existing helpers in `parse-mcp-servers.ts` (the JSONC,
+//    TOML, and YAML readers) DO use `node:fs`. The guard scopes the
+//    purity check to the new helper's source slice, not the whole
+//    file, so the existing read helpers are not flagged.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Co-located in `packages/agents/src/`, compiled as CommonJS
+// (see `packages/agents/tsconfig.json`), so `__dirname` is available.
+const PARSE_MCP_SERVERS_PATH = join(__dirname, 'parse-mcp-servers.ts');
+
+const SCAN_MATRIX_IMPORT_REGEX =
+  /import\s+(?:type\s+)?[^'"]*from\s+['"]@overture\/scan-matrix['"]/;
+
+/**
+ * Extract the source slice of `detectCanonicalSettingsDrift`'s
+ * declaration: from `export function detectCanonicalSettingsDrift(`
+ * up to the next top-level `export function` / `export const` /
+ * `export type` / `export interface` declaration, or end-of-file.
+ * The helper is the last `export function` in the file, so the
+ * end-of-file bound is the practical case.
+ */
+function extractHelperSource(text: string): string {
+  const start = text.indexOf('export function detectCanonicalSettingsDrift');
+  if (start === -1) {
+    throw new Error(
+      'parse-mcp-servers.ts: detectCanonicalSettingsDrift helper not found',
+    );
+  }
+  // Look for the next top-level declaration AFTER the helper starts.
+  // Top-level declarations in this file all start at column 0 with
+  // `export `, so a simple regex from `start + 1` is sufficient.
+  const rest = text.slice(start + 1);
+  const nextDecl = rest.match(
+    /\nexport\s+(?:function|const|type|interface|class)\s/,
+  );
+  if (nextDecl && typeof nextDecl.index === 'number') {
+    return text.slice(start, start + 1 + nextDecl.index);
+  }
+  return text.slice(start);
+}
+
+describe('parse-mcp-servers.ts — F3 boundary guard', () => {
+  it('does not import @overture/scan-matrix', () => {
+    const source = readFileSync(PARSE_MCP_SERVERS_PATH, 'utf8');
+    expect(SCAN_MATRIX_IMPORT_REGEX.test(source)).toBe(false);
+  });
+
+  it('detectCanonicalSettingsDrift declaration does not reference node:fs', () => {
+    const source = readFileSync(PARSE_MCP_SERVERS_PATH, 'utf8');
+    const helperSlice = extractHelperSource(source);
+    expect(helperSlice).not.toMatch(/node:fs/);
+  });
+
+  it('detectCanonicalSettingsDrift declaration does not reference readFile', () => {
+    const source = readFileSync(PARSE_MCP_SERVERS_PATH, 'utf8');
+    const helperSlice = extractHelperSource(source);
+    expect(helperSlice).not.toMatch(/readFile/);
+  });
+
+  it('detectCanonicalSettingsDrift declaration is not async', () => {
+    const source = readFileSync(PARSE_MCP_SERVERS_PATH, 'utf8');
+    const helperSlice = extractHelperSource(source);
+    // The declaration line itself must not declare `async function`.
+    expect(helperSlice.startsWith('export function ')).toBe(true);
+    expect(helperSlice).not.toMatch(/export\s+async\s+function/);
+    // No `async (` arrow inside the helper body either — that
+    // would also break the synchronous detector contract.
+    expect(helperSlice).not.toMatch(/\basync\s/);
+  });
+});

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -167,6 +167,14 @@ export interface AgentMcpWriteResult {
   readonly format?: McpLocationFormat;
   /** Total byte delta of the write operation. */
   readonly bytesChanged?: number;
+  /**
+   * Per-server conflict detail when settings drift was detected.
+   * Populated only when non-empty; the CLI maps this to
+   * `ApplyStatus: 'conflict'` via `statusFromWriterResult`. Mirrors
+   * B3 'canonical-settings-drift' message vocabulary. CLI-local
+   * output — does not widen `WriteReason`.
+   */
+  readonly conflicts?: readonly ServerConflict[];
   /** Structured reason when write was not applicable. */
   readonly reason?: WriteReason;
 }
@@ -187,6 +195,17 @@ export type WriteReason =
   | 'unsupported-format'
   | 'unsupported-shape'
   | 'no-change';
+
+/**
+ * Conflict detail for a single server name where canonical settings
+ * differ from the existing target entry after B2 normalization.
+ * JSON-serializable — no functions, no class instances.
+ */
+export interface ServerConflict {
+  readonly serverName: string;
+  readonly message: string; // mirrors B3 message vocabulary
+  readonly diffKeys: readonly string[]; // sorted ascending
+}
 
 /**
  * Per-agent typed read handler. Each per-agent file can also export a


### PR DESCRIPTION
## Summary

Adds the F3 slice: `overture apply` refuses to overwrite an agent's existing MCP server entry when the canonical entry is already present with different settings. Refused agents are reported with per-server detail in both human and JSON output, no backup or write happens, and the run exits non-zero.

## Commits

- `2397d82d` — `feat(cli): add F3 conflict status type contract`
- `684079fb` — `feat(agents): add canonical settings drift detector`
- `f8e3eb08` — `feat(agents): wire conflict detection into production per-agent writers`
- `1e060a4b` — `feat(cli): apply refuses canonical settings drift conflicts`
- `86cc8637` — `docs(f3): mark canonical settings drift refusal slice complete`
- `a711489d` — `fix(agents): F3 reviewer-driven compliance fixes`

## F3 surface

- **New CLI-local `'conflict'` status** on `ApplyStatus` and `ApplyDryRunStatus` (`WriteReason` union frozen per project memory 112).
- **`ServerConflict` shape** declared in `packages/agents/src/types.ts` and re-exported from `packages/agents/src/index.ts` (CLI imports the type; not CLI-local — honors the `@overture/scan-matrix` boundary at memory 111).
- **`detectCanonicalSettingsDrift` helper** in `packages/agents/src/parse-mcp-servers.ts` — pure, deterministic, JSON-friendly. Both arguments are `ReadonlyMap<serverName, AgentNormalizedMcpServer>` (keyed, never array index — defuses the silent-pass pattern surfaced in PR #133's F2 retro). Comparator honors `args` order significance and `env`/`headers` key-order independence; `undefined` vs `[]`/`{}` are distinct.
- **Per-agent writer integration** in OpenCode, Claude Code, GitHub Copilot CLI, and OpenAI Codex writers. Claude Code extends its existing map to include `projects[workspaceDir].mcpServers` (workspace entries win on collision). Each writer reads → normalizes → compares → refuses-or-proceeds. OpenCode has an explicit `parseTarget` helper that runs BEFORE `planEdits` per the plan's ordering contract.
- **Orchestrator short-circuit** is automatic via the existing `if (dryStatus !== 'would-update') return …` gate; no per-status arm was needed.
- **`Conflicts:` block** in `formatHumanApply` AND `formatHumanApplyDryRun` plus a refusal-summary line.
- **`reasonDetail` policy** pinned to synthesized / non-writer refusals only; conflict detail is sourced EXCLUSIVELY from `AgentMcpWriteResult.conflicts`.
- **Dry-run JSON envelope** carries `AgentMcpWriteResult.conflicts` per agent; real-write JSON is unchanged (F2 gate F2-4 honored).
- **`settings.conflictPolicy`** is NOT read in the apply path (B3 pinned this out).

## Verification

```
yarn nx test @overture/agents --skip-nx-cache    → rc=0, 476 tests
yarn nx test @jander99/overture --skip-nx-cache  → rc=0, 266 tests (+10 F3 integration tests)
yarn tsc -b apps/cli/tsconfig.json               → rc=0 (pre-existing TS6305 errors per memory 78 off-scope)
yarn nx lint @jander99/overture --skip-nx-cache  → rc=0
yarn nx build @jander99/overture --skip-nx-cache → rc=0 (dist/main.js 343.6K)
./node_modules/.bin/prettier --check .           → rc=0
node apps/cli/scripts/verify-package.mjs         → rc=0 (F2 no-change + F3 refused-apply smokes)
```

**F3 refused-apply smoke** (`verify-package.mjs`) drives `overture apply` against a divergent Claude Code config (existing `command: 'old'` vs canonical `'node'`) and asserts: exit `1`, target bytes unchanged, no `.bak.*`, stdout contains `Conflicts:` plus `filesystem`.

**F1-F4 reviewer wave** — all four audits APPROVE:

- F1 (plan compliance) — APPROVE (after one re-audit that surfaced and resolved a `OpenCode` detector-before-`planEdits` ordering violation; the third pass confirmed all criteria green).
- F2 (code quality) — APPROVE.
- F3 (manual QA gates) — APPROVE — 7 gates rc=0.
- F4 (scope fidelity) — APPROVE — 18 files in expected scope; `.gitignore:47` `*.tsbuildinfo` is the only off-glob path (justified scope expansion to address F1's prior deviation #1; the durable fix for the previously untracked `apps/cli/tsconfig.tsbuildinfo`).

## Anti-silent-pass verification

`detectCanonicalSettingsDrift` uses a structured depth walk (`compareNormalizedServers` + `arraysEqualOrderSignificant` + `recordEqualOrderInsignificant` + `isPlainRecord`). No `JSON.stringify` equality on the compare path — that's the silent-pass pattern the F2 retro (PR #133) flagged and F3 closes via the keyed-Map signature and the structured comparator. The `packages/agents/src/scope-guards.spec.ts` boundary-guard test asserts the helper does not import `@overture/scan-matrix` and contains no `node:fs` / `readFile` / `async`.

## Project-memory updates

Memories 113-119 were added across the F3 lifecycle to encode the design contract, the type-export location, the `mapDryRefusalToApply` exhaustiveness requirement, the F1/F2 → conflict contract change (F1/F2 divergent tests updated to expect `conflict`), the universal `'would-update'`-exclusive short-circuit pattern, the detector-before-planning ordering contract, and the on-disk evidence-log discipline.

## Out of scope (memory 112 / plan guardrails)

- No `WriteReason` widening.
- No `--force` flag.
- No `settings.conflictPolicy` branching.
- No per-server partial sync (whole-agent refusal only).
- No removal / restore / state-file surface (G-track).
- No real-write JSON envelope (F2 gate F2-4 unchanged).
- No new package, no new dependency.

## Plan

Draft + reviewer verdict: `.omo/plans/f3-conflict-refusal.md`. Slice doc paragraph: `docs/overture-implementation-slices.md` (F3 section).