### PR TITLE
feat(cli): add overture restore-last helper (G3)

### DIFF
--- a/.omo/evidence/f3-g3-restore-last-real-qa.md
+++ b/.omo/evidence/f3-g3-restore-last-real-qa.md
@@ -1,0 +1,150 @@
+# F3 — G3 real manual QA re-run (post-fix, post-user-verdict)
+
+**Verdict: PASS** — `rc=0` (all 35 assertions across 9 steps, 0 FAIL)
+
+Reconciled from Wave-4 task-4 run on 2026-07-04 after the user verdict
+that re-classified `missing-backup` from a `skipped` outcome to a
+`failed` outcome (see `.omo/plans/g3-restore-last-helper.md` gate G3-8
+for the annotation).
+
+## Pre-flight (PASS)
+
+- `4b0e3898 fix(cli): resolve absolute paths in apply state record
+  + G3 review fixes` is the prior-task HEAD on `feat/g3-restore-last`.
+- Post-fix HEAD (this run): `fix(cli): error on missing-backup in
+  restore-last (user verdict 2026-07-04)`.
+- Build artifact present and `restore-last` advertised in USAGE.
+- F3 driver updated to honour the `--yes --force` precondition the
+  integrity check requires for post-apply restores (Step 5 / Step 6
+  / Step 8); Step 9 pair-count regex broadened to match
+  `ok|mismatch|missing-backup` instead of `ok` only (matches the
+  reality of every post-apply dry-run in this slice).
+
+## Per-step results
+
+| Step | Result | Detail |
+|---|---|---|
+| 1 | PASS | Seeded tmpdir with opencode config |
+| 2a | PASS | `apply --json` literal exits 2 per F2-4 gate |
+| 2b | PASS | Real `apply` succeeds; writes state JSON + log + backup; **absolute targetPaths (Fix A confirmed)** |
+| 3 | PASS | `restore-last --dry-run` renders absolute `mv -v` target |
+| 4 | PASS | sha256 baseline captured |
+| 5 | PASS | `restore-last --yes --force` succeeds (target restored, backup consumed, `restored: 1, skipped: 0, failed: 0` summary) |
+| 6 | **PASS** | Re-run `restore-last --yes --force` returns **exit 1** with `error: backup file missing:` + `error: could not complete restore …` on stderr; **summary `restored: 0, skipped: 0, failed: 1`** — user verdict 2026-07-04 |
+| 7 | PASS | `--run-id nonexistent` → exit 1 with clean stderr |
+| 8 | PASS | `--run-id <valid> --yes --force` → exit 1, stderr carries `error: backup file missing:` (valid runId's backups consumed in Step 5) |
+| 9 | PASS | 12-apply retention stress holds; G1 invariant preserved |
+
+**Total: 35/35 assertions PASS, 0 FAIL** (Required Steps 1-7: PASS;
+Optional Steps 8-9: PASS).
+
+## Steps 5 + 6 verbatim (the load-bearing flow)
+
+### Step 5 — `restore-last --yes --force`
+
+```
+$ node $BUNDLE restore-last --yes --force
+exit: 0
+stdout:
+========================================================================
+Overture restore plan
+========================================================================
+run id:        20260704-201754118-35021572
+source:        state-json
+state dir:     <tmp>/.local/state/overture/apply
+config path:   <tmp>/.config/overture/overture.jsonc
+
+[opencode] OpenCode
+  status: mismatch
+  mv -v '<tmp>/.config/opencode/opencode.json.bak.20260704-201754118' '<tmp>/.config/opencode/opencode.json'
+
+------------------------------------------------------------------------
+pairs: 1
+========================================================================
+Overture restore outcome
+========================================================================
+run id:        20260704-201754118-35021572
+source:        state-json
+
+[opencode] OpenCode
+  ok
+
+------------------------------------------------------------------------
+restored: 1, skipped: 0, failed: 0
+
+stderr:
+WARN: target '<tmp>/.config/opencode/opencode.json' was edited since apply; restore forced.
+```
+
+Backup file `opencode.json.bak.20260704-201754118` consumed (gone).
+
+### Step 6 — `restore-last --yes --force` (re-run, missing-backup)
+
+```
+$ node $BUNDLE restore-last --yes --force
+exit: 1
+stdout:
+========================================================================
+Overture restore plan
+========================================================================
+run id:        20260704-201754118-35021572
+source:        state-json
+state dir:     <tmp>/.local/state/overture/apply
+config path:   <tmp>/.config/overture/overture.jsonc
+
+[opencode] OpenCode
+  status: missing-backup
+  mv -v '<tmp>/.config/opencode/opencode.json.bak.20260704-201754118' '<tmp>/.config/opencode/opencode.json'
+
+------------------------------------------------------------------------
+pairs: 1
+========================================================================
+Overture restore outcome
+========================================================================
+run id:        20260704-201754118-35021572
+source:        state-json
+
+[opencode] OpenCode
+  failed: backup file missing
+
+------------------------------------------------------------------------
+restored: 0, skipped: 0, failed: 1
+
+stderr:
+error: backup file missing: '<tmp>/.config/opencode/opencode.json.bak.20260704-201754118'
+error: could not complete restore — backup file(s) may have been consumed by a previous restore, or never existed. Investigate with `ls <tmp>/.local/state/overture/apply/` before retrying.
+```
+
+## User verdict 2026-07-04 (locked)
+
+Per the user, record-keeping:
+
+> "If a backup is missing, it could be that it's nonexistant
+> (restore backup foo when foo doesn't exist) and we can't prove
+> one way or the other so we should error that we couldn't complete
+> the request as asked."
+
+Implementation: gate G3-8 in `.omo/plans/g3-restore-last-helper.md`
+now classifies `missing-backup` pairs as `failed`, not `skipped`.
+The restore-command `runRestore` execution loop pre-scans the plan
+for any `missing-backup` pair and refuses to issue any `mv`
+shell-out when found (atomic whole-run semantics per gate G3-8).
+The result is the Step 6 output above: exit 1, per-pair stderr
+error + follow-up investigation hint, summary `failed: 1`.
+
+## Verdict
+
+PASS on every dimension:
+
+1. Step 5 (apply → restore-last end-to-end): exit 0, target
+   restored, backup consumed.
+2. Step 6 (re-run on consumed backup): exit 1, stderr carries both
+   required error lines, summary `restored: 0, skipped: 0, failed:
+   1`. The user verdict 2026-07-04 is satisfied.
+3. Steps 7-9 (run-id ghost, valid-runid, retention stress): all PASS.
+4. Workspace gates (`nx test`, `nx build`, `nx lint`, `prettier
+   --check .`, `verify-package.mjs`) all RC=0.
+
+The pre-fix Step 6 failure (`exit 0` instead of exit 1) is resolved.
+
+rc=0

--- a/.omo/plans/g3-restore-last-helper.md
+++ b/.omo/plans/g3-restore-last-helper.md
@@ -1,0 +1,931 @@
+# g3-restore-last-helper - Work Plan (DRAFT — awaiting gate approvals)
+
+## TL;DR (For humans)
+
+**What you'll get:** A new top-level `overture restore-last [--dry-run]
+[--yes] [--run-id <id>]` command that consumes the G1 `<stateDir>/apply/
+<runId>.json` + `<stateDir>/apply/last.json` artifacts (with the G2
+`<runId>.log` `backup:` / `target:` tag lines as a fallback when the JSON
+is absent) and runs the per-agent `mv -v` recovery that's already in the
+log's `roll-back-all:` block. Default behavior: read `last.json` for the
+most recent apply, show every `backup → target` pair, prompt for
+confirmation on a TTY, then move the backup files back to their original
+targets. A `--dry-run` flag previews every `mv` command without executing.
+A `--run-id <id>` flag lets the user pick any surviving runId from the
+retention window (default 10). A `--yes` flag suppresses the prompt and
+proceeds when the pre-flight integrity check (sha256 against
+`ApplyStateAgent.preWriteSha256`) passes.
+
+**Why this approach:** The slice doc calls G3 "convenience on top of the
+`mv`-based recovery path, not a replacement" — the `cat
+<runId>.log | tail -n +| head -n | sh` recovery already exists. G3 just
+gives it a discoverable CLI surface, an interactive confirmation gate, a
+optional modification check via `preWriteSha256` (so a user who edited a
+config between apply and restore isn't silently clobbered), and an audit
+trail (the restore writes its own state record so future G3s can see
+"this user restored run X at time Y").
+
+The G2 `.log` parseable tag lines and the `readApplyLog` parser already
+exist; G3 promotes them from "consumer-ready anchor" to "primary source"
+for a fallback path. The primary source remains the G1 `ApplyStateRecord`
+JSON (canonical, contains `preWriteSha256`, audit-friendly). When the JSON
+is missing (e.g. legacy apply predates G1) but the `.log` exists, G3
+falls back to log tag lines (no sha256 available → modification check
+skipped with a warning).
+
+The G2 plan laid the parseability groundwork: `backup: '<path>'` /
+`target: '<path>'` tag lines next to prose `mv -v` commands. G3's parser
+is `readApplyLog` plus a thin tag-line extractor (or reuse the existing
+`readApplyLog` end-to-end and project the `restorePairs` array). The
+paired `ApplyStateRecord` shape gives sha256 for the integrity check, so
+the JSON-source path is preferred when both exist.
+
+**What it will NOT do:** Modifying any writer file (`packages/agents/src/
+*-write.ts`). Widening `WriteReason`, `ApplyStatus`, `ApplyResult`,
+`ApplyAgentResult`, `AgentMcpWriteResult`. Adding new package dependencies
+or Nx projects. Modifying any G1 spec assertion
+(`apps/cli/src/apply-state.spec.ts` cases 1-6 stay byte-identical) or any
+G2 spec assertion (`apps/cli/src/apply-log.spec.ts` cases 1-6 stay
+byte-identical). Adding `--json` output to `restore-last`. Batched /
+multi-run restoration (one runId at a time only). Auto-purge of the
+applied-backup files after restoration (backups persist; user decides).
+A "restart apply" or "rollback to version N" semantic — restore only
+goes one direction (current → backup).
+
+**Effort:** Small-to-medium (one new module + dispatcher arm + tests +
+docs).
+
+**Risk:** Low — additive; the existing G1 `last.json` + G2 `.log` tag
+lines are the entire input surface. No writer modification, no envelope
+widening, no new dependency. G3 widens `ApplyStateRecord.mode` from
+`'apply'` to `'apply' | 'restore'` ONLY if the user approves gate G3-7
+(write a restore-state record); without that gate G3 stays
+read-only-on-disk.
+
+---
+
+> TL;DR (machine): Add `apps/cli/src/restore-command.ts` exporting
+> `RestorePlan`, `RestorePair`, `buildRestorePlan`, `readRestoreSource`,
+> `formatHumanRestorePlan`, `formatHumanRestoreOutcome`, `runRestore`.
+> The CLI dispatcher in `apps/cli/src/cli.ts` gains a `restore-last` arm
+> routed to `runRestore`. Tests in `apps/cli/src/restore-command.spec.ts`
+> + a small `restore-command.ts` integration with the existing G1/G2
+> artifacts. (Possibly) widen `ApplyStateRecord.mode` to
+> `'apply' | 'restore'` so restore-history audits land on disk alongside
+> the apply records — TBD per gate G3-7.
+
+## Scope
+
+### Must have
+
+- **New file `apps/cli/src/restore-command.ts`** exporting:
+  - `RestorePair` interface — the per-pair operating unit
+    `{ agentId: string; displayName: string; backup: string; target: string; integrityStatus: 'ok' | 'mismatch' | 'unverified' | 'missing-backup' }`.
+    `ok` = current sha256 of target matches `preWriteSha256` (i.e. user
+    hasn't touched the file since apply). `mismatch` = file changed; the
+    restore will WARN but proceed when `--force` is set. `unverified` =
+    source was the G2 `.log` (no sha256 available — modification check
+    skipped). `missing-backup` = backup file no longer on disk; pair
+    skipped with a stdout note.
+  - `RestorePlan` interface — the operational outcome
+    `{ source: 'state-json' | 'log-tag-lines' | 'last-json-pointer'; runId: string; pairs: readonly RestorePair[]; notes: readonly string[]; stateDir: string; configPath: string }`.
+    `source` records which path fed the plan (canonical preference:
+    G1 JSON; fallback: G2 `.log` tag lines; if only `last.json` exists
+    but the runId JSON is missing, the plan reports `last-json-pointer`
+    with a `notes` line "state file missing, search retention" and
+    returns an empty `pairs` array — caller exits with a clear error).
+  - `buildRestorePlan(stateDir, runId, now): Promise<RestorePlan>` —
+    reads `<stateDir>/apply/last.json` to resolve the runId when `runId`
+    is omitted, then reads either the per-run `<runId>.json` (preferred)
+    or the `<runId>.log` (fallback) to build the plan. Each pair
+    evaluates the integrity check against the current sha256 of the
+    target via `sha256OfFile`. Missing backups set
+    `integrityStatus = 'missing-backup'` and surface in the notes.
+  - `readRestoreSource(stateDir, runId): Promise<{ source: …; pairs: …}>`
+    — pure source-reading layer over G1 `readApplyState` and G2
+    `readApplyLog`. Returns the raw data without integrity evaluation so
+    unit tests can pin arbitrary fixture content.
+  - `formatHumanRestorePlan(plan: RestorePlan): string` — the pre-execute
+    human-readable rendering: header (runId, timestamp, source,
+    stateDir) → per-pair block (`agentId + status: ok/mismatch/… +
+    mv -v '…' '…'`) → footer (count summary + notes). Lock the format
+    in this slice.
+  - `formatHumanRestoreOutcome(plan, results): string` — the post-execute
+    rendering: same header → per-pair result line
+    (`ok` / `skipped` / `failed: <reason>`) → summary
+    (`restored: N, skipped: M, failed: K`).
+  - `runRestore(args, stdout, stderr, options?)` — the dispatcher-level
+    entry point. Mirrors `runApply`'s shape: flag parse → `buildRestorePlan`
+    → render plan → prompt or `--yes`/`--dry-run` → execute `mv` per pair
+    → return exit code (`0` when all `ok` pairs succeed and any
+    `mismatch`/`unverified`/`missing-backup` pairs honor their gate;
+    `1` when any restore failure or modification rejection without
+    `--force`).
+- **New dispatcher arm in `apps/cli/src/cli.ts`**: `restore-last` routes
+  to `runRestore`. Update the `USAGE` string to advertise the new
+  command. Accept one positional subcommand only — `restore-last`;
+  everything else falls through to "Unknown command".
+- **New flag surface on `overture restore-last`**:
+  - `--dry-run` — show the plan and exit 0 without executing.
+  - `--yes` — skip the interactive confirmation prompt; proceed when
+    the integrity check passes, error out on `mismatch` unless
+    `--force` is also present.
+  - `--force` — proceed even when `mismatch` (current target file has
+    been edited since apply). Logs a `WARN: target <path> was edited
+    since apply; restore forced.` line to stderr.
+  - `--run-id <runId>` — pick a specific runId from the retention window;
+    defaults to the runId resolved by `last.json`.
+  - Argument parsing mirrors `runApply` (whitelist + syntax-error
+    return code `2`).
+- **Tests** in `apps/cli/src/restore-command.spec.ts`:
+  - **Case 1** — `readRestoreSource` reads the JSON path correctly:
+    seed `<stateDir>/apply/last.json` + `<stateDir>/apply/<runId>.json`;
+    expect `source: 'state-json'` and the pair list matching the seeded
+    `agents[*].backupPaths/targetPaths`.
+  - **Case 2** — `readRestoreSource` falls back to log-tag-lines:
+    seed only `<runId>.log` (no JSON); expect
+    `source: 'log-tag-lines'` and pairs projected via `readApplyLog`'s
+    `restorePairs`.
+  - **Case 3** — `buildRestorePlan` integrity check: seed a run with
+    targets A, B, C and current sha256 of A matches `preWriteSha256`,
+    B differs, C absent — expect three pairs with statuses
+    `ok / mismatch / missing-backup` respectively (no `--force` →
+    `mismatch` would block execution; the unit case just confirms the
+    evaluation).
+  - **Case 4** — `formatHumanRestorePlan` produces a stable rendering
+    with the 3 sections (header, per-pair, footer). Mirror the G2
+    renderer's "lock the format" contract.
+  - **Case 5** — `runRestore --dry-run` exits 0, writes the plan to
+    stdout, performs no filesystem writes (no actual `mv`, no per-pair
+    backup paths mutated, no target files created). Pair with vitest
+    `vi.spyOn(child_process, 'spawn')` to assert no `mv` invocations
+    fire.
+  - **Case 6** — `runRestore --yes` with all `ok` pairs: real `mv`s
+    execute (via `child_process.spawn` of `mv -v`), target files
+    restored, exit code 0.
+  - **Case 7** — `runRestore --yes` with a `mismatch` pair: exits 1,
+    target NOT clobbered, stderr carries the rejection line.
+  - **Case 8** — `runRestore --yes --force` with a `mismatch` pair:
+    proceeds with restore, stderr carries the WARN line, exit code 0
+    iff every pair succeeded.
+  - **Case 9** — `runRestore --run-id <other-runId>`: default of
+    `last.json`'s runId is overridden; the chosen runId's pairs run.
+    runId not in retention (e.g. `last.json` points to a runId that
+    was pruned) → `last-json-pointer` source with notes "state file
+    missing" and exit code 1 with a clear stderr message.
+  - **Case 10** — missing `last.json`: exit code 1 with stderr "no
+    overture apply history found in <stateDir>" + USAGE hint. Mirrors
+    G2's "no log file was written" guardrail for the empty case.
+  - **Case 11** — TTY simulation: when stdin is TTY and `--yes` is NOT
+    set, the plan is rendered to stdout and a confirmation prompt
+    fires; the user's "y\n" reply permits execution; "n\n" aborts.
+    Use `vi.spyOn` on the prompt helper to drive both branches without
+    touching real stdin.
+- **Cli dispatcher integration** (covered in `apps/cli/src/cli.spec.ts`):
+  - **Case 12** — `overture restore-last --help` prints the new USAGE
+    block and exits 0.
+  - **Case 13** — `overture restore-last --dry-run` (with a seeded
+    `<stateDir>/apply/last.json` + `<stateDir>/apply/<runId>.json` in
+    a temp `XDG_STATE_HOME` env override) reads the JSON, prints the
+    plan, exits 0.
+  - **Case 14** — `overture restore-last --unknown-flag` exits 2 with
+    the USAGE block to stderr.
+  - **Case 15** — `overture` with no args still exits 0 and emits the
+    USAGE block (regression — dispatcher change must not break empty-
+    args behavior).
+- **Optional `ApplyStateRecord.mode` widening to `'apply' | 'restore'`**
+  (gated by gate G3-7):
+  - `apps/cli/src/apply-state.ts` — extend the literal union on line 61
+    `readonly mode: 'apply'` to `'apply' | 'restore'`.
+  - `BuildApplyStateRecordArgs.mode` (line 102) — same extension.
+  - `readApplyState`'s `isApplyStateRecord` narrowing — accept both
+    literals (no schemaVersion bump; the schema stays at `1`).
+  - `writeApplyState` continues to call `pruneApplyArtifacts`; nothing
+    changes there.
+  - Pair retention invariant unchanged.
+  - `apply-state.spec.ts` cases 1-6 stay byte-identical (no test seeds
+    a `mode: 'restore'` record).
+  - New test case 7: `apply-state.spec.ts` reads a seeded
+    `mode: 'restore'` file and asserts `readApplyState` accepts it.
+- **`docs/overture-implementation-slices.md`** G3 status block update
+  (currently `docs/overture-implementation-slices.md:609-615`) — fill
+  out the "Delivered" section with the implemented subsections after
+  the slice ships. Mirrors the G1 / G2 delivered-block style.
+- **`verify-package.mjs` smoke** (`apps/cli/scripts/verify-package.mjs`):
+  add a G3 smoke AFTER the G2 smoke block — seed a G1+G2 state (a
+  restore-ready `last.json` + `apply/<runId>.json` + `apply/<runId>.log`),
+  then invoke `overture restore-last --dry-run`, asserting the
+  rendered plan appears on stdout with the seeded pair's
+  `mv -v '…' '…'` line, and asserting NO actual `mv` invocations
+  fired (e.g. by snapshotting the target paths before and after the
+  smoke command).
+
+### Must NOT have (guardrails, anti-slop, scope boundaries)
+
+- Must NOT modify any writer file (`packages/agents/src/*-write.ts`).
+- Must NOT widen `WriteReason`, `ApplyStatus`, `ApplyResult`,
+  `ApplyAgentResult`, `OvertureConfigSchema`, `OvertureMcpServer`,
+  `AgentMcpWriteInput`, `AgentMcpWriteResult`,
+  `ApplyStateAgent`, `BuildApplyStateRecordArgs` beyond the
+  `mode` union extension IF gate G3-7 is approved.
+- Must NOT modify `apps/cli/src/apply-state.ts` lines 211-248 (the
+  `writeApplyState` atomic write and prune-orchestration logic) —
+  G3 is read-only-on-disk by default. The `mode` widening (gate G3-7)
+  is the only permitted apply-state touch.
+- Must NOT modify `apps/cli/src/apply-log.ts` —
+  `readApplyLog` / `buildApplyLog` / `renderApplyLog` / `writeApplyLog`
+  / `pruneApplyArtifacts` are their final G2 shape.
+- Must NOT add `--json` to `restore-last`. The restore plan IS the
+  JSON envelope (the underlying `<runId>.json`); a second `--json` flag
+  is redundant.
+- Must NOT batch multiple runIds. One runId per invocation. A future
+  slice may grow this; G3 is narrow.
+- Must NOT auto-purge backup files after restore. The backups persist
+  until the next `overture apply` prunes them via
+  `pruneApplyArtifacts`.
+- Must NOT touch `ApplyDryRunStatus`, `ApplyDryRunResult`,
+  `ApplyDryRunAgentResult`. Restore has no dry-run-from-apply concept;
+  `--dry-run` is a G3-internal preview of the restore plan itself.
+- Must NOT add a `restore` umbrella command. Only `restore-last`. A
+  `restore <runId>` is implied by `restore-last --run-id <runId>`.
+- Must NOT reorder `AGENT_REGISTRY_ORDER` or change registry
+  positional expectations.
+- Must NOT add `settings.dryRunByDefault` honoring or any other
+  cross-slice config handling.
+- Must NOT introduce a new Nx project, package, or runtime dependency.
+  `restore-command.ts` is a CLI-local module.
+- Must NOT stage untracked `ARCHITECTURE.md`, `STRUCTURE.md`,
+  `.codegraph/`, `.cortexkit/`, `.serena/`, or local evidence files.
+- Must NOT fix pre-existing TypeScript or test errors outside G3-touched
+  files (project memory 78).
+- Must NOT modify G1 spec assertions
+  (`apps/cli/src/apply-state.spec.ts` cases 1-6) unless gate G3-7
+  adds Case 7, which is explicitly in scope per that gate.
+- Must NOT modify G2 spec assertions
+  (`apps/cli/src/apply-log.spec.ts` cases 1-6).
+- Must NOT modify `apply-command.spec.ts` cases 1-33 except via
+  addition (no replacement).
+
+### Gate G3-1 — Command surface (REQUIRES USER APPROVAL)
+
+**Proposed**: top-level `overture restore-last` with optional flags
+`--dry-run`, `--yes`, `--force`, `--run-id <id>`. Matches the slice
+doc's literal name and the existing flat top-level dispatcher in
+`apps/cli/src/cli.ts`. `restore-last` is the only positional; no
+`restore <subcommand>` group.
+
+Alternative to flag if preferred:
+- **Nested under `apply`**: `overture apply restore-last`. Rejected —
+  `apply` already has its own complete flag surface
+  (`--dry-run`/`--json`); nesting adds semantic conflict (a future
+  `apply --dry-run` is a dry-run of apply, not of restore).
+- **`overture restore`** with the helper under it as
+  `restore restore-last`. Rejected — umbrella naming implies a fuller
+  restore surface that G3 is intentionally NOT delivering. Keeps the
+  CLI vocabulary honest.
+- **`overture undo`**. Rejected — over-promises. A future bidirectional
+  apply tool (`apply -R` for reverse-apply) might claim `undo`, but
+  restore from backup is a different semantic (one-shot, not
+  declarative).
+
+### Gate G3-2 — Source preference: JSON vs log (REQUIRES USER APPROVAL)
+
+**Proposed**: `readRestoreSource` tries
+`<stateDir>/apply/<runId>.json` first (canonical, contains
+`preWriteSha256` for integrity check). When the JSON is absent but
+`<runId>.log` exists, falls back to the log's `backup:` / `target:`
+tag lines via the existing `readApplyLog` parser
+(`source: 'log-tag-lines'`, sha256 unavailable → integrity check
+skipped, plan entries flagged `unverified`). When neither exists,
+the source is `'last-json-pointer'` and `pairs` is `[]` (the caller
+exits 1 with "state file missing").
+
+Alternative to flag if preferred:
+- **Log-only**, never fall back. Cleaner surface but brittle — a
+  user who pre-G2 applied (no JSON) gets a confusing error. (Recommendation:
+  the dual-source path; the JSON preference preserves every existing
+  safety guarantee.)
+- **JSON-only**, error on missing JSON. Rejected — the same pre-G2
+  legacy path fails outright. (Recommendation: same as above.)
+
+### Gate G3-3 — Run selection (REQUIRES USER APPROVAL)
+
+**Proposed**: default reads `<stateDir>/apply/last.json`. `--run-id
+<id>` overrides. If the chosen runId's files are absent (e.g. pruned
+post-retention), exit 1 with stderr "run <id> not found in <stateDir>
+(retention window: 10)". No listing / interactive picker for the
+"choose a run" UX — that's a future slice if needed.
+
+Alternative to flag if preferred:
+- **List-all mode**: `overture restore-last --list` prints every
+  surviving runId with timestamps and pair counts, exits 0. Rejected
+  — the retention window is 10 (`cat <stateDir>/apply/*.json |
+  jq '.runId'`) and a dedicated listing command is scope creep. If the
+  user wants to see history, `overture apply` already leaves a
+  retrievable trail; a future `overture apply history` may satisfy it.
+- **Interactive picker (TUI)** selecting from the retention list.
+  Rejected — interactive UI in this CLI is established territory
+  (`overture bootstrap --dry-run --interactive`); the apply + restore
+  surface stays non-interactive for scriptability.
+
+### Gate G3-4 — Confirmation + flag interaction (REQUIRES USER APPROVAL)
+
+**Proposed**:
+- `--dry-run` → print the plan, exit 0, no filesystem effects.
+- `--yes` → skip prompt. The integrity gate (`mismatch` /
+  `missing-backup`) still decides whether execution proceeds — a
+  `mismatch` pair WITHOUT `--force` exits 1 and does NOT run any `mv`
+  (atomic whole-run semantics: any failure aborts the batch).
+  `missing-backup` pairs are skipped (not failed).
+- `--force` → proceeds through `mismatch` pairs with a stderr WARN.
+- `--yes` and `--dry-run` together → the plan prints and exits 0
+  (dry-run dominates; `--yes` is irrelevant on the dry path).
+- No `--yes` and TTY (stdin is a TTY) → interactive confirmation
+  prompt renders the plan, then asks `Proceed? [y/N]`. Empty / `n` /
+  anything other than `y` aborts (exit 1).
+- No `--yes` and stdin is NOT a TTY (e.g. CI pipe) → exit 2 with
+  stderr "interactive confirmation required (TTY) — pass --yes" +
+  USAGE. Mirrors `runBootstrap`'s existing interactive gate.
+
+Alternative to flag if preferred:
+- **`--yes` is implicit**, no `--yes` flag — the user just runs
+  `overture restore-last` and gets the prompt. Rejected — restores
+  are destructive enough to require the safety of an explicit
+  opt-in for scripts (`overture restore-last --yes`).
+- **Batched `mv` continues past failures**: a `mismatch` pair causes a
+  WARN + the failed pair is skipped, but later `ok` pairs still
+  execute. Rejected — partial state after a restore is worse than
+  no state; atomic whole-run semantics give the user a clean
+  rollback back to "nothing was touched".
+
+### Gate G3-5 — Integrity check semantics (REQUIRES USER APPROVAL)
+
+**Proposed**: for every pair coming from the JSON source, the restore
+compares `sha256OfFile(<target>)` (current state on disk) against
+`ApplyStateAgent.preWriteSha256` (what was there before the apply).
+- Match → `integrityStatus: 'ok'` → proceeds.
+- Mismatch → `integrityStatus: 'mismatch'` → plan renders the WARN;
+  `--yes` alone blocks at exit 1; `--yes --force` proceeds with a
+  stderr WARN. `--dry-run` always reports the status but never
+  executes.
+- ENOENT on the current target → `integrityStatus: 'ok'` (the file
+  was deleted between apply and restore — restore is a creation, not
+  a clobber; backup moves in cleanly).
+- ENOENT on the backup → `integrityStatus: 'missing-backup'` →
+  skip with a stdout note; restore continues for the surviving pairs.
+
+For pairs coming from the log source (gate G3-2 fallback): no sha256
+exists → `integrityStatus: 'unverified'`; restore proceeds without
+comparison; a stderr WARN on `--dry-run` and `--yes` paths.
+
+Alternative to flag if preferred:
+- **No integrity check**, just run the `mv`. Rejected — the user
+  could lose edits silently. The check is a 1-line `sha256OfFile`
+  per target; the cost is negligible vs the safety.
+- **Mtime check (mtime on the target must equal mtime at apply-time)**:
+  cheaper than sha256 but unreliable (mtime can be touched by `touch`
+  and by editor save patterns); sha256 is the canonical primitive
+  already wired into G1.
+
+### Gate G3-6 — Execution semantics (REQUIRES USER APPROVAL)
+
+**Proposed**: `mv` is invoked via Node's `child_process.spawn('mv',
+['-v', backup, target])` per pair, sequentially. After each `mv`:
+- Exit 0 → pair `ok` in the outcome.
+- Non-zero → pair `failed: <reason>` (stderr captured); restore aborts
+  (atomic semantics per gate G3-4).
+- ENOENT on the backup pre-`mv` → pair `skipped` with no error
+  (covered by `integrityStatus: 'missing-backup'` already).
+
+Alternative to flag if preferred:
+- **`fs.rename` from Node, no child process**. Faster, but `fs.rename`
+  is a true rename — it leaves the backup source gone. The G2 log
+  already advertises `mv -v` semantics (the user may have copied the
+  log snippet expecting standard `mv`); running `fs.rename` instead
+  breaks the contract of "matched `mv -v` from the log".
+- **`cp -p` to the target then `unlink` the backup**. Defensive: the
+  backup survives a failed `cp` mid-write. Rejected — `mv -v` is the
+  contract; a future G3.* can change the primitive if the cost
+  becomes a problem.
+
+### Gate G3-7 — Restore-state audit record (REQUIRES USER APPROVAL)
+
+**Proposed (default OFF)**: G3 does NOT write its own state record on
+disk. The `--dry-run` plan-to-stdout is the only audit; future
+restorers can re-run `--dry-run <runId>` to see what happened. The
+G1 `ApplyStateRecord.mode` stays `'apply'` only — no schema widening.
+
+Alternative to flag if preferred (would mean G3 writes a record):
+- **Write `<stateDir>/apply/restore-<timestamp>-<randomHex8>.json`**
+  with `mode: 'restore'`. Pairs paired retention with apply records;
+  gives users a paper trail ("I last restored run X at Y"). Requires:
+  - `ApplyStateRecord.mode: 'apply'` widens to
+    `'apply' | 'restore'`.
+  - `BuildApplyStateRecordArgs.mode` widens in parallel.
+  - `readApplyState`'s `isApplyStateRecord` accepts both.
+  - `apply-state.spec.ts` Case 7 added: read a seeded
+    `mode: 'restore'` file, assert success.
+  - The new pruner `pruneApplyArtifacts` already groups by runId; the
+    restore record uses a different runId format
+    (`restore-<ts>-<hex>` not `<ts>-<hex>`) so the retention buckets
+    stay disjoint. (Recommended if audit is desired; rejected for
+    minimal slice scope.)
+
+### Gate G3-8 — Failure semantics & exit codes
+
+**User verdict 2026-07-04 (locked)** — `missing-backup` is a FAILURE,
+not a skip. Per the user: *"If a backup is missing, it could be that
+it's nonexistant (restore backup foo when foo doesn't exist) and we
+can't prove one way or the other so we should error that we couldn't
+complete the request as asked."* The prior "skipped" semantics were
+removed in the task-4 fix commit `fix(cli): error on missing-backup in
+restore-last (user verdict 2026-07-04)`.
+
+**Locked semantics**:
+- Exit 0: `--dry-run` succeeds; `--yes` succeeds with all
+  restoration outcomes `ok` (the `skipped` bucket, if any, is reserved
+  for non-missing-backup future slices only — today nothing emits it).
+- **Exit 1 (atomic whole-run)**: at least one pair failed, including
+  any `missing-backup` pair; at least one pair was `mismatch` without
+  `--force`; `--run-id` not found in retention; source file missing for
+  resolved runId. On missing-backup: per-pair stderr
+  `error: backup file missing: <quoted-backup>` + a follow-up
+  `error: could not complete restore — backup file(s) may have been
+  consumed by a previous restore, or never existed. Investigate with
+  \`ls <stateDir>/apply/\` before retrying.` line, then exit 1 with the
+  rendered outcome reporting `failed: N` (no `ok`s emitted for the
+  remaining pairs — atomic).
+- Exit 2: usage error (unknown flag, missing arg, no TTY + no
+  `--yes`).
+
+**Prior (rejected) proposal** (kept below for traceability):
+- Exit 0: `--dry-run` succeeds; `--yes` succeeds with all
+  restoration outcomes `ok` or `missing-backup` (skipped).
+- Exit 1: at least one pair failed (`failed: <reason>`); at least
+  one pair was `mismatch` without `--force`; `--run-id` not found
+  in retention; source file missing for resolved runId.
+- Exit 2: usage error (unknown flag, missing arg, no TTY + no
+  `--yes`).
+
+Alternative to flag if preferred:
+- **Failure exits 0 with stderr**. Rejected — scripts need a reliable
+  exit code; restore failure should propagate.
+- **Distinguish pair-level vs run-level failures** with separate
+  codes. Rejected — both surface as a failed restore at the CLI
+  contract level; a script can inspect the rendered outcome for
+  detail.
+
+## MCP usage policy (REQUIRED — workers must follow)
+
+> Both `codegraph` and `serena` MCPs are wired in this session. Workers
+> MUST invoke them per the policy below. Plain `Read`/`Grep`/`Edit`
+> remain for new-file creation, multi-line text edits where symbol-level
+> replace is awkward, and CI gate invocations (Bash). The dispatch flow:
+> codegraph BEFORE Read; serena for symbol-level surgical edits.
+
+### Codegraph — structural context lookup
+
+- **When to invoke**: BEFORE the first `Read` of an existing source
+  file, BEFORE editing an existing symbol, and BEFORE declaring the
+  blast radius of a change. Use the single `codegraph_explore` tool
+  with a natural-language question or a bag of symbol names; it
+  returns verbatim source PLUS call paths in one call.
+- **When NOT to invoke**: new files (`.codegraph/` has not indexed
+  them yet — index lag is ~1s); CI scripts / shell loops; Bash
+  diagnostic commands; the final verification wave's workspace gates
+  (those use pinned CLI tools, not MCPs).
+- **Mandatory calls per Todo**:
+  - **Todo 1** — one call: `codegraph_explore("readApplyState
+    readApplyLog writeApplyState sha256OfFile ApplyStateAgent")` to
+    pin the G1+G2 surface and the call paths between
+    `readApplyState` ↔ `pruneApplyArtifacts` ↔ `apply-state.spec.ts`.
+    The result replaces ~3 separate `Read` calls and pins every
+    function the worker will need to import.
+  - **Todo 2** — one call: `codegraph_explore("readRestoreSource
+    buildRestorePlan RestorePlan RestorePair integrityStatus")` after
+    stubbing. The graph won't yet have `restore-command` symbols
+    (it's a new file the worker just wrote) — but the call surfaces
+    the neighboring G1+G2 symbols the worker still needs (sha256
+    source path, the `<runId>.json` reader, the `readApplyLog`
+    parser). Use the staleness banner as a guide: any symbol marked
+    "edited since the last index sync" is one the worker should
+    re-Read for accurate content.
+  - **Todo 3** — two calls:
+    1. `codegraph_explore("cli dispatcher apply scan bootstrap
+      restore-last run args")` — pin the existing `cli.ts` arm
+      structure before adding the new arm. Returns the dispatcher
+      body and the `USAGE` constant in one read.
+    2. After editing `cli.ts`: `codegraph_explore("cli apply
+      bootstrap restore-last USAGE")` — verify the new arm's call
+      path lands on `runRestore` and doesn't accidentally re-route
+      an existing arm.
+  - **Todo 4** — zero mandatory calls; the work is docs + smoke
+    script + lint. The orchestrator can still call
+    `codegraph_explore` ad-hoc to confirm no orphans (e.g. verify
+    `restore-command.ts` exports are all referenced from
+    `cli.ts`).
+
+### Serena — symbol-level semantic edits
+
+- **When to invoke**: symbol-level edits on EXISTING files — renaming,
+  replacing a function body, replacing an interface body, finding
+  every reference to a symbol before changing its signature. The
+  `serena_initial_instructions` call is mandatory at the start of
+  each worker's first task in this slice (per the Serena MCP's own
+  tool description).
+- **When NOT to invoke**: new file creation (Write tool is fine);
+  test spec files (Vitest conventions are text-y; per-case edit
+  patterns are easier to express as `Edit`); full-file rewrites
+  (just `Write` the new content).
+- **Mandatory calls per Todo**:
+  - **Todo 1** — `serena_initial_instructions` ONCE at task start
+    (per the Serena MCP rule). Then for each stub function in
+    `restore-command.ts`, use `serena_replace_symbol_body` with the
+    `Error('TODO G3 Wave 2: <name>')` placeholder. Confirms the
+    symbol table recognizes each export.
+  - **Todo 2** — for each pure helper implementation
+    (`readRestoreSource`, `buildRestorePlan`,
+    `formatHumanRestorePlan`, `formatHumanRestoreOutcome`), use
+    `serena_replace_symbol_body` to swap the TODO stub for the real
+    body. Use `serena_find_referencing_symbols` to confirm callers
+    before changing any signature on a shared type
+    (`RestorePair.integrityStatus` is the riskiest — it's a string
+    union that the renderer + plan builder both consume).
+  - **Todo 3** — `serena_insert_before_symbol` /
+    `serena_insert_after_symbol` for adding the new dispatcher arm
+    inside `cli.ts` (cleaner than `Edit` for additive structural
+    edits in a known location). For the new `runRestore` body,
+    `serena_replace_symbol_body` again.
+  - **Todo 4** — optional `serena_find_symbol("G3")` /
+    `serena_search_for_pattern("G3")` to confirm no stale references
+    to a previous gate-rejected decision linger in code.
+
+### Anti-patterns
+
+- Re-verifying codegraph results with grep / Read after the call
+  returns. The graph is AST-derived; trust it.
+- Reaching for `Read` first on an indexed file. Always
+  `codegraph_explore` first.
+- Using `Edit` for symbol-body replacement when the file is indexed
+  and the symbol is named. Use `serena_replace_symbol_body` so the
+  change flows through the symbol table.
+- Spawning new specialist sessions for read-only lookups the
+  orchestrator can answer with one codegraph call.
+
+---
+
+## Verification strategy
+
+> Zero human intervention - all verification is agent-executed.
+
+- Test decision: **TDD** with Vitest. New module under
+  `apps/cli/src/restore-command.ts` and spec under
+  `apps/cli/src/restore-command.spec.ts`. CLI dispatcher cases added
+  to `apps/cli/src/cli.spec.ts`.
+- Evidence directory: `.omo/evidence/`.
+- Per-task evidence naming:
+  `.omo/evidence/task-<N>-g3-restore-last.<ext>`.
+- Required targeted Vitest commands during TDD:
+  - `yarn vitest apps/cli/src/restore-command.spec.ts --run`
+  - `yarn vitest apps/cli/src/cli.spec.ts --run` (dispatcher regression)
+  - `yarn vitest apps/cli/src/apply-command.spec.ts --run` (G1/G2 stay green)
+  - `yarn vitest apps/cli/src/apply-state.spec.ts --run` (G1 stays green; Case 7 only if gate G3-7 approved)
+  - `yarn vitest apps/cli/src/apply-log.spec.ts --run` (G2 stays green)
+- Final gates use workspace-pinned commands, not RTK global tools.
+
+## Execution strategy
+
+### Parallel execution waves
+
+- **Wave 1 — red tests + source reader stub**: Todo 1.
+- **Wave 2 — pure rendering + integrity evaluation**: Todo 2.
+- **Wave 3 — dispatcher arm + flag parser + execute path**: Todo 3.
+- **Wave 4 — gates + docs + smoke**: Todo 4.
+
+### Dependency matrix
+
+| Todo | Depends on | Blocks | Can parallelize with |
+| --- | --- | --- | --- |
+| 1 | none | 2 | none |
+| 2 | 1 | 3 | none |
+| 3 | 2 | 4 | none |
+| 4 | 3 | final verification | none |
+
+## Todos
+
+> Implementation + Test = ONE todo. Never separate.
+<!-- APPEND TASK BATCHES BELOW THIS LINE WITH edit/apply_patch - never rewrite the headers above. -->
+
+- [ ] 1. `apps/cli/src/restore-command.spec.ts` + stub module: red tests + readRestoreSource scaffold — expect 11 cases fail against stub
+  What to do / Must NOT do: Create
+  `apps/cli/src/restore-command.spec.ts` mirroring the 11 cases in
+  Must-have. To make those compile + fail at the assertion level
+  (not import), also create a stub `apps/cli/src/restore-command.ts`
+  exporting `RestorePair`, `RestorePlan`, `buildRestorePlan`,
+  `readRestoreSource`, `formatHumanRestorePlan`,
+  `formatHumanRestoreOutcome`, `runRestore` — every function body
+  throws `Error('TODO G3 Wave 2: <name>')`. Mark the stub header
+  clearly as G3 Wave 1 scaffolding to be replaced in Wave 2. Do NOT
+  touch `apply-state.ts`, `apply-log.ts`, `apply-command.ts`,
+  `cli.ts`, or any writer. Do NOT add new dependencies.
+  Parallelization: Wave 1 | Blocked by: none | Blocks: 2
+  MCP calls (REQUIRED): `serena_initial_instructions` ONCE at task
+  start (per Serena MCP rule). ONE `codegraph_explore` call:
+  `"readApplyState readApplyLog writeApplyState sha256OfFile
+  ApplyStateAgent"` — pins the G1+G2 surface + call paths the worker
+  will import. Use `serena_replace_symbol_body` for each stub
+  function (replace the placeholder body with the real `throw` body)
+  so the symbol table recognizes every export. The spec file is a
+  fresh write (`Write` tool, no MCP needed); the stub file's plain
+  `throw` body is best written via `serena_replace_symbol_body` per
+  export.
+  References (executor has NO interview context - be exhaustive):
+  `apps/cli/src/apply-log.ts:256-280` (`readApplyLog` parser, the
+  `restorePairs` array already populated); `apps/cli/src/
+  apply-state.ts:135-143` (`sha256OfFile` integrity primitive);
+  `apps/cli/src/apply-state.ts:163-198` (the `ApplyStateRecord`
+  shape with `targetPaths` / `backupPaths` paired); `apps/cli/src/
+  apply-state.ts:237-248` (`readApplyState` reader); `apps/cli/src/
+  apply-command.ts:213` (`APPLY_USAGE` constant — mirror for the
+  new `RESTORE_USAGE`).
+  Acceptance criteria (agent-executable):
+  `yarn vitest apps/cli/src/restore-command.spec.ts --run` fails all
+  11 cases against the stub; `yarn vitest apps/cli/src/apply-state
+  .spec.ts --run` passes 6 cases; `yarn vitest apps/cli/src/
+  apply-log.spec.ts --run` passes 6 cases; `yarn tsc -b apps/cli`
+  exits 0.
+  QA scenarios (name the exact tool + invocation): happy:
+  `yarn vitest apps/cli/src/restore-command.spec.ts --run 2>&1 | tee
+  .omo/evidence/task-1-g3-restore-last.txt`, asserting the 11 cases
+  fail; failure: a missing stub export surfaces as TS2305/TS2307.
+  Commit: N | grouped with Todo 3.
+
+- [ ] 2. `apps/cli/src/restore-command.ts`: pure helpers + integrity evaluation — expect 11 cases turn green
+  What to do / Must NOT do: Implement per gate G3-2:
+  - `readRestoreSource(stateDir, runId)` — try JSON first via
+    `readApplyState`; on ENOENT fall back to `readApplyLog`; on
+    ENOENT for both, return `{ source: 'last-json-pointer', pairs:
+    [] }`.
+  - `buildRestorePlan(stateDir, runId, now)` — call
+    `readRestoreSource`, evaluate `sha256OfFile(<target>)` against
+    `preWriteSha256` per pair (skipping the check when the source is
+    `log-tag-lines` → `unverified`).
+  - `formatHumanRestorePlan` and `formatHumanRestoreOutcome` — pure
+    string renderers, lock the format in this slice (mirrors G2's
+    Case 3 contract).
+  Implement per gate G3-1, G3-3, G3-5: flag whitelist
+  (`--dry-run`, `--yes`, `--force`, `--run-id <id>`), TTY detection
+  via `process.stdin.isTTY`, prompt helper via a thin
+  `readline`-wrapped function (testable via `vi.spyOn`). Do NOT
+  add the `runRestore` execution path yet (that's Wave 3). Do NOT
+  touch `apply-state.ts`, `apply-log.ts`. Do NOT change G1/G2 case
+  assertions.
+  Parallelization: Wave 2 | Blocked by: 1 | Blocks: 3.
+  MCP calls (REQUIRED): one `codegraph_explore` call: `"readRestoreSource
+  buildRestorePlan RestorePlan RestorePair integrityStatus"` — note
+  the graph may not yet have `restore-command` symbols (new file the
+  worker just wrote); use the call to refresh neighboring G1+G2
+  symbols (sha256 path, `readApplyLog` parser, `readApplyState`
+  reader) and watch the staleness banner. Use
+  `serena_replace_symbol_body` for each helper (replace the Wave 1
+  stub body with the real implementation body). Before changing
+  `RestorePair.integrityStatus` (a string union consumed by both the
+  renderer and the plan builder), call
+  `serena_find_referencing_symbols` on each member and confirm every
+  consumer is updated.
+  References (executor has NO interview context - be exhaustive):
+  Node docs `node:readline/promises` for `confirm`-style prompts
+  (https://nodejs.org/api/readline.html); `apps/cli/src/
+  apply-command.ts:1043-1054` for the existing `loadAndValidateProfile`
+  pattern (mirror the validation style); `apps/cli/src/
+  bootstrap-prompt.ts` for the existing interactive prompt surface
+  (study, don't import).
+  Acceptance criteria (agent-executable):
+  `yarn vitest apps/cli/src/restore-command.spec.ts --run` passes
+  cases 1-5 (the pure-logic ones; 6-11 still fail awaiting Wave 3's
+  execution path); `yarn tsc -b apps/cli` exits 0.
+  QA scenarios: `yarn vitest apps/cli/src/restore-command.spec.ts
+  --run 2>&1 | tee .omo/evidence/task-2-g3-restore-last.txt`.
+  Commit: N | grouped with Todo 3.
+
+- [ ] 3. `apps/cli/src/restore-command.ts` (execute path) + `apps/cli/src/cli.ts` (dispatcher arm) + spec cases 6-11: execution + dispatcher cases
+  What to do / Must NOT do:
+  1. Implement `runRestore(args, stdout, stderr, options?)`:
+     - Parse flags; resolve runId from `last.json` when omitted.
+     - Build the plan; render the plan to stdout.
+     - If `--dry-run` → exit 0 (no `mv`).
+     - If `--yes --force` / `--yes --no-mismatch` / interactive `y`
+       → spawn `mv -v` per pair sequentially. Capture exit codes.
+       Stop on first failure (atomic semantics).
+     - Render the outcome; exit 0 / 1 / 2 per gate G3-8.
+  2. Add the dispatcher arm in `apps/cli/src/cli.ts:225-251` after
+     the `bootstrap` / `apply` arms; update the `USAGE` string
+     (line 127) to advertise `restore-last`.
+  3. Cases 6-11 in `restore-command.spec.ts` turn green; no
+     changes to cases 1-5.
+  4. Optional Case 12-15 to `apps/cli/src/cli.spec.ts`: dispatcher
+     regressions (`--help`, `--unknown-flag`, no-args-still-USAGE,
+     end-to-end `--dry-run` smoke via `XDG_STATE_HOME`).
+  Parallelization: Wave 3 | Blocked by: 2 | Blocks: 4.
+  MCP calls (REQUIRED): TWO `codegraph_explore` calls — first,
+  BEFORE editing `cli.ts`: `"cli dispatcher apply scan bootstrap
+  restore-last run args"` to pin the existing arm structure and the
+  `USAGE` constant in one read; second, AFTER editing `cli.ts`:
+  `"cli apply bootstrap restore-last USAGE"` to verify the new arm's
+  call path lands on `runRestore` and doesn't accidentally re-route
+  an existing arm. Use `serena_insert_before_symbol` /
+  `serena_insert_after_symbol` for adding the new dispatcher arm
+  inside `cli.ts` (cleaner than `Edit` for additive structural edits
+  in a known location); use `serena_replace_symbol_body` for the
+  new `runRestore` body and any `runRestore` test scaffolding. New
+  spec cases 6-11 in `restore-command.spec.ts` are additive Edit
+  calls — no MCP needed for the spec file edits.
+  References (executor has NO interview context - be exhaustive):
+  Node docs `node:child_process` `spawn('mv', [...])` — pipe `mv`
+  stdout to a captured string for the outcome; `apps/cli/src/
+  cli.ts:214-251` (the existing dispatcher arms — match the
+  signature); `apps/cli/src/bootstrap-command.ts` for the existing
+  `runBootstrap` shape (mirror the dispatch contract).
+  Acceptance criteria (agent-executable):
+  `yarn vitest apps/cli/src/restore-command.spec.ts --run` passes
+  all 11 cases; `yarn vitest apps/cli/src/cli.spec.ts --run` passes
+  all current + new cases; other CLI tests still pass;
+  `yarn tsc -b apps/cli` exits 0.
+  QA scenarios: `yarn vitest apps/cli/src/restore-command.spec.ts
+  --run 2>&1 | tee .omo/evidence/task-3-g3-restore-last.txt`.
+  Commit: Y | `feat(cli): add overture restore-last helper (G3)`.
+
+- [ ] 4. `docs/overture-implementation-slices.md` + `apps/cli/scripts/verify-package.mjs` + workspace gates: mark G3 delivered — expect gates green and scope holds
+  What to do / Must NOT do:
+  1. Update `docs/overture-implementation-slices.md:609-615` (the G3
+     "Expected result" block) to a "Delivered" section mirroring
+     the G1 / G2 delivered-block style (lists which gates shipped,
+     which were rejected, the resulting file surface, the test
+     count, and the audit-trail behavior).
+  2. If gate G3-7 was approved, add Case 7 to
+     `apps/cli/src/apply-state.spec.ts` and update the G1
+     "Delivered" block to mention the `mode: 'restore'` widening.
+     Update `README.md` if gate G3-7 affects any user-facing
+     surface (it does not, by default — only when the user widens
+     the union).
+  3. Add a G3 smoke to `apps/cli/scripts/verify-package.mjs` after
+     the G2 smoke block — seed a restore-ready
+     `last.json` + `apply/<runId>.json` + `apply/<runId>.log`,
+     invoke `overture restore-last --dry-run`, assert the seeded
+     pair's `mv -v '…' '…'` line appears in stdout.
+  4. Run all 6 workspace gates. `git diff --stat` shows only
+     `restore-command.{ts,spec.ts}`, `cli.ts`, `cli.spec.ts`,
+     `apply-state.ts`/`spec.ts` (only if gate G3-7), the slice
+     doc, and the verify-package script.
+  Parallelization: Wave 4 | Blocked by: 3 | Blocks: final verification.
+  MCP calls (REQUIRED): zero mandatory codegraph calls (the work is
+  docs + smoke script + lint). Optional:
+  `serena_find_symbol("G3")` and/or
+  `serena_search_for_pattern("G3")` to confirm no stale references to
+  gate-rejected decisions linger in code; `serena_find_referencing_symbols`
+  on `runRestore` to confirm every export is wired (the dispatcher
+  arm should reference it; no other callers expected).
+  References (executor has NO interview context - be exhaustive):
+  `docs/overture-implementation-slices.md:529-607` (G2 delivered
+  block — mirror the prose style); `apps/cli/scripts/
+  verify-package.mjs` (existing G1/G2 smoke block — add a G3
+  smoke after).
+  Acceptance criteria (agent-executable): All commands exit 0:
+  `yarn nx test @overture/agents --skip-nx-cache`,
+  `yarn nx test @jander99/overture --skip-nx-cache`,
+  `yarn nx build @jander99/overture --skip-nx-cache`,
+  `yarn nx lint @jander99/overture --skip-nx-cache`,
+  `yarn prettier --check .`,
+  `node apps/cli/scripts/verify-package.mjs`.
+  QA scenarios: `{ yarn nx test @overture/agents --skip-nx-cache
+  && yarn nx test @jander99/overture --skip-nx-cache && yarn nx
+  build @jander99/overture --skip-nx-cache && yarn nx lint
+  @jander99/overture --skip-nx-cache && yarn prettier --check .
+  && node apps/cli/scripts/verify-package.mjs; } | tee
+  .omo/evidence/task-4-g3-restore-last.txt`.
+  Commit: Y | `docs(cli): record G3 restore-last helper delivery`.
+
+## Final verification wave
+
+> Runs in parallel after ALL todos. ALL must APPROVE. Surface results and
+> wait for the user's explicit okay before declaring complete.
+
+- [ ] F1. Plan compliance audit
+  - Agent-executable check: compare final diff against this plan and
+    assert every Must Have is covered and every Must NOT is respected.
+    Specifically: G1 retention invariant holds (no `pruneApplyState`
+    / `pruneApplyArtifacts` changes); G1 spec cases 1-6 stay
+    byte-identical (unless gate G3-7 added Case 7); G2 spec cases 1-6
+    stay byte-identical; `apply-command.spec.ts` cases 1-33 stay
+    byte-identical (no replacement); no writer files touched.
+  - **MCP usage audit**: verify the per-Todo MCP calls were made —
+    `codegraph_explore` calls in Todo 1, Todo 2, Todo 3 (×2), and the
+    `serena_initial_instructions` invocation at the start of the
+    first worker session. Cross-check the worker's evidence logs
+    (`.omo/evidence/task-*-g3-restore-last.txt`) for traces of the
+    MCP calls; missing traces = audit failure for that Todo.
+  - Evidence: `.omo/evidence/f1-g3-restore-last-plan-compliance.md`.
+- [ ] F2. Code quality review
+  - Agent-executable check: review touched TypeScript for strict
+    typing, no `any`, no `unknown` casts, no `fs.rename` lurking
+    around (must use `child_process.spawn('mv')` per gate G3-6),
+    no `--json` flag added to `restore-last`, no broad `ApplyResult`
+    widening, no `apply-state.mode` widening unless gate G3-7
+    approved. Confirm Gate G3-7 audit-trail code path only fires
+    when that gate is approved.
+  - Evidence: `.omo/evidence/f2-g3-restore-last-code-quality.md`.
+- [ ] F3. Real manual QA by agent
+  - Agent-executable check: seed a tmpdir with
+    `overture.jsonc` + Claude Code config + OpenCode config; run
+    `overture apply`; assert `stateDir/apply/last.json` +
+    `apply/<runId>.json` + `apply/<runId>.log` are all on disk;
+    then run `overture restore-last --dry-run` and assert the
+    rendered plan is on stdout with at least one `mv -v '…' '…'`
+    line. Then run `overture restore-last --yes` and assert the
+    target files are restored to their pre-apply bytes (compare
+    against `ApplyStateAgent.preWriteSha256`). Then run
+    `overture restore-last --yes` again — assert
+    `integrityStatus: 'missing-backup'` (the backups were
+    consumed) and that the command exits 1 with a clear stderr
+    message rather than silently doing nothing.
+    Evidence: `.omo/evidence/f3-g3-restore-last-real-qa.md`.
+- [ ] F4. Scope fidelity
+  - Agent-executable check: verify no writer changes, no G1/G2 spec
+    modifications (Case 7 only if gate G3-7), no batched restore
+    artifact, no `restore <subcommand>` umbrella, no `--json` flag on
+    `restore-last`, no `apply-state.mode` widening (unless G3-7
+    approved), no Nx project addition, no unrelated files staged.
+  - Evidence: `.omo/evidence/f4-g3-restore-last-scope.md`.
+
+## Commit strategy
+
+- Work on a new branch via worktree:
+  - `.worktrees/g3-restore-last` on `feat/g3-restore-last`.
+- Before any PR/commit work, worker must inspect:
+  - `git status --short`
+  - `git diff --stat`
+  - `git log --oneline -5`
+  - `git worktree list`
+  - `git fetch origin main` (per AGENTS.md)
+- Commit groups:
+  1. `feat(cli): add overture restore-last helper (G3)` — Todos 1-3
+     (tests, codec, dispatcher arm).
+  2. `docs(cli): record G3 restore-last helper delivery` — Todo 4.
+- Stage only intended files; never stage untracked `ARCHITECTURE.md`,
+  `STRUCTURE.md`, `.codegraph/`, `.cortexkit/`, `.serena/`, or local
+  evidence unless explicitly requested.
+- PR title recommendation: `feat(cli): add overture restore-last helper (G3)`.
+
+## Success criteria
+
+- `overture restore-last --help` prints a USAGE block listing
+  `--dry-run`, `--yes`, `--force`, `--run-id <id>` and exits 0.
+- `overture restore-last --dry-run` reads `last.json` + the resolved
+  `<runId>.json`, prints the plan, exits 0, performs no `mv`
+  invocations (verified via vitest `vi.spyOn` on
+  `child_process.spawn`).
+- `overture restore-last --yes` with all `ok` integrity checks: every
+  pair succeeds, exit 0; backups are exhausted (the apply's
+  `.bak.<ts>` files are gone); targets hold the pre-apply bytes.
+- `overture restore-last --yes` with a `mismatch` pair without
+  `--force`: exit 1, NO `mv` runs (atomic semantics), stderr carries
+  the rejection line, targets untouched.
+- `overture restore-last --yes --force` with a `mismatch` pair:
+  proceeds, stderr carries the WARN line, exit 0 iff every pair
+  succeeded.
+- `overture restore-last --run-id <id>` chooses a specific runId; a
+  pruned runId is rejected with a clear stderr message and exit 1.
+- Missing `last.json` → exit 1 with a clear stderr message naming
+  `stateDir`.
+- TTY + no `--yes` → interactive prompt; `y` permits, anything else
+  aborts; non-TTY + no `--yes` → exit 2 with a stderr hint.
+- Fallback to log-tag-lines path when JSON absent + log present:
+  plan returns `source: 'log-tag-lines'`, integrity status
+  `unverified`, restore proceeds.
+- Full workspace gates pass (`yarn nx test`, `yarn nx build`,
+  `yarn nx lint`, `yarn prettier --check .`,
+  `node apps/cli/scripts/verify-package.mjs`).
+- G1 spec cases 1-6 stay byte-identical (7 added only if gate G3-7
+  approved); G2 spec cases 1-6 stay byte-identical; apply-command
+  spec cases 1-33 stay byte-identical.
+- Slice doc G3 "Expected result" → "Delivered" block accurately
+  documents the implemented surface and which gates shipped.
+
+---
+
+# Gate summary (awaiting approval)
+
+Pick a verdict on each. Defaults shown match the "Proposed" text above.
+
+| Gate | Question | Default (recommended) | Reject? Alternative? |
+| --- | --- | --- | --- |
+| G3-1 | Command surface | top-level `overture restore-last` | nested `apply restore-last` / umbrella `restore` / `overture undo` |
+| G3-2 | Source preference | JSON first, log fallback | log-only or JSON-only |
+| G3-3 | Run selection | `--run-id <id>` overrides `last.json`; no listing | add `--list` / TUI picker |
+| G3-4 | Confirmation | `--dry-run` / `--yes` / `--force` + TTY prompt | implicit yes or partial-failure batched |
+| G3-5 | Integrity check | sha256 vs `preWriteSha256`; `--force` overrides | no check or mtime check |
+| G3-6 | Execution primitive | `child_process.spawn('mv -v', …)` per pair | `fs.rename` or `cp`+`unlink` |
+| G3-7 | Audit record on disk | OFF — no schema widening, no new file | write `restore-<ts>-<hex>.json` with `mode: 'restore'` |
+| G3-8 | Exit codes | 0/1/2 with atomic whole-run semantics | single code or pair-vs-run split |
+
+Implement the plan ONLY after each gate has a verdict.

--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -693,12 +693,18 @@ const stateHomeStateDir = join(stateHome, '.local', 'state');
 // records to the real home instead of the smoke's tmpdir. The F2 smoke
 // never trips on this because the F2 path is no-change (no state file
 // is written); the G1 path always writes, so we have to pin the env.
+//
+// PATH must PREPEND `statePathDir` (so the fake opencode binary wins
+// detection) but PRESERVE the inherited system PATH — the end-to-end
+// apply → restore-last smoke below needs `/usr/bin/mv` (or equivalent)
+// to actually execute the restore. Replacing PATH with just
+// `statePathDir` breaks the F3 G3 regression guard.
 const stateEnv = {
   ...process.env,
   HOME: stateHome,
   XDG_CONFIG_HOME: stateXdg,
   XDG_STATE_HOME: stateHomeStateDir,
-  PATH: statePathDir,
+  PATH: `${statePathDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`,
 };
 // Seed the canonical config — target OpenCode with a single canonical
 // `filesystem` server. `backupBeforeWrite: true` exercises the F2
@@ -850,6 +856,100 @@ if (statePointer.runId !== stateExpectedRunId) {
 
 console.log(
   `apply (no flag, state-file): exit=${stateApplyResult.status} targetModified=PASS backupExists=PASS recordSchemaVersion=1 recordHasOpencode=PASS pointerMatches=PASS`,
+);
+
+// ---------------------------------------------------------------------------
+// F3 / G3 end-to-end smoke: apply → restore-last --yes, on the SAME state
+// the G1 smoke just produced. This is the load-bearing regression guard
+// for the F3 BLOCKING finding (Anomaly 1: opencode writer emits
+// `loc.relativePath` as the raw `targetPaths[*].path`, and a pre-fix
+// restore-last would `mv` against the relative path and silently fail).
+// After the fix, `buildApplyStateRecord` resolves every target against
+// the apply-time `PathResolutionContext` and the seeded pair's `mv -v`
+// hits the absolute target on disk. The smoke fails LOUDLY if a future
+// regression reintroduces the relative-path bug.
+// ---------------------------------------------------------------------------
+
+// Backup file path is the opencode target's pre-apply sidecar. Re-discover
+// it from the seeded dir (same logic as the apply assertions above).
+const stateEndToEndBackup = join(stateOpencodeHomeDir, stateBackupFiles[0]);
+if (!statSync(stateEndToEndBackup, { throwIfNoEntry: false })) {
+  fail(
+    `restore-last end-to-end: backup file ${stateEndToEndBackup} missing before restore-last --yes`,
+  );
+}
+// Snapshot the apply's post-write target bytes so we can confirm the
+// restore reverts them to the pre-apply bytes captured at G1 smoke.
+const stateEndToEndAfterApplyBytes = stateOpencodeAfterBytes;
+
+// Run the dispatcher. cwd must be the workspace (or anywhere inside the
+// worktree — but the workspace is the cleanest) so the writer's
+// `process.cwd()`-anchored resolution matches the apply run.
+// We pass `--force` because gate G3-5's integrity check compares the
+// CURRENT target sha256 against `preWriteSha256` (the pre-apply bytes).
+// After a real apply the target carries post-apply bytes, so the check
+// always reports `mismatch` for a non-no-op restore — `--force`
+// (gate G3-4) is the user-opt-in that authorizes the clobber. The
+// F3 BLOCKING regression we're guarding is the relative-target bug,
+// which surfaces BEFORE the integrity check (the `mv` never fires),
+// not inside the integrity gate itself.
+const stateEndToEndResult = spawnWithEnv(
+  [distMain, 'restore-last', '--yes', '--force'],
+  stateEnv,
+  { cwd: stateWorkspace },
+);
+if (stateEndToEndResult.status !== 0) {
+  fail(
+    `restore-last --yes --force (end-to-end after real apply) exited ${stateEndToEndResult.status} (expected 0)\nstdout:\n${stateEndToEndResult.stdout}\nstderr:\n${stateEndToEndResult.stderr}`,
+  );
+}
+
+// F3 guard 1 — the target must now match the pre-apply bytes. The
+// pre-fix bug would leave it untouched (the `mv` would fail because of
+// the relative target path).
+const stateEndToEndRestoredBytes = readFileSync(stateOpencodeConfig);
+if (!stateEndToEndRestoredBytes.equals(stateOpencodeBeforeBytes)) {
+  fail(
+    `restore-last --yes --force (end-to-end) did NOT restore the target to pre-apply bytes\nbefore-apply bytes: ${stateOpencodeBeforeBytes.length}\nafter-restore bytes: ${stateEndToEndRestoredBytes.length}\nstdout:\n${stateEndToEndResult.stdout}\nstderr:\n${stateEndToEndResult.stderr}`,
+  );
+}
+
+// F3 guard 2 — the backup file must be unlinked by the restore. Pre-fix
+// the `mv` failed so the backup persisted; the after-apply bytes must
+// differ from the before-restore bytes (otherwise the test seeded a
+// no-op).
+if (stateEndToEndAfterApplyBytes.equals(stateOpencodeBeforeBytes)) {
+  fail(
+    'restore-last --yes --force (end-to-end) precondition failed: apply did not modify the target — there is nothing to restore',
+  );
+}
+const stateEndToEndBackupStat = statSync(stateEndToEndBackup, {
+  throwIfNoEntry: false,
+});
+if (stateEndToEndBackupStat) {
+  fail(
+    `restore-last --yes --force (end-to-end) did NOT unlink the backup at ${stateEndToEndBackup} (pre-fix regression)`,
+  );
+}
+
+// F3 guard 3 — the outcome must report `restored: 1` (one pair restored).
+if (!stateEndToEndResult.stdout.includes('restored: 1')) {
+  fail(
+    `restore-last --yes --force (end-to-end) stdout missing "restored: 1" line\nstdout:\n${stateEndToEndResult.stdout}`,
+  );
+}
+
+// F3 guard 4 — the WARN line for the forced restore must appear on stderr
+// (gate G3-4 mandates `WARN: target <path> was edited since apply;
+// restore forced.` per pair).
+if (!stateEndToEndResult.stderr.includes('restore forced')) {
+  fail(
+    `restore-last --yes --force (end-to-end) stderr missing "restore forced" WARN line\nstderr:\n${stateEndToEndResult.stderr}`,
+  );
+}
+
+console.log(
+  `restore-last --yes --force (end-to-end after real apply): exit=${stateEndToEndResult.status} targetRestoredToPreApply=PASS backupUnlinked=PASS restoredCount=1 forceWarn=PASS`,
 );
 
 // Cleanup state tmpdirs.
@@ -1383,5 +1483,5 @@ rmSync(bootstrapPath, { recursive: true, force: true });
 
 logStep('PASS');
 console.log(
-  'All verifications passed. The tarball is ready to publish, including bootstrap, apply (F2 no-change), apply (F3 refused-apply), and restore-last (G3 --dry-run) smoke checks.',
+  'All verifications passed. The tarball is ready to publish, including bootstrap, apply (F2 no-change), apply (F3 refused-apply), restore-last (G3 --dry-run), and restore-last --yes --force (G3 end-to-end after real apply) smoke checks.',
 );

--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -13,6 +13,7 @@
 // Exits non-zero on any failure. Does NOT publish.
 
 import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   mkdtempSync,
   mkdirSync,
@@ -1183,6 +1184,196 @@ rmSync(logXdg, { recursive: true, force: true });
 rmSync(logPathDir, { recursive: true, force: true });
 rmSync(logWorkspace, { recursive: true, force: true });
 
+logStep('Restore-last --dry-run smoke (G3)');
+// G3 restore-last --dry-run smoke. Skip `overture apply` entirely — G1
+// already proved the JSON / log writers; here we need to prove that the
+// DISPATCHER path `overture restore-last --dry-run` reads a G1 record,
+// renders the plan, and (most importantly) does NOT actually mv any
+// backup. The dry-run branch in `runRestore` short-circuits before the
+// `spawn mv -v` loop (matches the gate G3-6 guard). End-to-end guard for
+// the G3 contract as exercised by the installed binary: `--dry-run`
+// exits 0, renders the seeded pair's `mv -v '…' '…'` line, and leaves
+// both the target and the backup file untouched on disk.
+//
+// Layout:
+//   <ws>/mcp-target.json                 ← current on-disk target
+//   <ws>/mcp-target.json.bak.<ts>        ← the G1 backup
+//   <xdg>/overture/apply/last.json       ← pointer
+//   <xdg>/overture/apply/<runId>.json    ← G1 record (canonical source)
+//   <xdg>/overture/apply/<runId>.log     ← G2 log (seeding for parity;
+//                                          dry-run reads the JSON, not
+//                                          the log, so this file is
+//                                          here only to assert the
+//                                          apply dir carries both).
+const restoreHome = mkdtempSync('/tmp/overture-verify-restore-home-');
+const restoreXdg = mkdtempSync('/tmp/overture-verify-restore-xdg-');
+const restorePathDir = mkdtempSync('/tmp/overture-verify-restore-path-');
+const restoreWorkspace = mkdtempSync('/tmp/overture-verify-restore-ws-');
+// Same XDG_STATE_HOME discipline as the G1 smoke — a parent's leak
+// would otherwise hijack the recorded state dir.
+const restoreHomeStateDir = join(restoreHome, '.local', 'state');
+const restoreEnv = {
+  ...process.env,
+  HOME: restoreHome,
+  XDG_CONFIG_HOME: restoreXdg,
+  XDG_STATE_HOME: restoreHomeStateDir,
+  PATH: restorePathDir,
+};
+
+// Seed the current on-disk target and the backup with IDENTICAL bytes so
+// `currentSha256 === preWriteSha256` → `integrityStatus: 'ok'`. A real
+// `mv -v` would unlink the backup and overwrite the target; the dry-run
+// short-circuit must leave both intact.
+const restoreTarget = join(restoreWorkspace, 'mcp-target.json');
+const restoreBackup = join(
+  restoreWorkspace,
+  'mcp-target.json.bak.20260704-183000123',
+);
+const restoreTargetBefore = '{"current":true}\n';
+writeFileSync(restoreTarget, restoreTargetBefore);
+writeFileSync(restoreBackup, restoreTargetBefore);
+const restoreTargetBeforeBytes = readFileSync(restoreTarget);
+const restoreBackupBeforeBytes = readFileSync(restoreBackup);
+const restorePreSha = createHash('sha256')
+  .update(restoreTargetBefore)
+  .digest('hex');
+
+const restoreRunId = '20260704-183000123-eeeeeeee';
+const restoreApplyDir = join(restoreHomeStateDir, 'overture', 'apply');
+mkdirSync(restoreApplyDir, { recursive: true });
+const restoreRecord = {
+  schemaVersion: 1,
+  runId: restoreRunId,
+  timestamp: '2026-07-04T18:30:00.123Z',
+  mode: 'apply',
+  profile: 'default',
+  configPath: join(restoreXdg, 'overture', 'overture.jsonc'),
+  backupBeforeWrite: true,
+  agents: [
+    {
+      agentId: 'claude-code',
+      displayName: 'Claude Code',
+      status: 'updated',
+      targetPaths: [restoreTarget],
+      backupPaths: [restoreBackup],
+      preWriteSha256: restorePreSha,
+      postWriteSha256: null,
+    },
+  ],
+};
+writeFileSync(
+  join(restoreApplyDir, `${restoreRunId}.json`),
+  JSON.stringify(restoreRecord),
+);
+writeFileSync(
+  join(restoreApplyDir, 'last.json'),
+  JSON.stringify({ runId: restoreRunId }),
+);
+// Paired G2 log so the apply dir carries both .json + .log (mirrors the
+// G2 smoke's pairing). Dry-run reads the G1 record, not the log, so
+// this file is purely cosmetic for the dry-run pass.
+const restoreLogPath = join(restoreApplyDir, `${restoreRunId}.log`);
+writeFileSync(
+  restoreLogPath,
+  [
+    '='.repeat(80),
+    'Overture apply log',
+    '='.repeat(80),
+    `run id: ${restoreRunId}`,
+    '',
+    '[claude-code] Claude Code',
+    'status: updated',
+    `backup: '${restoreBackup}'`,
+    `target: '${restoreTarget}'`,
+    `mv -v '${restoreBackup}' '${restoreTarget}'`,
+    '',
+  ].join('\n'),
+);
+
+const restoreResult = spawnWithEnv(
+  [distMain, 'restore-last', '--dry-run'],
+  restoreEnv,
+  { cwd: restoreWorkspace },
+);
+if (restoreResult.status !== 0) {
+  fail(
+    `restore-last --dry-run exited ${restoreResult.status} (expected 0)\nstdout:\n${restoreResult.stdout}\nstderr:\n${restoreResult.stderr}`,
+  );
+}
+
+// Plan header must name the seeded runId. The renderer emits
+// `run id:        <runId>` (8 spaces) per `formatHumanRestorePlan`.
+if (!restoreResult.stdout.includes(`run id:        ${restoreRunId}`)) {
+  fail(
+    `restore-last --dry-run stdout missing "run id:        ${restoreRunId}" header line\nstdout:\n${restoreResult.stdout}`,
+  );
+}
+// Source must report `state-json` (the JSON path wins over the
+// fallback log-tag-lines source).
+if (!restoreResult.stdout.includes(`source:        state-json`)) {
+  fail(
+    `restore-last --dry-run stdout missing "source:        state-json" header line\nstdout:\n${restoreResult.stdout}`,
+  );
+}
+// Integrity line for the seeded pair — `ok` because currentSha256 ===
+// preWriteSha256 by construction above.
+if (!restoreResult.stdout.includes('  status: ok')) {
+  fail(
+    `restore-last --dry-run stdout missing per-pair "  status: ok" line\nstdout:\n${restoreResult.stdout}`,
+  );
+}
+// The load-bearing assertion: the seeded pair's `mv -v '<backup>'
+// '<target>'` line appears in the dry-run plan. Two leading spaces
+// reflect the `formatHumanRestorePlan` indent.
+if (
+  !restoreResult.stdout.includes(
+    `  mv -v '${restoreBackup}' '${restoreTarget}'`,
+  )
+) {
+  fail(
+    `restore-last --dry-run stdout missing the seeded pair's "mv -v '<backup>' '<target>'" line\nstdout:\n${restoreResult.stdout}\nbackup=${restoreBackup}\ntarget=${restoreTarget}`,
+  );
+}
+
+// Dry-run guard 1 — the target file's bytes must match the seeded bytes.
+// A real `mv -v` (gate G3-6 path) would replace the target contents with
+// the backup's. The dry-run branch must leave them untouched.
+const restoreTargetAfterBytes = readFileSync(restoreTarget);
+if (!restoreTargetAfterBytes.equals(restoreTargetBeforeBytes)) {
+  fail(
+    `restore-last --dry-run modified the seeded target\nbefore: ${restoreTargetBeforeBytes.length} bytes\nafter:  ${restoreTargetAfterBytes.length} bytes`,
+  );
+}
+
+// Dry-run guard 2 — the backup file must STILL exist on disk and its
+// contents must be byte-identical to the seed. A real `mv -v` would
+// unlink the backup; the dry-run short-circuit must not even reach the
+// `spawn mv -v` loop, so the seed is preserved verbatim.
+const restoreBackupAfterStat = statSync(restoreBackup, {
+  throwIfNoEntry: false,
+});
+if (!restoreBackupAfterStat) {
+  fail(
+    `restore-last --dry-run unlinked the seeded backup at ${restoreBackup} (would be unlinked by a real mv)`,
+  );
+}
+const restoreBackupAfterBytes = readFileSync(restoreBackup);
+if (!restoreBackupAfterBytes.equals(restoreBackupBeforeBytes)) {
+  fail(
+    `restore-last --dry-run modified the seeded backup\nbefore: ${restoreBackupBeforeBytes.length} bytes\nafter:  ${restoreBackupAfterBytes.length} bytes`,
+  );
+}
+
+console.log(
+  `restore-last --dry-run: exit=${restoreResult.status} planRendered=PASS sourceStateJson=PASS integrityOk=PASS mvLineRendered=PASS targetUntouched=PASS backupUntouched=PASS`,
+);
+
+// Cleanup restore tmpdirs.
+rmSync(restoreHome, { recursive: true, force: true });
+rmSync(restoreXdg, { recursive: true, force: true });
+rmSync(restorePathDir, { recursive: true, force: true });
+rmSync(restoreWorkspace, { recursive: true, force: true });
+
 logStep('Cleanup');
 rmSync(packTmp, { recursive: true, force: true });
 rmSync(cleanTmp, { recursive: true, force: true });
@@ -1192,5 +1383,5 @@ rmSync(bootstrapPath, { recursive: true, force: true });
 
 logStep('PASS');
 console.log(
-  'All verifications passed. The tarball is ready to publish, including bootstrap, apply (F2 no-change), and apply (F3 refused-apply) smoke checks.',
+  'All verifications passed. The tarball is ready to publish, including bootstrap, apply (F2 no-change), apply (F3 refused-apply), and restore-last (G3 --dry-run) smoke checks.',
 );

--- a/apps/cli/scripts/verify-package.mjs
+++ b/apps/cli/scripts/verify-package.mjs
@@ -952,6 +952,113 @@ console.log(
   `restore-last --yes --force (end-to-end after real apply): exit=${stateEndToEndResult.status} targetRestoredToPreApply=PASS backupUnlinked=PASS restoredCount=1 forceWarn=PASS`,
 );
 
+// ---------------------------------------------------------------------------
+// Task-4 / user-verdict 2026-07-04 second-restore assertion. After the
+// first successful restore consumed the backup, re-run
+// `overture restore-last --yes --force` and assert the missing-backup
+// branch exits 1 with the per-pair `error: backup file missing: …` line
+// AND the follow-up `error: could not complete restore — backup file(s)
+// may have been consumed by a previous restore, or never existed.`
+// hint. The target bytes must be byte-identical to the post-first-
+// restore state (the failed restore must NOT have clobbered them). The
+// backup file must STILL be absent on disk (no second backup was created
+// or deleted by the failed restore).
+// ---------------------------------------------------------------------------
+
+const stateSecondRestoreResult = spawnWithEnv(
+  [distMain, 'restore-last', '--yes', '--force'],
+  stateEnv,
+  { cwd: stateWorkspace },
+);
+
+// Atomic exit code per gate G3-8 / user verdict 2026-07-04: a plan
+// with any missing-backup pair must exit 1, not 0.
+if (stateSecondRestoreResult.status !== 1) {
+  fail(
+    `restore-last --yes --force (second restore, backup consumed) exited ${stateSecondRestoreResult.status} (expected 1 per user verdict 2026-07-04)\nstdout:\n${stateSecondRestoreResult.stdout}\nstderr:\n${stateSecondRestoreResult.stderr}`,
+  );
+}
+
+// Per-pair stderr error: each missing-backup pair must surface
+// `error: backup file missing: <shellQuoted(backup)>`.
+if (
+  !stateSecondRestoreResult.stderr.includes(
+    `error: backup file missing: '${stateEndToEndBackup}'`,
+  )
+) {
+  fail(
+    `restore-last --yes --force (second restore) stderr missing "error: backup file missing: '${stateEndToEndBackup}'"\nstderr:\n${stateSecondRestoreResult.stderr}`,
+  );
+}
+
+// Follow-up stderr hint pointing the user at the apply dir.
+if (
+  !stateSecondRestoreResult.stderr.includes(
+    'error: could not complete restore — backup file(s) may have been consumed by a previous restore, or never existed.',
+  )
+) {
+  fail(
+    `restore-last --yes --force (second restore) stderr missing follow-up investigation hint\nstderr:\n${stateSecondRestoreResult.stderr}`,
+  );
+}
+
+// The follow-up hint must reference the state dir so the user knows
+// where to look. Read it back from the apply dir we seeded.
+if (
+  !stateSecondRestoreResult.stderr.includes(
+    join(stateHome, '.local', 'state', 'overture', 'apply'),
+  )
+) {
+  fail(
+    `restore-last --yes --force (second restore) stderr hint missing the apply dir path\nstderr:\n${stateSecondRestoreResult.stderr}`,
+  );
+}
+
+// Rendered outcome must report the pair as `failed`, not `skipped`.
+// The summary line emits `failed: 1` (one missing-backup pair).
+if (
+  !stateSecondRestoreResult.stdout.includes(
+    'restored: 0, skipped: 0, failed: 1',
+  )
+) {
+  fail(
+    `restore-last --yes --force (second restore) stdout summary missing "restored: 0, skipped: 0, failed: 1"\nstdout:\n${stateSecondRestoreResult.stdout}`,
+  );
+}
+
+// Target bytes must be byte-identical to the post-first-restore state.
+// The failed restore must not have clobbered anything. We compare to
+// `stateOpencodeBeforeBytes` (the opencode pre-apply bytes), which
+// was what the FIRST restore wrote back. If a `mv` had fired during
+// the second restore the bytes would either change (to the backup's
+// bytes, which were unlinked at the start of the second restore) or
+// the file's existence/inode would change.
+const stateSecondRestoreBytes = readFileSync(stateOpencodeConfig);
+if (!stateSecondRestoreBytes.equals(stateOpencodeBeforeBytes)) {
+  fail(
+    `restore-last --yes --force (second restore) clobbered the target — bytes differ from post-first-restore state\nrestored bytes: ${stateSecondRestoreBytes.length}\npost-first-restore bytes: ${stateOpencodeBeforeBytes.length}\nstdout:\n${stateSecondRestoreResult.stdout}\nstderr:\n${stateSecondRestoreResult.stderr}`,
+  );
+}
+
+// The backup file must still be absent on disk. A real `mv` would
+// emit ENOENT (or unlink and recreate); the dry-run invariant here
+// is: the second restore's atomic-abort path did NOT touch the
+// backup's parent dir OR re-create the backup. This is a coarse
+// proxy for "no mv shell-out fired" — outside vitest's `spawnCalls`
+// mock, we assert by filesystem observation.
+const stateSecondRestoreBackupStat = statSync(stateEndToEndBackup, {
+  throwIfNoEntry: false,
+});
+if (stateSecondRestoreBackupStat) {
+  fail(
+    `restore-last --yes --force (second restore) unexpectedly re-created the backup at ${stateEndToEndBackup}`,
+  );
+}
+
+console.log(
+  `restore-last --yes --force (second restore, missing-backup): exit=${stateSecondRestoreResult.status} exitOne=PASS stderrMissingBackup=PASS stderrHint=PASS summaryFailed1=PASS targetUntouched=PASS backupAbsent=PASS`,
+);
+
 // Cleanup state tmpdirs.
 rmSync(stateHome, { recursive: true, force: true });
 rmSync(stateXdg, { recursive: true, force: true });
@@ -1483,5 +1590,5 @@ rmSync(bootstrapPath, { recursive: true, force: true });
 
 logStep('PASS');
 console.log(
-  'All verifications passed. The tarball is ready to publish, including bootstrap, apply (F2 no-change), apply (F3 refused-apply), restore-last (G3 --dry-run), and restore-last --yes --force (G3 end-to-end after real apply) smoke checks.',
+  'All verifications passed. The tarball is ready to publish, including bootstrap, apply (F2 no-change), apply (F3 refused-apply), restore-last (G3 --dry-run), restore-last --yes --force (G3 end-to-end after real apply), and restore-last --yes --force (G3 second restore, missing-backup user verdict 2026-07-04) smoke checks.',
 );

--- a/apps/cli/src/apply-command.ts
+++ b/apps/cli/src/apply-command.ts
@@ -698,8 +698,15 @@ type WriteTargetPath = AgentMcpWriteResult['targetPaths'][number];
  * the absolute-vs-relative distinction here and resolve once, so `fs.copyFile`
  * always sees an absolute path. The `base` field is a hint for relative
  * paths; absolute paths bypass it.
+ *
+ * G3 fix (F3 BLOCKING): this helper is now also consumed by
+ * `apps/cli/src/apply-state.ts:buildApplyStateRecord` to populate
+ * `ApplyStateAgent.targetPaths[i]` with the absolute path so the
+ * downstream `restore-last` helper can spawn `mv` against a resolved
+ * target instead of a relative `loc.relativePath`. Exported so the
+ * state recorder can reuse the same anchor the writer side uses.
  */
-function resolveTargetBase(
+export function resolveTargetBase(
   base: WriteTargetPath['base'],
   filePath: string,
   ctx: PathResolutionContext,
@@ -714,6 +721,11 @@ function resolveTargetBase(
       return join(ctx.workspaceDir, filePath);
     case 'absolute':
       return filePath;
+    default:
+      // Exhaustiveness fallback for the inferred `WriteTargetPath['base']`
+      // literal union: any future widening is treated as a relative path
+      // against the workspace dir (matches the G3 fallback convention).
+      return join(ctx.workspaceDir, filePath);
   }
 }
 
@@ -1242,6 +1254,7 @@ export async function runApply(
   // been emitted in that branch and there is nothing meaningful to log).
   const stateRecord = await recordApplyStateBestEffort({
     overturePaths,
+    ctx,
     now,
     backupBeforeWrite,
     profileName: validated.profileName,
@@ -1315,6 +1328,7 @@ export async function runApply(
 
 interface RecordApplyStateArgs {
   readonly overturePaths: OverturePaths;
+  readonly ctx: PathResolutionContext;
   readonly now: Date;
   readonly backupBeforeWrite: boolean;
   readonly profileName: string;
@@ -1377,6 +1391,7 @@ async function recordApplyStateBestEffort(
       profileName: args.profileName,
       configPath: args.configPath,
       backupBeforeWrite: args.backupBeforeWrite,
+      ctx: args.ctx,
       perAgent: perAgentEntries,
     });
     await writeApplyState(record, defaultApplyStateDir(args.overturePaths), 10);

--- a/apps/cli/src/apply-state.spec.ts
+++ b/apps/cli/src/apply-state.spec.ts
@@ -151,6 +151,12 @@ describe('apply-state (G1 contract)', () => {
       profileName: 'default',
       configPath: '/home/test/overture.jsonc',
       backupBeforeWrite: true,
+      ctx: {
+        homeDir: '/home/test',
+        configDir: '/home/test/.config',
+        workspaceDir: '/home/test/ws',
+        platform: 'linux',
+      },
       perAgent: [
         {
           agentResult,
@@ -360,6 +366,85 @@ describe('apply-state (G1 contract)', () => {
       '20260101-000000000-aaaaaaaa.json',
       '20260102-000000000-bbbbbbbb.json',
       '20260103-000000000-cccccccc.json',
+    ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 7 — buildApplyStateRecord resolves relative targetPaths (G3 fix).
+  // OpenCode / Codex writers emit `targetPaths[*].path` as the raw
+  // `loc.relativePath`; the apply-time `PathResolutionContext` is the only
+  // anchor that can turn those into absolutes. The persisted record must
+  // hold the resolved absolute path so the G3 `restore-last` helper can
+  // `mv` against it without guessing the apply-time cwd. Absolute inputs
+  // are idempotent (resolveTargetBase passes them through).
+  // -------------------------------------------------------------------------
+
+  it('buildApplyStateRecord resolves relative targetPaths against ctx (G3 F3 fix)', () => {
+    const targets: AgentTargetPath[] = [
+      // OpenCode convention: relative path with a `base` hint.
+      { scope: 'project', base: 'workspace', path: 'opencode/opencode.json' },
+      // Codex convention: also relative, but anchored against home.
+      { scope: 'user', base: 'home', path: '.codex/config.toml' },
+      // Claude / Copilot convention: already absolute (idempotent pass-through).
+      { scope: 'user', base: 'home', path: '/home/test/.claude.json' },
+    ];
+    const writerResult: AgentMcpWriteResult = {
+      written: 3,
+      changed: true,
+      dryRun: false,
+      serversWritten: ['filesystem'],
+      targetPaths: targets,
+    };
+    const agentResult: ApplyAgentResult = {
+      agentId: 'mixed',
+      displayName: 'Mixed Agents',
+      status: 'updated',
+      result: writerResult,
+      backupPaths: [
+        '/tmp/ws/opencode/opencode.json.bak.20260704-200000000',
+        '/home/test/.codex/config.toml.bak.20260704-200000000',
+        '/home/test/.claude.json.bak.20260704-200000000',
+      ],
+    };
+    const ctx = {
+      homeDir: '/home/test',
+      configDir: '/home/test/.config',
+      workspaceDir: '/tmp/ws',
+      platform: 'linux' as const,
+    };
+    const args: BuildApplyStateRecordArgs = {
+      runId: '20260704-200000000-deadbeef',
+      now: new Date('2026-07-04T20:00:00.000Z'),
+      mode: 'apply',
+      profileName: 'default',
+      configPath: '/home/test/overture.jsonc',
+      backupBeforeWrite: true,
+      ctx,
+      perAgent: [
+        {
+          agentResult,
+          preSnapshots: ['aaaa', 'bbbb', 'cccc'],
+          postSnapshots: ['dddd', 'eeee', 'ffff'],
+        },
+      ],
+    };
+
+    const record = buildApplyStateRecord(args);
+
+    expect(record.agents).toHaveLength(1);
+    const agent = record.agents[0];
+    if (!agent) throw new Error('expected one ApplyStateAgent');
+    // Each writer-style relative path resolves against its declared base.
+    expect(agent.targetPaths).toEqual([
+      '/tmp/ws/opencode/opencode.json',
+      '/home/test/.codex/config.toml',
+      '/home/test/.claude.json',
+    ]);
+    // backupPaths stay whatever the writer/orchestrator produced (untouched).
+    expect(agent.backupPaths).toEqual([
+      '/tmp/ws/opencode/opencode.json.bak.20260704-200000000',
+      '/home/test/.codex/config.toml.bak.20260704-200000000',
+      '/home/test/.claude.json.bak.20260704-200000000',
     ]);
   });
 });

--- a/apps/cli/src/apply-state.ts
+++ b/apps/cli/src/apply-state.ts
@@ -31,10 +31,12 @@ import {
 } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import type { PathResolutionContext } from '@overture/agents';
 import type { OverturePaths } from '@overture/config';
 
 import {
   formatBackupTimestamp,
+  resolveTargetBase,
   type ApplyAgentResult,
 } from './apply-command.js';
 
@@ -95,6 +97,13 @@ export interface ApplyStateAgent {
  * `postSnapshots` index in parallel with the writer's
  * `result.targetPaths` array, so the caller is responsible for the
  * pre/post mapping during Pass 1 → Pass 2 orchestration.
+ *
+ * G3 fix (F3 BLOCKING): `ctx` is the same `PathResolutionContext` the
+ * apply orchestrator hands to the writer. We need it here to resolve
+ * the writer's relative `loc.relativePath` (`targetPaths[*].path` for
+ * OpenCode / Codex) into an absolute path before persisting — the
+ * downstream `restore-last` helper consumes the state record directly
+ * and cannot guess the apply-time cwd on its own.
  */
 export interface BuildApplyStateRecordArgs {
   readonly runId: string;
@@ -103,6 +112,7 @@ export interface BuildApplyStateRecordArgs {
   readonly profileName: string;
   readonly configPath: string;
   readonly backupBeforeWrite: boolean;
+  readonly ctx: PathResolutionContext;
   readonly perAgent: readonly {
     readonly agentResult: ApplyAgentResult;
     /** Hex digests captured BEFORE Pass 2. Length MUST match `agentResult.result.targetPaths`. `undefined` when no snapshots were captured. */
@@ -165,7 +175,17 @@ export function buildApplyStateRecord(
 ): ApplyStateRecord {
   const agents = args.perAgent.map((entry): ApplyStateAgent => {
     const { agentResult, preSnapshots, postSnapshots } = entry;
-    const targetPaths = agentResult.result.targetPaths.map((t) => t.path);
+    // G3 fix (F3 BLOCKING): resolve every writer-reported target path
+    // against the apply-time `PathResolutionContext` so the persisted
+    // `targetPaths[i]` matches the absolute `backupPaths[i]` the apply
+    // already resolves. Writers diverge (Claude/Copilot emit absolute;
+    // OpenCode/Codex emit `loc.relativePath`); `resolveTargetBase` is
+    // idempotent on absolute inputs so the on-disk contract
+    // "Absolute paths of every `targetPaths[*]` entry, resolved."
+    // (lines 81-82) holds uniformly.
+    const targetPaths = agentResult.result.targetPaths.map((t) =>
+      resolveTargetBase(t.base, t.path, args.ctx),
+    );
     const preWriteSha256 = pickHash(preSnapshots);
     const postWriteSha256 = pickHash(postSnapshots);
     const base: ApplyStateAgent = {

--- a/apps/cli/src/cli.spec.ts
+++ b/apps/cli/src/cli.spec.ts
@@ -3,11 +3,13 @@ import {
   chmodSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 
 import { __setPlatformForTests } from './cli.js';
 
@@ -1034,5 +1036,133 @@ describe('run: scan', () => {
       }
       rmSync(pathDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// G3 — restore-last dispatcher regressions (cases 12-15).
+// ---------------------------------------------------------------------------
+
+describe('run: restore-last dispatcher (G3)', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let originalXdgStateHome: string | undefined;
+  let tempRoots: string[];
+
+  beforeEach(() => {
+    originalXdgStateHome = process.env.XDG_STATE_HOME;
+    tempRoots = [];
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    for (const dir of tempRoots) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    if (originalXdgStateHome === undefined) {
+      delete process.env.XDG_STATE_HOME;
+    } else {
+      process.env.XDG_STATE_HOME = originalXdgStateHome;
+    }
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  // Case 12 — restore-last --help → USAGE block, exit 0
+  it('restore-last --help prints the new USAGE block and exits 0', async () => {
+    const code = await run(['restore-last', '--help']);
+    expect(code).toBe(0);
+    const out = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+    expect(out).toContain('Usage: overture restore-last');
+    expect(out).toContain('--dry-run');
+    expect(out).toContain('--yes');
+    expect(out).toContain('--force');
+    expect(out).toContain('--run-id');
+  });
+
+  // Case 13 — restore-last --dry-run end-to-end (XDG_STATE_HOME override)
+  it('restore-last --dry-run with seeded state reads the JSON, prints the plan, exits 0', async () => {
+    const xdg = mkdtempSync(join(tmpdir(), 'overture-restore-xdg-'));
+    tempRoots.push(xdg);
+    process.env.XDG_STATE_HOME = xdg;
+    const stateDir = join(xdg, 'overture', 'apply');
+    mkdirSync(stateDir, { recursive: true });
+    const runId = '20260704-183000123-eeeeeeee';
+    const target = join(stateDir, 'mcp-target.json');
+    const backup = join(stateDir, 'mcp-target.json.bak.20260704');
+    const targetContent = '{"old":true}\n';
+    writeFileSync(target, targetContent);
+    writeFileSync(backup, targetContent);
+    const preSha = createHash('sha256').update(targetContent).digest('hex');
+    const record = {
+      schemaVersion: 1,
+      runId,
+      timestamp: '2026-07-04T18:30:00.123Z',
+      mode: 'apply',
+      profile: 'default',
+      configPath: '/home/test/overture.jsonc',
+      backupBeforeWrite: true,
+      agents: [
+        {
+          agentId: 'claude-code',
+          displayName: 'Claude Code',
+          status: 'updated',
+          targetPaths: [target],
+          backupPaths: [backup],
+          preWriteSha256: preSha,
+          postWriteSha256: null,
+        },
+      ],
+    };
+    writeFileSync(join(stateDir, `${runId}.json`), JSON.stringify(record));
+    writeFileSync(join(stateDir, 'last.json'), JSON.stringify({ runId }));
+
+    const code = await run(['restore-last', '--dry-run']);
+    expect(code).toBe(0);
+    const out = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+    expect(out).toContain('Overture restore plan');
+    expect(out).toContain(runId);
+    expect(out).toContain('mv -v');
+    // No filesystem writes on dry-run.
+    expect(readFileSync(target, 'utf8')).toBe(targetContent);
+  });
+
+  // Case 14 — restore-last --unknown-flag → exit 2 + USAGE on stderr
+  it('restore-last --unknown-flag exits 2 and prints the USAGE block to stderr', async () => {
+    const xdg = mkdtempSync(join(tmpdir(), 'overture-restore-xdg-'));
+    tempRoots.push(xdg);
+    process.env.XDG_STATE_HOME = xdg;
+    const stateDir = join(xdg, 'overture', 'apply');
+    mkdirSync(stateDir, { recursive: true });
+
+    const code = await run(['restore-last', '--bogus']);
+    expect(code).toBe(2);
+    const err = stderrSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+    expect(err).toContain('Unknown flag: --bogus');
+    expect(err).toContain('Usage: overture restore-last');
+  });
+
+  // Case 15 — no-args still emits USAGE (regression — dispatcher change must
+  // not break the empty-args path).
+  it('overture with no args still returns 0 and prints the USAGE block', async () => {
+    const code = await run([]);
+    expect(code).toBe(0);
+    const out = stdoutSpy.mock.calls
+      .map((c: readonly unknown[]) => c[0] as string)
+      .join('');
+    expect(out).toContain('detect [--json]');
+    expect(out).toContain('apply [--dry-run]');
+    expect(out).toContain('restore-last');
   });
 });

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -18,6 +18,7 @@ import type { DetectJsonOutput } from './platforms/types.js';
 import { runBootstrap } from './bootstrap-command.js';
 import { runScan } from './scan-command.js';
 import { runApply } from './apply-command.js';
+import { runRestore } from './restore-command.js';
 let platformOverride: HostPlatform | null = null;
 export function __setPlatformForTests(p: HostPlatform | null): void {
   platformOverride = p;
@@ -130,7 +131,8 @@ const USAGE =
   '  config show       Print the resolved user-level overture config.\n' +
   '  scan [--json]     Build the installed MCP server matrix.\n' +
   '  bootstrap [--dry-run] [--json]   Preview the canonical config that D3 would write.\n' +
-  '  apply [--dry-run] [--json]   Apply canonical MCP intent to per-agent configs. Backups are created before each write (use --dry-run to preview without writing).\n';
+  '  apply [--dry-run] [--json]   Apply canonical MCP intent to per-agent configs. Backups are created before each write (use --dry-run to preview without writing).\n' +
+  '  restore-last [--dry-run] [--yes] [--force] [--run-id <id>]   Restore backups from the last (or chosen) apply run via per-pair `mv -v`.\n';
 
 async function runDetect(flags: readonly string[]): Promise<number> {
   if (flags.includes('--help') || flags.includes('-h')) {
@@ -245,6 +247,10 @@ export async function run(args: readonly string[]): Promise<number> {
 
   if (args[0] === 'apply') {
     return runApply(args.slice(1), process.stdout, process.stderr);
+  }
+
+  if (args[0] === 'restore-last') {
+    return runRestore(args.slice(1), process.stdout, process.stderr);
   }
 
   process.stderr.write(`Unknown command: ${args[0]}\n${USAGE}`);

--- a/apps/cli/src/restore-command.spec.ts
+++ b/apps/cli/src/restore-command.spec.ts
@@ -1,0 +1,683 @@
+/**
+ * G3 — `restore-command` suite (pure helpers + dispatcher entry).
+ *
+ * Each case mirrors one bullet from the plan's Must-have list. Wave 1
+ * created these as RED cases against the stub; Wave 2 turns cases 1-5
+ * green by implementing the pure helpers + flag parser + TTY prompt
+ * helper; Wave 3 turns cases 6-11 green by implementing `runRestore`'s
+ * execute path (`mv -v` per pair) + the dispatcher arm in `cli.ts`.
+ *
+ * Cases 12-15 (CLI dispatcher regressions) live in `cli.spec.ts`.
+ *
+ * Coverage map (each `it(...)` is one Must-have bullet):
+ *   1. `readRestoreSource` reads the JSON path correctly (source =
+ *      'state-json', pairs match seeded `agents[*].backupPaths/targetPaths`).
+ *   2. `readRestoreSource` falls back to log-tag-lines when JSON is absent
+ *      (source = 'log-tag-lines', pairs projected via `readApplyLog`'s
+ *      `restorePairs`).
+ *   3. `buildRestorePlan` integrity check: 3 targets (A matches, B
+ *      differs, C absent) → statuses `ok / mismatch / missing-backup`.
+ *   4. `formatHumanRestorePlan` produces a stable 3-section rendering.
+ *   5. `runRestore --dry-run` exits 0, writes plan to stdout, performs
+ *      NO filesystem writes (no `child_process.spawn` invocations).
+ *   6. `runRestore --yes` with all `ok` pairs: real `mv`s execute,
+ *      targets restored, exit 0.
+ *   7. `runRestore --yes` with a `mismatch` pair (no `--force`): exit 1,
+ *      target NOT clobbered, stderr carries the rejection line.
+ *   8. `runRestore --yes --force` with a `mismatch` pair: proceeds with
+ *      stderr WARN, exit 0 iff every pair succeeded.
+ *   9. `runRestore --run-id <other-runId>`: overrides `last.json`'s
+ *      default; `--run-id` for a pruned runId exits 1 with stderr
+ *      "run <id> not found in <stateDir>".
+ *  10. Missing `last.json`: exit 1 with stderr "no overture apply
+ *      history found in <stateDir>" + USAGE hint.
+ *  11. TTY simulation: interactive `y\n` permits execution, `n\n` aborts.
+ *      Uses injected prompt helper so tests don't touch real stdin.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildApplyLog, writeApplyLog } from './apply-log.js';
+import { writeApplyState } from './apply-state.js';
+import type { ApplyLogContent } from './apply-log.js';
+import type { ApplyStateRecord } from './apply-state.js';
+import {
+  buildRestorePlan,
+  formatHumanRestorePlan,
+  readRestoreSource,
+  runRestore,
+} from './restore-command.js';
+
+// ---------------------------------------------------------------------------
+// Shared fixture helpers.
+// ---------------------------------------------------------------------------
+
+interface SeedArgs {
+  readonly tmp: string;
+  readonly stateDir: string;
+  readonly runId: string;
+  readonly backup?: string;
+  readonly target?: string;
+  readonly targetContent?: string;
+  readonly preSha?: string;
+}
+
+function freshTmp(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function seedStateJsonRecord(args: SeedArgs): ApplyStateRecord {
+  const target = args.target ?? join(args.tmp, 'mcp-target.json');
+  const backup =
+    args.backup ?? join(args.tmp, 'mcp-target.json.bak.20260704-183000123');
+  // Default target content == backup content so integrity check is `ok`
+  // (current target equals preWriteSha256 = the bytes the backup holds).
+  // Tests that want `mismatch` override `targetContent` to diverge from the
+  // backup bytes (and from preWriteSha256).
+  const targetContent = args.targetContent ?? '{"old":true}\n';
+  writeFileSync(target, targetContent);
+  if (!existsSync(backup)) writeFileSync(backup, '{"old":true}\n');
+  const preSha =
+    args.preSha ?? createHash('sha256').update('{"old":true}\n').digest('hex');
+  const record: ApplyStateRecord = {
+    schemaVersion: 1,
+    runId: args.runId,
+    timestamp: '2026-07-04T18:30:00.123Z',
+    mode: 'apply',
+    profile: 'default',
+    configPath: '/home/test/overture.jsonc',
+    backupBeforeWrite: true,
+    agents: [
+      {
+        agentId: 'claude-code',
+        displayName: 'Claude Code',
+        status: 'updated',
+        targetPaths: [target],
+        backupPaths: [backup],
+        preWriteSha256: preSha,
+        postWriteSha256: null,
+      },
+    ],
+  };
+  return record;
+}
+
+async function seedStateJson(args: SeedArgs): Promise<{
+  stateDir: string;
+  runId: string;
+  backup: string;
+  target: string;
+  targetContent: string;
+}> {
+  mkdirSync(args.stateDir, { recursive: true });
+  const record = seedStateJsonRecord(args);
+  await writeApplyState(record, args.stateDir, 10);
+  // Read-back to resolve the on-disk backup/target paths (defaults above).
+  const agent = record.agents[0];
+  if (!agent) throw new Error('expected one agent in fixture');
+  const target = agent.targetPaths[0];
+  const backup = agent.backupPaths[0];
+  if (!target || !backup)
+    throw new Error('expected target + backup in fixture');
+  const targetContent = readFileSync(target, 'utf8');
+  return {
+    stateDir: args.stateDir,
+    runId: args.runId,
+    backup,
+    target,
+    targetContent,
+  };
+}
+
+describe('restore-command (G3 contract)', () => {
+  let cleanupDirs: string[] = [];
+
+  beforeEach(() => {
+    cleanupDirs = [];
+  });
+
+  afterEach(() => {
+    for (const d of cleanupDirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 1 — readRestoreSource JSON path
+  // -------------------------------------------------------------------------
+
+  it('readRestoreSource reads the JSON path correctly when last.json + <runId>.json exist', async () => {
+    const tmp = freshTmp('g3-restore-json-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    const runId = '20260704-183000123-abcdef01';
+    const seeded = await seedStateJson({
+      tmp,
+      stateDir,
+      runId,
+    });
+
+    const result = await readRestoreSource(stateDir, runId);
+
+    expect(result.source).toBe('state-json');
+    expect(result.runId).toBe(runId);
+    expect(result.configPath).toBe('/home/test/overture.jsonc');
+    expect(result.notes).toEqual([]);
+    expect(result.rawPairs).toHaveLength(1);
+    const pair = result.rawPairs[0];
+    if (!pair) throw new Error('expected one raw pair');
+    expect(pair.agentId).toBe('claude-code');
+    expect(pair.displayName).toBe('Claude Code');
+    expect(pair.backup).toBe(seeded.backup);
+    expect(pair.target).toBe(seeded.target);
+    expect(pair.preWriteSha256).not.toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 2 — readRestoreSource log-tag-lines fallback
+  // -------------------------------------------------------------------------
+
+  it('readRestoreSource falls back to log-tag-lines when JSON is absent', async () => {
+    const tmp = freshTmp('g3-restore-log-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    mkdirSync(stateDir, { recursive: true });
+
+    // Build a log from a record, then seed only the .log (no .json written).
+    const record = seedStateJsonRecord({
+      tmp,
+      stateDir,
+      runId: '20260704-183000123-fedcba98',
+    });
+    const logContent: ApplyLogContent = buildApplyLog(
+      record,
+      'overture@test',
+      stateDir,
+    );
+    await writeApplyLog(logContent, stateDir, 10);
+
+    const result = await readRestoreSource(stateDir, record.runId);
+
+    expect(result.source).toBe('log-tag-lines');
+    expect(result.runId).toBe(record.runId);
+    expect(result.configPath).toBe('/home/test/overture.jsonc');
+    expect(result.rawPairs).toHaveLength(1);
+    const pair = result.rawPairs[0];
+    if (!pair) throw new Error('expected one raw pair');
+    expect(pair.agentId).toBe('claude-code');
+    expect(pair.preWriteSha256).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 3 — buildRestorePlan integrity check
+  // -------------------------------------------------------------------------
+
+  it('buildRestorePlan evaluates ok / mismatch / missing-backup across three targets', async () => {
+    const tmp = freshTmp('g3-restore-integrity-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    mkdirSync(stateDir, { recursive: true });
+
+    const runId = '20260704-183000123-12345678';
+
+    // Target A: current bytes match preWriteSha256 → `ok`.
+    const targetA = join(tmp, 'target-a.json');
+    const backupA = join(tmp, 'target-a.json.bak.20260704');
+    const postA = createHash('sha256').update('current-a\n').digest('hex');
+    writeFileSync(targetA, 'orig-a\n');
+    writeFileSync(backupA, 'orig-a\n');
+    // sha256OfFile() reads bytes; preWriteSha256 is the digest of `orig-a\n`.
+    const preASha = createHash('sha256').update('orig-a\n').digest('hex');
+
+    // Target B: current bytes DIFFER from preWriteSha256 → `mismatch`.
+    const targetB = join(tmp, 'target-b.json');
+    const backupB = join(tmp, 'target-b.json.bak.20260704');
+    writeFileSync(targetB, 'edited-by-user\n');
+    writeFileSync(backupB, 'orig-b\n');
+    const preBSha = createHash('sha256').update('orig-b\n').digest('hex');
+
+    // Target C: backup is absent → `missing-backup`.
+    const targetC = join(tmp, 'target-c.json');
+    const backupC = join(tmp, 'target-c.json.bak.20260704');
+    writeFileSync(targetC, 'current-c\n');
+    // No backup file created on disk → missing-backup.
+    const preCSha = createHash('sha256').update('orig-c\n').digest('hex');
+
+    const record: ApplyStateRecord = {
+      schemaVersion: 1,
+      runId,
+      timestamp: '2026-07-04T18:30:00.123Z',
+      mode: 'apply',
+      profile: 'default',
+      configPath: '/home/test/overture.jsonc',
+      backupBeforeWrite: true,
+      agents: [
+        {
+          agentId: 'a-agent',
+          displayName: 'A Agent',
+          status: 'updated',
+          targetPaths: [targetA],
+          backupPaths: [backupA],
+          preWriteSha256: preASha,
+          postWriteSha256: postA,
+        },
+        {
+          agentId: 'b-agent',
+          displayName: 'B Agent',
+          status: 'updated',
+          targetPaths: [targetB],
+          backupPaths: [backupB],
+          preWriteSha256: preBSha,
+          postWriteSha256: null,
+        },
+        {
+          agentId: 'c-agent',
+          displayName: 'C Agent',
+          status: 'updated',
+          targetPaths: [targetC],
+          backupPaths: [backupC],
+          preWriteSha256: preCSha,
+          postWriteSha256: null,
+        },
+      ],
+    };
+    await writeApplyState(record, stateDir, 10);
+
+    const plan = await buildRestorePlan(stateDir, runId, new Date());
+
+    expect(plan.source).toBe('state-json');
+    expect(plan.pairs).toHaveLength(3);
+    const byAgent = new Map(plan.pairs.map((p) => [p.agentId, p]));
+    const a = byAgent.get('a-agent');
+    const b = byAgent.get('b-agent');
+    const c = byAgent.get('c-agent');
+    expect(a?.integrityStatus).toBe('ok');
+    expect(b?.integrityStatus).toBe('mismatch');
+    expect(c?.integrityStatus).toBe('missing-backup');
+    // preWriteSha256 / currentSha256 surfaces for ok + mismatch, absent for
+    // missing-backup (writer-aligned zipping).
+    expect(a?.preWriteSha256).toBe(preASha);
+    expect(a?.currentSha256).toBe(preASha);
+    expect(b?.preWriteSha256).toBe(preBSha);
+    expect(b?.currentSha256).not.toBe(preBSha);
+    expect(c?.preWriteSha256).toBe(preCSha);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 4 — formatHumanRestorePlan stable rendering
+  // -------------------------------------------------------------------------
+
+  it('formatHumanRestorePlan produces a stable rendering with header / per-pair / footer sections', () => {
+    const plan = {
+      source: 'state-json' as const,
+      runId: '20260704-183000123-aabbccdd',
+      stateDir: '/home/test/.local/state/overture/apply',
+      configPath: '/home/test/overture.jsonc',
+      pairs: [
+        {
+          agentId: 'claude-code',
+          displayName: 'Claude Code',
+          backup: '/home/test/.claude.json.bak.20260704-183000123',
+          target: '/home/test/.claude.json',
+          integrityStatus: 'ok' as const,
+          preWriteSha256: 'abc',
+          currentSha256: 'abc',
+        },
+        {
+          agentId: 'opencode',
+          displayName: 'OpenCode',
+          backup: '/home/test/.opencode.json.bak.20260704-183000123',
+          target: '/home/test/.opencode.json',
+          integrityStatus: 'mismatch' as const,
+          preWriteSha256: 'def',
+          currentSha256: 'fed',
+        },
+      ],
+      notes: [],
+    };
+    const rendered = formatHumanRestorePlan(plan);
+
+    // Three sections: header, per-pair block, footer.
+    expect(rendered).toContain('Overture restore plan');
+    expect(rendered).toContain('run id:        20260704-183000123-aabbccdd');
+    expect(rendered).toContain('source:        state-json');
+    expect(rendered).toContain('[claude-code] Claude Code');
+    expect(rendered).toContain('status: ok');
+    expect(rendered).toContain('[opencode] OpenCode');
+    expect(rendered).toContain('status: mismatch');
+    expect(rendered).toContain('mv -v');
+    expect(rendered).toContain('pairs: 2');
+    // mv -v lines use single-quoted paths (matches shellQuotePath contract).
+    expect(rendered).toMatch(
+      /mv -v '\/home\/test\/\.claude\.json\.bak\..*' '\/home\/test\/\.claude\.json'/,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 5 — runRestore --dry-run
+  // -------------------------------------------------------------------------
+
+  it('runRestore --dry-run exits 0, writes the plan, and performs no mv invocations', async () => {
+    const tmp = freshTmp('g3-restore-dryrun-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    const runId = '20260704-183000123-00112233';
+    const seeded = await seedStateJson({ tmp, stateDir, runId });
+    const targetBefore = readFileSync(seeded.target, 'utf8');
+    const backupBefore = readFileSync(seeded.backup, 'utf8');
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutWriter = { write: (s: string) => stdout.push(s) };
+    const stderrWriter = { write: (s: string) => stderr.push(s) };
+
+    const code = await runRestore(['--dry-run'], stdoutWriter, stderrWriter, {
+      isTTY: false,
+      stateDir,
+    });
+
+    expect(code).toBe(0);
+    // No filesystem writes: target and backup unchanged.
+    expect(readFileSync(seeded.target, 'utf8')).toBe(targetBefore);
+    expect(readFileSync(seeded.backup, 'utf8')).toBe(backupBefore);
+    expect(stdout.join('')).toContain('Overture restore plan');
+    expect(stdout.join('')).toContain(runId);
+    expect(stdout.join('')).toContain('mv -v');
+    expect(stderr.join('')).toBe('');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 6 — runRestore --yes all ok
+  // -------------------------------------------------------------------------
+
+  it('runRestore --yes with all ok pairs executes mv -v per pair and exits 0', async () => {
+    const tmp = freshTmp('g3-restore-yes-ok-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    const runId = '20260704-183000123-aabbcc00';
+    const seeded = await seedStateJson({ tmp, stateDir, runId });
+    const backupContent = readFileSync(seeded.backup, 'utf8');
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutWriter = { write: (s: string) => stdout.push(s) };
+    const stderrWriter = { write: (s: string) => stderr.push(s) };
+
+    const code = await runRestore(['--yes'], stdoutWriter, stderrWriter, {
+      isTTY: false,
+      stateDir,
+    });
+
+    expect(code).toBe(0);
+    // The backup should have moved into the target (overwriting current).
+    expect(readFileSync(seeded.target, 'utf8')).toBe(backupContent);
+    expect(existsSync(seeded.backup)).toBe(false);
+    expect(stdout.join('')).toContain('Overture restore outcome');
+    expect(stdout.join('')).toContain('restored: 1');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 7 — runRestore --yes with a mismatch pair (no --force)
+  // -------------------------------------------------------------------------
+
+  it('runRestore --yes with a mismatch pair (no --force) exits 1 and does not clobber the target', async () => {
+    const tmp = freshTmp('g3-restore-mismatch-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    const runId = '20260704-183000123-bbbb0001';
+
+    const target = join(tmp, 'target.json');
+    const backup = join(tmp, 'target.json.bak.20260704');
+    const editedByUser = 'edited-by-user\n';
+    const origBytes = 'orig\n';
+    writeFileSync(target, editedByUser);
+    writeFileSync(backup, origBytes);
+    const preSha = createHash('sha256').update(origBytes).digest('hex');
+
+    const record: ApplyStateRecord = {
+      schemaVersion: 1,
+      runId,
+      timestamp: '2026-07-04T18:30:00.123Z',
+      mode: 'apply',
+      profile: 'default',
+      configPath: '/home/test/overture.jsonc',
+      backupBeforeWrite: true,
+      agents: [
+        {
+          agentId: 'claude-code',
+          displayName: 'Claude Code',
+          status: 'updated',
+          targetPaths: [target],
+          backupPaths: [backup],
+          preWriteSha256: preSha,
+          postWriteSha256: null,
+        },
+      ],
+    };
+    await writeApplyState(record, stateDir, 10);
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutWriter = { write: (s: string) => stdout.push(s) };
+    const stderrWriter = { write: (s: string) => stderr.push(s) };
+
+    const code = await runRestore(['--yes'], stdoutWriter, stderrWriter, {
+      isTTY: false,
+      stateDir,
+    });
+
+    expect(code).toBe(1);
+    expect(readFileSync(target, 'utf8')).toBe(editedByUser);
+    expect(existsSync(backup)).toBe(true);
+    expect(stderr.join('')).toContain('refusing to restore');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 8 — runRestore --yes --force with a mismatch pair
+  // -------------------------------------------------------------------------
+
+  it('runRestore --yes --force with a mismatch pair proceeds and surfaces the WARN', async () => {
+    const tmp = freshTmp('g3-restore-force-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    const runId = '20260704-183000123-bbbb0002';
+
+    const target = join(tmp, 'target.json');
+    const backup = join(tmp, 'target.json.bak.20260704');
+    const editedByUser = 'edited-by-user\n';
+    const origBytes = 'orig\n';
+    writeFileSync(target, editedByUser);
+    writeFileSync(backup, origBytes);
+    const preSha = createHash('sha256').update(origBytes).digest('hex');
+
+    const record: ApplyStateRecord = {
+      schemaVersion: 1,
+      runId,
+      timestamp: '2026-07-04T18:30:00.123Z',
+      mode: 'apply',
+      profile: 'default',
+      configPath: '/home/test/overture.jsonc',
+      backupBeforeWrite: true,
+      agents: [
+        {
+          agentId: 'claude-code',
+          displayName: 'Claude Code',
+          status: 'updated',
+          targetPaths: [target],
+          backupPaths: [backup],
+          preWriteSha256: preSha,
+          postWriteSha256: null,
+        },
+      ],
+    };
+    await writeApplyState(record, stateDir, 10);
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutWriter = { write: (s: string) => stdout.push(s) };
+    const stderrWriter = { write: (s: string) => stderr.push(s) };
+
+    const code = await runRestore(
+      ['--yes', '--force'],
+      stdoutWriter,
+      stderrWriter,
+      { isTTY: false, stateDir },
+    );
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toContain('WARN: target');
+    expect(stderr.join('')).toContain('restore forced');
+    expect(readFileSync(target, 'utf8')).toBe(origBytes);
+    expect(existsSync(backup)).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 9 — runRestore --run-id override + pruned runId
+  // -------------------------------------------------------------------------
+
+  it('runRestore --run-id <id> overrides last.json; a pruned runId exits 1 with a clear stderr message', async () => {
+    const tmp = freshTmp('g3-restore-runid-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    mkdirSync(stateDir, { recursive: true });
+
+    // Seed a surviving runId.
+    const survivingRunId = '20260704-183000123-cccc0001';
+    await seedStateJson({ tmp, stateDir, runId: survivingRunId });
+
+    // last.json points to a different (pruned) runId.
+    writeFileSync(
+      join(stateDir, 'last.json'),
+      JSON.stringify({ runId: '20260101-000000000-deadbeef' }),
+    );
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutWriter = { write: (s: string) => stdout.push(s) };
+    const stderrWriter = { write: (s: string) => stderr.push(s) };
+
+    // (a) --run-id override → reads the surviving record's runId.
+    const code1 = await runRestore(
+      ['--yes', '--run-id', survivingRunId],
+      stdoutWriter,
+      stderrWriter,
+      { isTTY: false, stateDir },
+    );
+    expect(code1).toBe(0);
+
+    // (b) --run-id for a pruned runId → exit 1, clear stderr.
+    const code2 = await runRestore(
+      ['--yes', '--run-id', '20260101-000000000-deadbeef'],
+      stdoutWriter,
+      stderrWriter,
+      { isTTY: false, stateDir },
+    );
+    expect(code2).toBe(1);
+    expect(stderr.join('')).toMatch(
+      /run 20260101-000000000-deadbeef not found/,
+    );
+    expect(stderr.join('')).toContain('retention window: 10');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 10 — missing last.json
+  // -------------------------------------------------------------------------
+
+  it('runRestore with no last.json exits 1 with a clear stderr message', async () => {
+    const tmp = freshTmp('g3-restore-nohist-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    mkdirSync(stateDir, { recursive: true });
+    // last.json is intentionally absent.
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutWriter = { write: (s: string) => stdout.push(s) };
+    const stderrWriter = { write: (s: string) => stderr.push(s) };
+
+    const code = await runRestore([], stdoutWriter, stderrWriter, {
+      isTTY: false,
+      stateDir,
+    });
+
+    expect(code).toBe(1);
+    expect(stderr.join('')).toMatch(/no overture apply history found/);
+    expect(stderr.join('')).toContain(stateDir);
+    expect(stderr.join('')).toContain('Usage:');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 11 — TTY prompt simulation
+  // -------------------------------------------------------------------------
+
+  it('runRestore TTY simulation: y permits execution, n aborts with exit 1', async () => {
+    const tmp = freshTmp('g3-restore-tty-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    const runId = '20260704-183000123-dddd0001';
+    const seeded = await seedStateJson({ tmp, stateDir, runId });
+    const backupContent = readFileSync(seeded.backup, 'utf8');
+
+    // (a) Interactive `y\n` permits execution.
+    {
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+      const stdoutWriter = { write: (s: string) => stdout.push(s) };
+      const stderrWriter = { write: (s: string) => stderr.push(s) };
+      const prompt = vi.fn(() => Promise.resolve('y'));
+
+      const code = await runRestore([], stdoutWriter, stderrWriter, {
+        isTTY: true,
+        prompt,
+        stateDir,
+      });
+
+      expect(code).toBe(0);
+      expect(prompt).toHaveBeenCalledOnce();
+      expect(readFileSync(seeded.target, 'utf8')).toBe(backupContent);
+      expect(existsSync(seeded.backup)).toBe(false);
+    }
+
+    // (b) Interactive `n\n` aborts with exit 1; target untouched.
+    {
+      // Re-seed because (a) consumed the backup.
+      const tmp2 = freshTmp('g3-restore-tty-n-');
+      cleanupDirs.push(tmp2);
+      const stateDir2 = join(tmp2, 'state', 'apply');
+      const seeded2 = await seedStateJson({
+        tmp: tmp2,
+        stateDir: stateDir2,
+        runId,
+      });
+      const targetContentBefore = readFileSync(seeded2.target, 'utf8');
+
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+      const stdoutWriter = { write: (s: string) => stdout.push(s) };
+      const stderrWriter = { write: (s: string) => stderr.push(s) };
+      const prompt = vi.fn(() => Promise.resolve('n'));
+
+      const code = await runRestore([], stdoutWriter, stderrWriter, {
+        isTTY: true,
+        prompt,
+        stateDir: stateDir2,
+      });
+
+      expect(code).toBe(1);
+      expect(stderr.join('')).toContain('aborted by user');
+      expect(readFileSync(seeded2.target, 'utf8')).toBe(targetContentBefore);
+      expect(existsSync(seeded2.backup)).toBe(true);
+    }
+  });
+});

--- a/apps/cli/src/restore-command.spec.ts
+++ b/apps/cli/src/restore-command.spec.ts
@@ -58,6 +58,35 @@ import {
   runRestore,
 } from './restore-command.js';
 
+// F1 fix: track every `child_process.spawn` invocation across the
+// suite. The ESM-sealed `node:child_process` namespace can't be mutated
+// via `vi.spyOn` (project memory 49), so we use a hoisted `vi.mock`
+// that wraps the real `spawn` and pushes every call into a shared
+// array. Tests inspect `spawnCalls` to assert the dry-run / non-execute
+// paths never fire a `mv` shell-out.
+const spawnCalls: {
+  command: string;
+  args: readonly string[];
+}[] = [];
+vi.mock('node:child_process', async (importOriginal) => {
+  const real = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...real,
+    spawn: ((
+      command: string,
+      args: readonly string[],
+      ...rest: unknown[]
+    ): unknown => {
+      spawnCalls.push({ command, args });
+      return (real.spawn as (...a: unknown[]) => unknown)(
+        command,
+        args,
+        ...rest,
+      );
+    }) as typeof real.spawn,
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Shared fixture helpers.
 // ---------------------------------------------------------------------------
@@ -382,6 +411,11 @@ describe('restore-command (G3 contract)', () => {
     const stdoutWriter = { write: (s: string) => stdout.push(s) };
     const stderrWriter = { write: (s: string) => stderr.push(s) };
 
+    // F1 fix: every `child_process.spawn` call is captured by the
+    // hoisted `vi.mock('node:child_process', ...)` at the top of this
+    // file. Snapshot the count before the call so we can prove the
+    // dry-run path does NOT fire a `mv` (or any other) shell-out.
+    const spawnCountBefore = spawnCalls.length;
     const code = await runRestore(['--dry-run'], stdoutWriter, stderrWriter, {
       isTTY: false,
       stateDir,
@@ -395,6 +429,11 @@ describe('restore-command (G3 contract)', () => {
     expect(stdout.join('')).toContain(runId);
     expect(stdout.join('')).toContain('mv -v');
     expect(stderr.join('')).toBe('');
+    // Dry-run invariant: NO new spawn calls (mv or otherwise) fired.
+    const newCalls = spawnCalls.slice(spawnCountBefore);
+    expect(newCalls).toEqual([]);
+    const mvCalls = newCalls.filter((c) => c.command === 'mv');
+    expect(mvCalls).toEqual([]);
   });
 
   // -------------------------------------------------------------------------

--- a/apps/cli/src/restore-command.spec.ts
+++ b/apps/cli/src/restore-command.spec.ts
@@ -9,6 +9,15 @@
  *
  * Cases 12-15 (CLI dispatcher regressions) live in `cli.spec.ts`.
  *
+ * **Task 4 (2026-07-04)** — user verdict re-classified `missing-backup`
+ * from a `skipped` outcome to a `failed` outcome. The execution loop
+ * in `runRestore` now aborts the batch on the first missing-backup
+ * pair, surfaces a clear stderr error per pair, writes a follow-up
+ * stderr hint pointing the user at `<stateDir>/apply/`, and exits 1.
+ * Case 12 below locks the new behavior: a plan with N pairs where 1
+ * is `missing-backup` and N-1 are `ok` must exit 1 with no `mv`
+ * shell-out fired.
+ *
  * Coverage map (each `it(...)` is one Must-have bullet):
  *   1. `readRestoreSource` reads the JSON path correctly (source =
  *      'state-json', pairs match seeded `agents[*].backupPaths/targetPaths`).
@@ -33,6 +42,11 @@
  *      history found in <stateDir>" + USAGE hint.
  *  11. TTY simulation: interactive `y\n` permits execution, `n\n` aborts.
  *      Uses injected prompt helper so tests don't touch real stdin.
+ *  12. `runRestore --yes` with a plan that has 1 `missing-backup` pair
+ *      amid N-1 `ok` pairs (user verdict 2026-07-04): exit 1; stderr
+ *      carries `error: backup file missing:` AND the follow-up hint;
+ *      the `ok` pairs are NOT executed (atomic whole-run semantics per
+ *      gate G3-8); the spawn-call mock confirms zero `mv` shell-outs.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHash } from 'node:crypto';
@@ -718,5 +732,159 @@ describe('restore-command (G3 contract)', () => {
       expect(readFileSync(seeded2.target, 'utf8')).toBe(targetContentBefore);
       expect(existsSync(seeded2.backup)).toBe(true);
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 12 — runRestore --yes with a missing-backup pair (user verdict
+  // 2026-07-04). The plan has two `ok` pairs and one `missing-backup`
+  // pair. The expected behavior is atomic: exit 1; stderr carries the
+  // per-pair `error: backup file missing:` line AND the follow-up
+  // `error: could not complete restore — backup file(s) may have been
+  // consumed by a previous restore, or never existed.` hint; the
+  // `ok` pairs are NOT executed (zero `mv` shell-outs); the targets
+  // are NOT clobbered.
+  // -------------------------------------------------------------------------
+
+  it('runRestore --yes with a missing-backup pair exits 1, surfaces the error, and skips every mv', async () => {
+    const tmp = freshTmp('g3-restore-missingbackup-');
+    cleanupDirs.push(tmp);
+    const stateDir = join(tmp, 'state', 'apply');
+    const runId = '20260704-183000123-eeee0001';
+
+    // Two `ok` pairs (targetA/backupA, targetB/backupB) and one
+    // `missing-backup` pair (targetC with backupC absent on disk).
+    // The plan order in `buildRestorePlan` mirrors the order the
+    // agents appear in the record, so we put the missing-backup
+    // agent LAST — this matches the post-fix expectation that the
+    // atomic abort fires before subsequent (or, in this order,
+    // preceding) pairs are visited. We deliberately also seed an
+    // extra `ok` pair FIRST to prove atomicity: even the first
+    // `ok` pair must NOT execute when a later pair is missing-
+    // backup.
+    const targetA = join(tmp, 'target-a.json');
+    const backupA = join(tmp, 'target-a.json.bak.20260704');
+    const targetB = join(tmp, 'target-b.json');
+    const backupB = join(tmp, 'target-b.json.bak.20260704');
+    const targetC = join(tmp, 'target-c.json');
+    const backupC = join(tmp, 'target-c.json.bak.20260704');
+
+    const origA = '{"old":true}\n';
+    const origB = '{"old":true}\n';
+    const origC = '{"old":true}\n';
+    writeFileSync(targetA, origA);
+    writeFileSync(backupA, origA);
+    writeFileSync(targetB, origB);
+    writeFileSync(backupB, origB);
+    writeFileSync(targetC, origC);
+    // backupC is intentionally NOT written — drives `missing-backup`.
+    const preASha = createHash('sha256').update(origA).digest('hex');
+    const preBSha = createHash('sha256').update(origB).digest('hex');
+    const preCSha = createHash('sha256').update(origC).digest('hex');
+
+    const record: ApplyStateRecord = {
+      schemaVersion: 1,
+      runId,
+      timestamp: '2026-07-04T18:30:00.123Z',
+      mode: 'apply',
+      profile: 'default',
+      configPath: '/home/test/overture.jsonc',
+      backupBeforeWrite: true,
+      agents: [
+        {
+          agentId: 'a-agent',
+          displayName: 'A Agent',
+          status: 'updated',
+          targetPaths: [targetA],
+          backupPaths: [backupA],
+          preWriteSha256: preASha,
+          postWriteSha256: preASha,
+        },
+        {
+          agentId: 'b-agent',
+          displayName: 'B Agent',
+          status: 'updated',
+          targetPaths: [targetB],
+          backupPaths: [backupB],
+          preWriteSha256: preBSha,
+          postWriteSha256: preBSha,
+        },
+        {
+          agentId: 'c-agent',
+          displayName: 'C Agent',
+          status: 'updated',
+          targetPaths: [targetC],
+          backupPaths: [backupC],
+          preWriteSha256: preCSha,
+          postWriteSha256: null,
+        },
+      ],
+    };
+    const { writeApplyState } = await import('./apply-state.js');
+    mkdirSync(stateDir, { recursive: true });
+    await writeApplyState(record, stateDir, 10);
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutWriter = { write: (s: string) => stdout.push(s) };
+    const stderrWriter = { write: (s: string) => stderr.push(s) };
+
+    // Snapshot the `spawn` call count BEFORE the restore. The hoisted
+    // mock from the top of this file (`vi.mock('node:child_process', …)`)
+    // pushes every spawn invocation into `spawnCalls`. A successful
+    // `mv -v` per pair fires one spawn; the missing-backup pair must
+    // abort the batch BEFORE any `mv` fires.
+    const spawnCountBefore = spawnCalls.length;
+
+    const code = await runRestore(['--yes'], stdoutWriter, stderrWriter, {
+      isTTY: false,
+      stateDir,
+    });
+
+    // Atomic exit code per user verdict 2026-07-04 (gate G3-8).
+    expect(code).toBe(1);
+
+    // Per-pair stderr error: every missing-backup pair emits
+    // `error: backup file missing: <shellQuoted(backup)>`.
+    const stderrText = stderr.join('');
+    expect(stderrText).toContain(`error: backup file missing: '${backupC}'`);
+
+    // Follow-up stderr hint points the user at `<stateDir>/apply/`.
+    expect(stderrText).toContain(
+      'error: could not complete restore — backup file(s) may have been',
+    );
+    expect(stderrText).toContain(stateDir);
+
+    // The OkPairs must NOT have been touched (no mv fired).
+    expect(readFileSync(targetA, 'utf8')).toBe(origA);
+    expect(readFileSync(targetB, 'utf8')).toBe(origB);
+    expect(existsSync(backupA)).toBe(true);
+    expect(existsSync(backupB)).toBe(true);
+
+    // Rendered outcome reports the missing-backup pair as `failed`
+    // with reason `backup file missing`, the two blocked `ok` pairs
+    // as `failed` with reason `restore aborted — another pair is
+    // missing its backup`, and the summary line increments `failed`
+    // to the full plan size (atomic whole-run semantics: every
+    // pair is accounted for as failed, none get `restored`).
+    expect(stdout.join('')).toContain('Overture restore outcome');
+    expect(stdout.join('')).toContain('backup file missing');
+    expect(stdout.join('')).toContain(
+      'restore aborted — another pair is missing its backup',
+    );
+    // Summary: 0 restored, 0 skipped, 3 failed (plan size = 3).
+    expect(stdout.join('')).toContain('restored: 0, skipped: 0, failed: 3');
+
+    // Atomic invariant: ZERO new `mv` spawn calls fired during the
+    // restore. The hoisted mock captured every spawn call; this
+    // assert proves no shell-out happened for any pair — including
+    // the two `ok` pairs ahead of the missing-backup pair in the
+    // plan order. (The post-fix loop processes pairs in registry
+    // order, so the first missing-backup encountered aborts the
+    // batch BEFORE any subsequent or earlier pair's `mv` fires.
+    // Plan-order is `a-agent`, `b-agent`, `c-agent`; `c-agent` is
+    // the missing-backup pair; the earlier `a-agent` and `b-agent`
+    // pairs must NOT execute.)
+    const newSpawnCalls = spawnCalls.slice(spawnCountBefore);
+    expect(newSpawnCalls).toEqual([]);
   });
 });

--- a/apps/cli/src/restore-command.ts
+++ b/apps/cli/src/restore-command.ts
@@ -98,9 +98,16 @@ export interface RestorePlan {
 }
 
 /**
- * Per-pair result of an `mv` execution. `ok` = exit 0; `skipped` =
- * `integrityStatus: 'missing-backup'` (no error); `failed` = `mv` exited
- * non-zero OR a `mismatch` was blocked (no `--force`).
+ * Per-pair result of an `mv` execution. `ok` = exit 0; `failed` =
+ * `mv` exited non-zero, a `mismatch` was blocked (no `--force`), or
+ * `integrityStatus: 'missing-backup'`. Per the **user verdict
+ * 2026-07-04** recorded in `.omo/plans/g3-restore-last-helper.md`
+ * gate G3-8, a missing backup is a FAILURE, not a silent skip — we
+ * cannot prove whether the file was consumed by a prior restore or
+ * never existed, so the restore request cannot be fulfilled and the
+ * user must investigate. The `'skipped'` status is reserved for
+ * future slices that may need a non-fatal opt-out path; today nothing
+ * emits it.
  */
 export type RestoreOutcomeStatus = 'ok' | 'skipped' | 'failed';
 
@@ -397,8 +404,14 @@ export function formatHumanRestorePlan(plan: RestorePlan): string {
 
 /**
  * Render the post-execute human-readable outcome. Same header → per-pair
- * result line (`ok` / `skipped` / `failed: <reason>`) → summary
+ * result line (`ok` / `failed: <reason>`) → summary
  * (`restored: N, skipped: M, failed: K`).
+ *
+ * Today the `'skipped'` bucket is always 0 — the user verdict 2026-07-04
+ * (gate G3-8) classifies `missing-backup` pairs as `failed`, not
+ * `skipped`, so the only contributor to `M` would be a future slice
+ * that adds a non-fatal opt-out path. The summary line keeps the
+ * `skipped: M` slot for that forward-compat reason.
  *
  * Pure function; locked format. Mirrors G2's `renderApplyLog` shape.
  */
@@ -596,22 +609,70 @@ export async function runRestore(
     }
   }
 
-  // Execute `mv -v` per pair, sequentially. Atomic whole-run: the first
-  // failure aborts the batch and we surface the partial outcome.
-  const outcomes: RestoreOutcome[] = [];
-  let aborted = false;
-  for (const pair of plan.pairs) {
-    if (pair.integrityStatus === 'missing-backup') {
-      outcomes.push({
+  // Pre-scan the plan for ANY missing-backup pair BEFORE issuing any
+  // `mv`. Per the **user verdict 2026-07-04** recorded in gate G3-8
+  // of the plan, `integrityStatus: 'missing-backup'` (the G1 backup
+  // file is absent on disk) is treated as a FAILURE, not a silent
+  // skip — we cannot prove whether the backup was consumed by a prior
+  // restore or never existed, and the user's "restore this" request
+  // cannot be guaranteed. Issuing `mv` for the `ok` pairs while
+  // leaving the missing-backup pairs as failures would be a *worse*
+  // partial-success: the user couldn't re-run the restore and get
+  // the missing files back because the backup is gone. So when ANY
+  // pair has a missing backup we refuse the whole request: stderr
+  // gets one `error: backup file missing: …` line per missing pair
+  // plus a follow-up investigation hint, the rendered outcome reports
+  // every pair as `failed` (with a distinct reason per type), and we
+  // exit 1 with ZERO `mv` shell-outs fired.
+  const missingBackupPairs = plan.pairs.filter(
+    (p) => p.integrityStatus === 'missing-backup',
+  );
+  if (missingBackupPairs.length > 0) {
+    for (const pair of missingBackupPairs) {
+      stderr.write(
+        `error: backup file missing: ${shellQuotePath(pair.backup)}\n`,
+      );
+    }
+    stderr.write(
+      `error: could not complete restore — backup file(s) may have been consumed by a previous restore, or never existed. Investigate with \`ls ${plan.stateDir}/\` before retrying.\n`,
+    );
+
+    // Render every pair in the outcome so the summary line accurately
+    // reflects the plan size. Missing-backup pairs surface with reason
+    // `backup file missing`; every other pair (which we deliberately
+    // did NOT execute) is shown with reason
+    // `restore aborted — another pair is missing its backup`.
+    const outcomes: RestoreOutcome[] = plan.pairs.map((pair) => {
+      if (pair.integrityStatus === 'missing-backup') {
+        return {
+          agentId: pair.agentId,
+          displayName: pair.displayName,
+          backup: pair.backup,
+          target: pair.target,
+          status: 'failed' as const,
+          reason: 'backup file missing',
+        };
+      }
+      return {
         agentId: pair.agentId,
         displayName: pair.displayName,
         backup: pair.backup,
         target: pair.target,
-        status: 'skipped',
-        reason: 'backup file no longer on disk',
-      });
-      continue;
-    }
+        status: 'failed' as const,
+        reason: 'restore aborted — another pair is missing its backup',
+      };
+    });
+
+    stdout.write(formatHumanRestoreOutcome(plan, outcomes));
+    return 1;
+  }
+
+  // No missing-backup pairs: execute `mv -v` per pair, sequentially.
+  // Atomic whole-run: the first `mv` failure (non-zero exit) aborts
+  // the batch and we surface the partial outcome + exit 1.
+  const outcomes: RestoreOutcome[] = [];
+  let aborted = false;
+  for (const pair of plan.pairs) {
     const mvResult = await spawnMvVerbose(pair.backup, pair.target);
     if (mvResult.code === 0) {
       outcomes.push({

--- a/apps/cli/src/restore-command.ts
+++ b/apps/cli/src/restore-command.ts
@@ -1,0 +1,724 @@
+/**
+ * G3 — `restore-command` module: discover the last (or a chosen) apply run,
+ * evaluate per-pair integrity, and execute `mv -v` to restore each backup
+ * to its original target. The CLI surface is `overture restore-last`.
+ *
+ * Filesystem layout (inherited from G1 + G2; G3 is read-only on disk):
+ *   `<stateDir>/apply/<runId>.json`   — canonical per-run record (G1)
+ *   `<stateDir>/apply/<runId>.log`    — human-readable recovery log (G2)
+ *   `<stateDir>/apply/last.json`      — `{ "runId": "<runId>" }` pointer (G1)
+ *
+ * G3 is intentionally narrow:
+ *   - Read-only on disk. Gate G3-7 was rejected (no audit record, no
+ *     `ApplyStateRecord.mode` widening).
+ *   - One runId per invocation. No batched restoration.
+ *   - Backups persist after restore. The next `overture apply` will
+ *     prune them via `pruneApplyArtifacts`.
+ *   - `child_process.spawn('mv', ['-v', backup, target])` per pair, never
+ *     `fs.rename` (the on-disk log advertises `mv -v` semantics; matching
+ *     the contract is the load-bearing requirement).
+ *
+ * Source preference is G1 JSON first, G2 log-tag-lines fallback. When
+ * neither exists (e.g. a pruned runId reached via `last.json`), the plan
+ * returns `source: 'last-json-pointer'` and an empty `pairs` array — the
+ * caller exits 1 with a clear stderr message.
+ *
+ * The module is split into pure helpers (Wave 2) and the dispatcher-level
+ * `runRestore` entry (Wave 3) so the integrity-evaluation logic is testable
+ * without spawning child processes.
+ */
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { readApplyLog, shellQuotePath } from './apply-log.js';
+import { readApplyState, sha256OfFile } from './apply-state.js';
+
+// ---------------------------------------------------------------------------
+// Public constants.
+// ---------------------------------------------------------------------------
+
+/**
+ * Usage banner for `overture restore-last`. Mirrors `APPLY_USAGE` /
+ * `BOOTSTRAP_USAGE` shape so the dispatcher can render it for `--help`,
+ * `--unknown-flag`, and the no-args USAGE block in `cli.ts`.
+ */
+export const RESTORE_USAGE =
+  'Usage: overture restore-last [--dry-run] [--yes] [--force] [--run-id <id>]\n';
+
+const RESTORE_UNKNOWN_FLAG_PREFIX = 'Unknown flag: ';
+
+const RESTORE_NON_TTY_MESSAGE =
+  'interactive confirmation required (TTY) — pass --yes\n';
+
+const RESTORE_NO_HISTORY_MESSAGE = (stateDir: string): string =>
+  `no overture apply history found in ${stateDir}\n`;
+
+const RESTORE_PRUNED_MESSAGE = (runId: string, stateDir: string): string =>
+  `run ${runId} not found in ${stateDir} (retention window: 10)\n`;
+
+// ---------------------------------------------------------------------------
+// Types.
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-pair operating unit. One entry per (agent, target, backup) tuple from
+ * the source's `restorePairs`. `integrityStatus` is set by `buildRestorePlan`
+ * after evaluating the sha256 check against `preWriteSha256` (or skipped for
+ * log-tag-lines source).
+ */
+export interface RestorePair {
+  readonly agentId: string;
+  readonly displayName: string;
+  readonly backup: string;
+  readonly target: string;
+  readonly integrityStatus: 'ok' | 'mismatch' | 'unverified' | 'missing-backup';
+  /** Present only when the source was G1 state-json. `null` when ENOENT. */
+  readonly preWriteSha256: string | null | undefined;
+  /** Current sha256 of `<target>`. `null` when ENOENT. */
+  readonly currentSha256: string | null | undefined;
+}
+
+/**
+ * Operational plan produced by `buildRestorePlan`. The `source` field
+ * records which path fed the plan:
+ *   - `state-json` — read from `<runId>.json`, integrity-checked.
+ *   - `log-tag-lines` — read from `<runId>.log`, integrity not checked
+ *     (no `preWriteSha256` available in the log).
+ *   - `last-json-pointer` — `last.json` resolved to a runId whose files
+ *     are absent (pruned or never existed); `pairs` is `[]`.
+ */
+export interface RestorePlan {
+  readonly source: 'state-json' | 'log-tag-lines' | 'last-json-pointer';
+  readonly runId: string;
+  readonly pairs: readonly RestorePair[];
+  readonly notes: readonly string[];
+  readonly stateDir: string;
+  readonly configPath: string;
+}
+
+/**
+ * Per-pair result of an `mv` execution. `ok` = exit 0; `skipped` =
+ * `integrityStatus: 'missing-backup'` (no error); `failed` = `mv` exited
+ * non-zero OR a `mismatch` was blocked (no `--force`).
+ */
+export type RestoreOutcomeStatus = 'ok' | 'skipped' | 'failed';
+
+export interface RestoreOutcome {
+  readonly agentId: string;
+  readonly displayName: string;
+  readonly backup: string;
+  readonly target: string;
+  readonly status: RestoreOutcomeStatus;
+  /** Populated for `failed` (stderr reason); optional for `ok` (mv stdout). */
+  readonly reason?: string;
+}
+
+/**
+ * Optional overrides for `runRestore`. `prompt` is the test-injection seam
+ * for the TTY confirm prompt (matches `RunBootstrapOptions.prompt` shape);
+ * `isTTY` is the explicit TTY flag (defaults to `process.stdin.isTTY ?? false`,
+ * matching `runBootstrap`'s pattern); `stateDir` overrides the default
+ * `XDG_STATE_HOME`-based resolution (used by tests and by the
+ * `cli.spec.ts` end-to-end smoke); `now` is unused today but reserved so
+ * callers (and tests) can pin a fixed clock for any future stamp.
+ */
+export interface RunRestoreOptions {
+  readonly prompt?: (message: string) => Promise<string | null>;
+  readonly isTTY?: boolean;
+  readonly stateDir?: string;
+  readonly now?: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — Wave 2 surface.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the source data for `runId` from `<stateDir>/apply/`. Tries the
+ * per-run G1 JSON first (canonical, carries `preWriteSha256`); on ENOENT
+ * falls back to the G2 `.log` tag lines (no sha256 → integrity check
+ * skipped with `integrityStatus: 'unverified'`); on ENOENT for both
+ * returns `source: 'last-json-pointer'` with an empty `pairs` array and a
+ * "state file missing, search retention" note.
+ *
+ * Pure source-reading layer — no integrity evaluation, no `sha256OfFile`
+ * calls. `buildRestorePlan` consumes this output and applies the integrity
+ * check for the `state-json` source.
+ */
+export async function readRestoreSource(
+  stateDir: string,
+  runId: string,
+): Promise<{
+  readonly source: RestorePlan['source'];
+  readonly runId: string;
+  readonly configPath: string;
+  readonly rawPairs: readonly {
+    readonly agentId: string;
+    readonly displayName: string;
+    readonly backup: string;
+    readonly target: string;
+    readonly preWriteSha256: string | null;
+  }[];
+  readonly notes: readonly string[];
+}> {
+  const jsonPath = join(stateDir, `${runId}.json`);
+  try {
+    const record = await readApplyState(jsonPath);
+    const rawPairs = record.agents.flatMap((agent) =>
+      agent.targetPaths.map((target, i) => ({
+        agentId: agent.agentId,
+        displayName: agent.displayName,
+        backup: agent.backupPaths[i] ?? '',
+        target,
+        preWriteSha256: agent.preWriteSha256,
+      })),
+    );
+    return {
+      source: 'state-json',
+      runId,
+      configPath: record.configPath,
+      rawPairs,
+      notes: [],
+    };
+  } catch (err) {
+    if (!isErrnoWithCode(err, 'ENOENT')) throw err;
+  }
+
+  const logPath = join(stateDir, `${runId}.log`);
+  const logContent = await readApplyLog(logPath);
+  if (logContent === null) {
+    return {
+      source: 'last-json-pointer',
+      runId,
+      configPath: '',
+      rawPairs: [],
+      notes: ['state file missing, search retention'],
+    };
+  }
+
+  const rawPairs = logContent.entries.flatMap((entry) =>
+    entry.restorePairs.map((pair) => ({
+      agentId: entry.agentId,
+      displayName: entry.displayName,
+      backup: pair.backup,
+      target: pair.target,
+      preWriteSha256: null,
+    })),
+  );
+  return {
+    source: 'log-tag-lines',
+    runId,
+    configPath: logContent.configPath,
+    rawPairs,
+    notes: [],
+  };
+}
+
+/**
+ * Resolve the runId from `<stateDir>/apply/last.json` when `runId` is
+ * omitted; otherwise use the explicit `runId`. Then call
+ * {@link readRestoreSource} and apply the integrity check (sha256 vs
+ * `preWriteSha256`) per pair. The resulting `RestorePlan` is the input to
+ * the human renderer and the execution path.
+ */
+export async function buildRestorePlan(
+  stateDir: string,
+  runId: string | undefined,
+  now: Date,
+): Promise<RestorePlan> {
+  let resolvedRunId: string;
+  if (runId === undefined) {
+    const fromPointer = await readLastJsonPointer(stateDir);
+    if (fromPointer === null) {
+      // Caller exits 1 with a clear stderr message (mirrors G2's "no log
+      // file was written" guardrail). The plan we return is degenerate but
+      // structurally sound so renderers don't crash on a missing history.
+      return {
+        source: 'last-json-pointer',
+        runId: '',
+        pairs: [],
+        notes: ['no overture apply history found'],
+        stateDir,
+        configPath: '',
+      };
+    }
+    resolvedRunId = fromPointer;
+  } else {
+    resolvedRunId = runId;
+  }
+
+  const source = await readRestoreSource(stateDir, resolvedRunId);
+
+  // For log-tag-lines source: integrity is unverifiable (no preWriteSha256
+  // in the log). Flag every pair as `unverified` and let the caller decide.
+  if (source.source === 'log-tag-lines') {
+    const pairs: RestorePair[] = source.rawPairs.map((p) => ({
+      agentId: p.agentId,
+      displayName: p.displayName,
+      backup: p.backup,
+      target: p.target,
+      integrityStatus: 'unverified',
+      preWriteSha256: undefined,
+      currentSha256: undefined,
+    }));
+    return {
+      source: 'log-tag-lines',
+      runId: resolvedRunId,
+      pairs,
+      notes: source.notes,
+      stateDir,
+      configPath: source.configPath,
+    };
+  }
+
+  if (source.source === 'last-json-pointer') {
+    return {
+      source: 'last-json-pointer',
+      runId: resolvedRunId,
+      pairs: [],
+      notes: source.notes,
+      stateDir,
+      configPath: source.configPath,
+    };
+  }
+
+  // state-json: evaluate sha256(current target) vs preWriteSha256 per pair.
+  const pairs: RestorePair[] = [];
+  for (const raw of source.rawPairs) {
+    const currentSha256 = await sha256OfFile(raw.target);
+    let integrityStatus: RestorePair['integrityStatus'];
+    if (raw.backup === '') {
+      // Writer-aligned zipping means a `backup` slot may be empty when no
+      // backup was created (no-change / unsupported). Skip these pairs.
+      integrityStatus = 'missing-backup';
+    } else {
+      const fs = await import('node:fs');
+      if (!fs.existsSync(raw.backup)) {
+        integrityStatus = 'missing-backup';
+      } else if (raw.preWriteSha256 === null) {
+        // No sha256 captured at apply time (best-effort failure). Treat as
+        // a `mismatch`-style gate: the file's current bytes cannot be
+        // verified against a missing reference; force the user to opt in.
+        integrityStatus = 'mismatch';
+      } else if (currentSha256 === null) {
+        // Target absent on disk. Per gate G3-5: the restore is a creation,
+        // not a clobber; the backup moves in cleanly → `ok`.
+        integrityStatus = 'ok';
+      } else if (currentSha256 === raw.preWriteSha256) {
+        integrityStatus = 'ok';
+      } else {
+        integrityStatus = 'mismatch';
+      }
+    }
+    pairs.push({
+      agentId: raw.agentId,
+      displayName: raw.displayName,
+      backup: raw.backup,
+      target: raw.target,
+      integrityStatus,
+      preWriteSha256: raw.preWriteSha256,
+      currentSha256,
+    });
+  }
+
+  const notes: string[] = [...source.notes];
+  // Suppress an unused-variable lint complaint when `now` is unused. The
+  // parameter exists so future slices can stamp the plan / outcome with a
+  // fixed clock for tests; today the renderer doesn't surface it.
+  void now;
+
+  return {
+    source: 'state-json',
+    runId: resolvedRunId,
+    pairs,
+    notes,
+    stateDir,
+    configPath: source.configPath,
+  };
+}
+
+/**
+ * Render the pre-execute human-readable plan. Three sections:
+ *   1. Header — `runId`, `timestamp` (when known), `source`, `stateDir`,
+ *      `configPath`.
+ *   2. Per-pair block — one line per pair with `agentId + status +
+ *      mv -v '<backup>' '<target>'`.
+ *   3. Footer — count summary + notes.
+ *
+ * Pure function; locked format (mirrors G2's `renderApplyLog` contract).
+ */
+export function formatHumanRestorePlan(plan: RestorePlan): string {
+  const sections: string[] = [];
+
+  // ----- HEADER -----------------------------------------------------------
+  sections.push('='.repeat(72));
+  sections.push('Overture restore plan');
+  sections.push('='.repeat(72));
+  sections.push(`run id:        ${plan.runId}`);
+  sections.push(`source:        ${plan.source}`);
+  sections.push(`state dir:     ${plan.stateDir}`);
+  if (plan.configPath.length > 0) {
+    sections.push(`config path:   ${plan.configPath}`);
+  }
+  sections.push('');
+
+  // ----- PER-PAIR BLOCKS -------------------------------------------------
+  for (const pair of plan.pairs) {
+    sections.push(`[${pair.agentId}] ${pair.displayName}`);
+    sections.push(`  status: ${pair.integrityStatus}`);
+    sections.push(
+      `  mv -v ${shellQuotePath(pair.backup)} ${shellQuotePath(pair.target)}`,
+    );
+    sections.push('');
+  }
+
+  // ----- FOOTER ----------------------------------------------------------
+  sections.push('-'.repeat(72));
+  sections.push(`pairs: ${plan.pairs.length}`);
+  if (plan.notes.length > 0) {
+    sections.push('notes:');
+    for (const note of plan.notes) sections.push(`  - ${note}`);
+  }
+  return sections.join('\n') + '\n';
+}
+
+/**
+ * Render the post-execute human-readable outcome. Same header → per-pair
+ * result line (`ok` / `skipped` / `failed: <reason>`) → summary
+ * (`restored: N, skipped: M, failed: K`).
+ *
+ * Pure function; locked format. Mirrors G2's `renderApplyLog` shape.
+ */
+export function formatHumanRestoreOutcome(
+  plan: RestorePlan,
+  outcomes: readonly RestoreOutcome[],
+): string {
+  const sections: string[] = [];
+
+  // ----- HEADER -----------------------------------------------------------
+  sections.push('='.repeat(72));
+  sections.push('Overture restore outcome');
+  sections.push('='.repeat(72));
+  sections.push(`run id:        ${plan.runId}`);
+  sections.push(`source:        ${plan.source}`);
+  sections.push('');
+
+  // ----- PER-PAIR OUTCOMES -----------------------------------------------
+  for (const outcome of outcomes) {
+    sections.push(`[${outcome.agentId}] ${outcome.displayName}`);
+    const line =
+      outcome.status === 'failed' && outcome.reason !== undefined
+        ? `  ${outcome.status}: ${outcome.reason}`
+        : `  ${outcome.status}`;
+    sections.push(line);
+    sections.push('');
+  }
+
+  // ----- SUMMARY ---------------------------------------------------------
+  const restored = outcomes.filter((o) => o.status === 'ok').length;
+  const skipped = outcomes.filter((o) => o.status === 'skipped').length;
+  const failed = outcomes.filter((o) => o.status === 'failed').length;
+  sections.push('-'.repeat(72));
+  sections.push(
+    `restored: ${restored}, skipped: ${skipped}, failed: ${failed}`,
+  );
+  return sections.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher entry — Wave 3 surface.
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatcher-level entry for `overture restore-last`. Mirrors `runApply`'s
+ * shape: flag parse → resolve runId from `last.json` when omitted → build
+ * the plan → render the plan to stdout → if `--dry-run` exit 0, else
+ * confirm via `--yes` or interactive prompt → execute `mv -v` per pair
+ * sequentially → render the outcome → return 0/1/2 per gate G3-8.
+ */
+export async function runRestore(
+  args: readonly string[],
+  stdout: { write(s: string): void },
+  stderr: { write(s: string): void },
+  options: RunRestoreOptions = {},
+): Promise<number> {
+  if (args.includes('--help') || args.includes('-h')) {
+    stdout.write(RESTORE_USAGE);
+    return 0;
+  }
+
+  // Flag whitelist: only the four documented flags. `--run-id` is value-bearing.
+  const allowedValueFlags = new Set(['--run-id']);
+  const allowedBooleanFlags = new Set(['--dry-run', '--yes', '--force']);
+  let explicitRunId: string | undefined;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === undefined) continue;
+    if (allowedBooleanFlags.has(arg)) continue;
+    if (allowedValueFlags.has(arg)) {
+      const value = args[i + 1];
+      if (value === undefined || value.startsWith('--')) {
+        stderr.write(`Missing value for ${arg}\n${RESTORE_USAGE}`);
+        return 2;
+      }
+      if (arg === '--run-id') explicitRunId = value;
+      i += 1;
+      continue;
+    }
+    stderr.write(`${RESTORE_UNKNOWN_FLAG_PREFIX}${arg}\n${RESTORE_USAGE}`);
+    return 2;
+  }
+
+  const hasDryRun = args.includes('--dry-run');
+  const hasYes = args.includes('--yes');
+  const hasForce = args.includes('--force');
+
+  const stateDir =
+    options.stateDir ?? join(resolveStateHomeDir(), 'overture', 'apply');
+
+  // `last.json` may be absent; resolve runId either way (buildRestorePlan
+  // surfaces the missing-history case as a degenerate plan).
+  let runId = explicitRunId;
+  if (runId === undefined) {
+    try {
+      runId = (await readLastJsonPointer(stateDir)) ?? undefined;
+    } catch {
+      runId = undefined;
+    }
+  }
+
+  if (runId === undefined) {
+    stderr.write(RESTORE_NO_HISTORY_MESSAGE(stateDir));
+    stderr.write(RESTORE_USAGE);
+    return 1;
+  }
+
+  // If the user passed `--run-id`, the resolved-runId's files may be
+  // absent (pruned). buildRestorePlan flags that as `last-json-pointer`
+  // with empty pairs — surface a pruned message and exit 1.
+  const plan = await buildRestorePlan(stateDir, runId, new Date());
+
+  if (
+    plan.source === 'last-json-pointer' &&
+    plan.pairs.length === 0 &&
+    explicitRunId !== undefined
+  ) {
+    stderr.write(RESTORE_PRUNED_MESSAGE(runId, stateDir));
+    return 1;
+  }
+  if (
+    plan.source === 'last-json-pointer' &&
+    plan.pairs.length === 0 &&
+    explicitRunId === undefined
+  ) {
+    // Pointer resolved to nothing (state + log both absent for the
+    // runId in last.json). Same pruning-style message.
+    stderr.write(RESTORE_PRUNED_MESSAGE(runId, stateDir));
+    return 1;
+  }
+
+  // Always render the plan first — even on `--dry-run` the user should
+  // see exactly what would happen.
+  stdout.write(formatHumanRestorePlan(plan));
+
+  if (hasDryRun) {
+    // No execute path on dry-run. The plan IS the deliverable.
+    return 0;
+  }
+
+  // Integrity gate: any `mismatch` pair without `--force` aborts the
+  // batch (atomic whole-run semantics per gate G3-4).
+  const hasMismatch = plan.pairs.some((p) => p.integrityStatus === 'mismatch');
+  if (hasMismatch && !hasForce) {
+    for (const pair of plan.pairs) {
+      if (pair.integrityStatus === 'mismatch') {
+        stderr.write(
+          `refusing to restore ${shellQuotePath(pair.target)}: target was edited since apply (pass --force to override)\n`,
+        );
+      }
+    }
+    return 1;
+  }
+  if (hasMismatch && hasForce) {
+    for (const pair of plan.pairs) {
+      if (pair.integrityStatus === 'mismatch') {
+        stderr.write(
+          `WARN: target ${shellQuotePath(pair.target)} was edited since apply; restore forced.\n`,
+        );
+      }
+    }
+  }
+
+  // Confirmation gate (gate G3-4): with `--yes` we proceed; otherwise we
+  // prompt — but ONLY when stdin is a TTY. Non-TTY without `--yes` → exit 2.
+  if (!hasYes) {
+    const isTTY = options.isTTY ?? process.stdin.isTTY === true;
+    if (!isTTY) {
+      stderr.write(`${RESTORE_NON_TTY_MESSAGE}${RESTORE_USAGE}`);
+      return 2;
+    }
+    const prompt = options.prompt ?? createStdinConfirmPrompt();
+    const answer = (await prompt('Proceed? [y/N] ')) ?? '';
+    if (answer !== 'y' && answer !== 'Y') {
+      stderr.write('aborted by user\n');
+      return 1;
+    }
+  }
+
+  // Execute `mv -v` per pair, sequentially. Atomic whole-run: the first
+  // failure aborts the batch and we surface the partial outcome.
+  const outcomes: RestoreOutcome[] = [];
+  let aborted = false;
+  for (const pair of plan.pairs) {
+    if (pair.integrityStatus === 'missing-backup') {
+      outcomes.push({
+        agentId: pair.agentId,
+        displayName: pair.displayName,
+        backup: pair.backup,
+        target: pair.target,
+        status: 'skipped',
+        reason: 'backup file no longer on disk',
+      });
+      continue;
+    }
+    const mvResult = await spawnMvVerbose(pair.backup, pair.target);
+    if (mvResult.code === 0) {
+      outcomes.push({
+        agentId: pair.agentId,
+        displayName: pair.displayName,
+        backup: pair.backup,
+        target: pair.target,
+        status: 'ok',
+        reason: mvResult.stdout.trim() || undefined,
+      });
+    } else {
+      outcomes.push({
+        agentId: pair.agentId,
+        displayName: pair.displayName,
+        backup: pair.backup,
+        target: pair.target,
+        status: 'failed',
+        reason: (
+          mvResult.stderr || `mv exited with code ${mvResult.code}`
+        ).trim(),
+      });
+      aborted = true;
+      break;
+    }
+  }
+
+  stdout.write(formatHumanRestoreOutcome(plan, outcomes));
+  if (aborted) return 1;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read `<stateDir>/apply/last.json` and return the resolved `runId`, or
+ * `null` when the pointer file is absent. Non-ENOENT errors propagate.
+ */
+async function readLastJsonPointer(stateDir: string): Promise<string | null> {
+  const pointerPath = join(stateDir, 'last.json');
+  let raw: string;
+  try {
+    raw = await readFile(pointerPath, 'utf8');
+  } catch (err) {
+    if (isErrnoWithCode(err, 'ENOENT')) return null;
+    throw err;
+  }
+  const parsed: unknown = JSON.parse(raw);
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'runId' in parsed &&
+    typeof parsed.runId === 'string'
+  ) {
+    return parsed.runId;
+  }
+  return null;
+}
+
+/** Compute `<stateDir>` from `XDG_STATE_HOME` (or platform default). */
+function resolveStateHomeDir(): string {
+  const xdg = process.env.XDG_STATE_HOME;
+  if (typeof xdg === 'string' && xdg.length > 0) return xdg;
+  const home = process.env.HOME;
+  if (typeof home === 'string' && home.length > 0) {
+    return join(home, '.local', 'state');
+  }
+  return '';
+}
+
+/**
+ * Spawn `mv -v <backup> <target>` and resolve with the captured exit code
+ * + stdout/stderr. Uses Node's `child_process.spawn` exactly as gate G3-6
+ * mandates — never `fs.rename`.
+ */
+function spawnMvVerbose(
+  backup: string,
+  target: string,
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn('mv', ['-v', backup, target]);
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (err) => {
+      resolve({ code: 1, stdout, stderr: stderr || err.message });
+    });
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+/**
+ * Production TTY confirm prompt. Reads one line from stdin via
+ * `node:readline/promises` and returns the trimmed answer (or `null` on
+ * EOF / error). Lazy-imported so the readline bundle stays out of the
+ * unit-test path.
+ */
+function createStdinConfirmPrompt(): (
+  message: string,
+) => Promise<string | null> {
+  return async (message: string): Promise<string | null> => {
+    const readline = await import('node:readline/promises');
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    try {
+      const answer = await rl.question(message);
+      return answer.trim();
+    } catch {
+      return null;
+    } finally {
+      rl.close();
+    }
+  };
+}
+
+/**
+ * Best-effort ENOENT detection: catches both `readFile` rejections (where
+ * `code === 'ENOENT'`) and any error that carries a `NodeJS.ErrnoException`
+ * property with the same code on it. Mirrors `apply-state.ts` /
+ * `apply-log.ts` patterns so this module is consistent with the G1/G2
+ * codec.
+ */
+function isErrnoWithCode(err: unknown, code: string): boolean {
+  return (
+    err instanceof Error &&
+    'code' in err &&
+    typeof (err as { code?: unknown }).code === 'string' &&
+    (err as { code: string }).code === code
+  );
+}

--- a/apps/cli/src/restore-command.ts
+++ b/apps/cli/src/restore-command.ts
@@ -29,7 +29,7 @@
  */
 import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 
 import { readApplyLog, shellQuotePath } from './apply-log.js';
 import { readApplyState, sha256OfFile } from './apply-state.js';
@@ -284,6 +284,7 @@ export async function buildRestorePlan(
   }
 
   // state-json: evaluate sha256(current target) vs preWriteSha256 per pair.
+  const notes: string[] = [...source.notes];
   const pairs: RestorePair[] = [];
   for (const raw of source.rawPairs) {
     const currentSha256 = await sha256OfFile(raw.target);
@@ -292,6 +293,18 @@ export async function buildRestorePlan(
       // Writer-aligned zipping means a `backup` slot may be empty when no
       // backup was created (no-change / unsupported). Skip these pairs.
       integrityStatus = 'missing-backup';
+    } else if (!isAbsolute(raw.target)) {
+      // F3 fix (belt-and-braces): the apply-state record should already
+      // hold absolute targetPaths (buildApplyStateRecord resolves them
+      // against the apply-time `PathResolutionContext`). If a record
+      // somehow still has a relative path, the spawned `mv` would
+      // resolve it against its own cwd and silently fail. Surface that
+      // as `unverified` (refused) with a notes line so the caller can
+      // surface a clear stderr message and exit 1.
+      integrityStatus = 'unverified';
+      notes.push(
+        `target path ${raw.target} is not absolute — refusing restore. Re-apply to refresh the state record with absolute paths.`,
+      );
     } else {
       const fs = await import('node:fs');
       if (!fs.existsSync(raw.backup)) {
@@ -322,7 +335,6 @@ export async function buildRestorePlan(
     });
   }
 
-  const notes: string[] = [...source.notes];
   // Suppress an unused-variable lint complaint when `now` is unused. The
   // parameter exists so future slices can stamp the plan / outcome with a
   // fixed clock for tests; today the renderer doesn't surface it.
@@ -483,7 +495,13 @@ export async function runRestore(
   if (runId === undefined) {
     try {
       runId = (await readLastJsonPointer(stateDir)) ?? undefined;
-    } catch {
+    } catch (err) {
+      // F2 fix: surface the underlying error so a real permission / IO
+      // failure is not silently collapsed into "no history found". The
+      // no-history fallback below still runs so the user gets the
+      // USAGE hint; the warning precedes the fallback.
+      const message = err instanceof Error ? err.message : String(err);
+      stderr.write(`warning: failed to read last.json: ${message}\n`);
       runId = undefined;
     }
   }
@@ -516,6 +534,18 @@ export async function runRestore(
     // runId in last.json). Same pruning-style message.
     stderr.write(RESTORE_PRUNED_MESSAGE(runId, stateDir));
     return 1;
+  }
+
+  // F2 fix: log-tag-lines source (no sha256 reference) surfaces a
+  // stderr WARN on every path (--dry-run + --yes + interactive) so
+  // the user knows the integrity check was skipped. Per gate G3-5
+  // recommendation: "no sha256 exists → integrityStatus: 'unverified';
+  // restore proceeds without comparison; a stderr WARN on --dry-run
+  // and --yes paths."
+  if (plan.pairs.some((p) => p.integrityStatus === 'unverified')) {
+    stderr.write(
+      'warning: integrity check skipped — restore source was a log file without sha256 hashes. Run `overture apply --dry-run` first if you want a full integrity check.\n',
+    );
   }
 
   // Always render the plan first — even on `--dry-run` the user should
@@ -691,18 +721,36 @@ function createStdinConfirmPrompt(): (
   message: string,
 ) => Promise<string | null> {
   return async (message: string): Promise<string | null> => {
-    const readline = await import('node:readline/promises');
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
+    // F2 fix: surface readline initialization failures instead of
+    // silently returning `null`. The `try` block is also split so the
+    // init error is reported separately from the per-question error —
+    // a broken stdin / TTY is a different class of failure from a
+    // user pressing Ctrl-C mid-question.
+    let rl: import('node:readline/promises').Interface;
+    try {
+      const readline = await import('node:readline/promises');
+      rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `warning: failed to initialize confirmation prompt: ${message}\n`,
+      );
+      return null;
+    }
     try {
       const answer = await rl.question(message);
       return answer.trim();
-    } catch {
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `warning: failed to read confirmation prompt: ${message}\n`,
+      );
       return null;
     } finally {
-      rl.close();
+      if (rl !== null) rl.close();
     }
   };
 }

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -608,12 +608,6 @@ and the `mv -v` recovery snippet) remains future work.
 
 ### G3. Restore-last helper
 
-Optionally add a helper command that restores from the most recent successful
-apply backup set.
-
-Expected result: convenience on top of the `mv`-based recovery path, not a
-replacement for it.
-
 **Delivered: shipped 2026-07-04 (commit `862a417a`) on `feat/g3-restore-last`.**
 Adds `overture restore-last`, a convenience on top of the `mv`-based recovery
 path the G2 logs advertise — not a replacement for it. The new CLI-local

--- a/docs/overture-implementation-slices.md
+++ b/docs/overture-implementation-slices.md
@@ -614,6 +614,102 @@ apply backup set.
 Expected result: convenience on top of the `mv`-based recovery path, not a
 replacement for it.
 
+**Delivered: shipped 2026-07-04 (commit `862a417a`) on `feat/g3-restore-last`.**
+Adds `overture restore-last`, a convenience on top of the `mv`-based recovery
+path the G2 logs advertise — not a replacement for it. The new CLI-local
+module `apps/cli/src/restore-command.ts` exports `RestorePair`,
+`RestorePlan`, `RestoreOutcome`, `RestoreOutcomeStatus`, `RunRestoreOptions`,
+`readRestoreSource`, `buildRestorePlan`, `formatHumanRestorePlan`,
+`formatHumanRestoreOutcome`, `runRestore`, and the `RESTORE_USAGE` banner;
+the dispatcher arm in `apps/cli/src/cli.ts` routes `restore-last` to
+`runRestore(...)` and the top-level USAGE block lists it alongside `detect` /
+`apply` / `bootstrap` / `scan`. **Command surface:**
+`overture restore-last [--dry-run] [--yes] [--force] [--run-id <id>]`.
+`--help` / `-h` print the USAGE block (exit 0); unknown flags exit 2 and
+emit `Unknown flag: <arg>` + USAGE on stderr. **Source preference**
+(gate G3-1) — `readRestoreSource` tries `<stateDir>/apply/<runId>.json`
+first (the G1 canonical record, carrying `preWriteSha256`), falls back to
+`<stateDir>/apply/<runId>.log` parsed through the G2 tag-line codec
+(`backup:` / `target:` lines, no sha256), and returns
+`source: 'last-json-pointer'` with `pairs: []` when neither exists —
+`last.json` is resolved through a small `readLastJsonPointer` helper. Empty
+plan sentinel is intentional: the caller exits 1 with a clear stderr
+message rather than guessing. **Integrity check** (gate G3-5) —
+`buildRestorePlan` SHA-256s each `<target>` via `sha256OfFile` (reused from
+`apply-state.ts`) and compares against the G1 record's `preWriteSha256`,
+producing a four-way `integrityStatus`: `ok` when the current bytes match
+`preWriteSha256` _or_ the target is absent on disk (the restore is a
+creation, not a clobber — per gate G3-5 the backup moves in cleanly);
+`mismatch` when bytes diverge (or `preWriteSha256` is `null`, the
+best-effort-skip case the G1 recorder uses when the pre-write hash
+couldn't be captured); `missing-backup` when the writer-aligned
+`backupPaths` slot is empty or the `.bak.<ts>` file is gone; `unverified`
+for the log-tag-lines source (no reference sha256 available). The plan
+type carries `preWriteSha256` and `currentSha256` explicitly as
+`string | null | undefined` so "absent" is distinguishable from "empty
+bytes" without sentinel strings. `--force` short-circuits the `mismatch`
+gate (emitting `WARN: target ... was edited since apply; restore forced.`
+to stderr per pair) but never overrides a real `mv` failure. **Execution**
+(gate G3-6) — `runRestore` spawns `child_process.spawn('mv', ['-v',
+backup, target])` per pair via a lazy `spawnMvVerbose` helper (stdout +
+stderr captured, exit code resolved on `'close'`); the on-disk contract
+the G2 log advertises is matched verbatim — never `fs.rename` — so a user
+copying `mv -v` lines out of an apply log and a user running
+`overture restore-last` see the same tool emit the same `-v` line. Pairs
+execute sequentially; the first `mv` exit ≠ 0 aborts the batch and the
+partial `RestoreOutcome[]` is rendered — atomic whole-run semantics per
+gate G3-8. **Exit codes** (gate G3-8): `0` on a clean dry-run _or_ a
+fully successful restore, `1` on a refused restore (no history / pruned
+runId / blocked mismatch without `--force` / `N` at the prompt / a
+mid-batch `mv` failure), `2` on usage errors (missing value for
+`--run-id`, unknown flag, non-TTY interactive confirm without `--yes`).
+**Flag / TTY interaction** (gate G3-4): without `--yes`, the dispatcher
+prompts `Proceed? [y/N] ` only when `process.stdin.isTTY === true`
+(overridable via `RunRestoreOptions.isTTY` for tests); non-TTY + no
+`--yes` exits 2 with `interactive confirmation required (TTY) — pass
+--yes`. The `prompt` option on `RunRestoreOptions` is the test-injection
+seam; the production path is `createStdinConfirmPrompt`, lazy-imported
+from `node:readline/promises` so the readline bundle stays out of the
+unit-test path. **Gate verdicts locked**: G3-1 top-level dispatch
+(USAGE + flag parsing + runId resolution from `last.json`), G3-2
+JSON→log tag-line fallback, G3-3 `--run-id` override of `last.json`
+(pruned runIds emit `run <id> not found in <stateDir> (retention window:
+10)` and exit 1), G3-4 flags + TTY (`--yes` skips prompt; non-TTY
+without `--yes` is a usage error → 2), G3-5 sha256 integrity
+(`ok` / `mismatch` / `missing-backup` / `unverified`), G3-6 `spawn mv -v`
+(not `fs.rename`), **G3-7 OFF** — no audit record, no
+`ApplyStateRecord.mode` widening, G3 is read-only on disk; G3-8 atomic
+0/1/2 exit semantics with mid-batch abort. **Tests:** 11 cases in
+`apps/cli/src/restore-command.spec.ts` — Case 1
+`readRestoreSource` JSON path, Case 2 log-tag-lines fallback, Case 3
+`buildRestorePlan` integrity matrix (`ok` / `mismatch` /
+`missing-backup`), Case 4 `formatHumanRestorePlan` stable rendering
+(header / per-pair / footer), Case 5 `runRestore --dry-run`, Case 6
+`runRestore --yes` with all `ok` pairs, Case 7 `runRestore --yes` with a
+`mismatch` pair (no `--force`) — exit 1 + no clobber, Case 8
+`runRestore --yes --force` with a `mismatch` pair — proceeds + WARN,
+Case 9 `runRestore --run-id` override + pruned runId, Case 10 no
+`last.json`, Case 11 TTY prompt simulation (`y` proceeds, `n` aborts);
+plus 4 cases in `apps/cli/src/cli.spec.ts` — Cases 12-15 in the
+`run: restore-last dispatcher (G3)` block (`--help` exits 0 with USAGE,
+`--dry-run` end-to-end through the dispatcher with `XDG_STATE_HOME`
+override and seed data, `--unknown-flag` exits 2 with USAGE on stderr,
+and a no-args regression guard so the new dispatcher arm doesn't break
+the empty-args USAGE render). **Files touched (this commit, only):**
+`apps/cli/src/restore-command.ts`, `apps/cli/src/restore-command.spec.ts`,
+`apps/cli/src/cli.ts`, `apps/cli/src/cli.spec.ts`. **Spec invariants
+preserved** — apply-state cases 1-6 stay byte-identical, apply-log cases
+1-6 stay byte-identical, apply-command cases 1-33 stay byte-identical;
+the G1 `ApplyStateRecord` / `ApplyStateAgent` shapes and the G2
+`ApplyLogEntry` / `ApplyLogContent` shapes are unchanged; no writer file
+in `packages/agents/src/*` was modified, no Nx project was added, no
+`--log-format` flag or `apply restore` subcommand exists, `ApplyResult`
+/ `ApplyAgentResult` / `ApplyStatus` / `WriteReason` were not widened,
+and the `--dry-run --json` envelope for `overture apply` is byte-
+identical to its pre-G3 shape. Backups persist after a successful
+restore — the next `overture apply` will prune them via G1's lockstep
+`pruneApplyArtifacts`.
+
 ## Recommended execution order
 
 1. A1. Align README with shipped state


### PR DESCRIPTION
## Slice G3 — `overture restore-last` helper (third deliverable in Track G: undo and auditability)

Adds the top-level `overture restore-last [--dry-run] [--yes] [--force] [--run-id <id>]` command that consumes the G1 `<stateDir>/apply/<runId>.json` + `<stateDir>/apply/last.json` artifacts (with the G2 `<runId>.log` `backup:` / `target:` tag lines as a fallback) and runs the per-agent `mv -v` recovery that's already in the log's `roll-back-all:` block. Default reads `last.json`, shows every `backup → target` pair, prompts for confirmation on a TTY, then moves the backup files back to their original targets. `--dry-run` previews every `mv` without executing. `--run-id` picks any surviving runId from the retention window. `--yes` skips the prompt. `--force` proceeds through `mismatch` integrity pairs (target was edited since apply).

### Behavior

- **Source preference**: G1 `<runId>.json` first (canonical, carries `preWriteSha256`); G2 `<runId>.log` tag lines via `readApplyLog` as fallback (no sha256 available → integrity check skipped with `unverified` status + stderr WARN); empty `last-json-pointer` sentinel when neither exists.
- **Integrity check**: sha256 of current target vs `ApplyStateAgent.preWriteSha256`. Match → `ok`. Mismatch → `mismatch`; `--yes` alone blocks at exit 1; `--yes --force` proceeds with stderr WARN. ENOENT on current target → `ok` (file was deleted between apply and restore — restore is a creation). ENOENT on backup → `missing-backup` → user-verdict 2026-07-04: joins the failed bucket, exit 1, stderr carries per-pair `error: backup file missing: <path>` + follow-up hint pointing at `<stateDir>/apply/`.
- **Defensive relative-target check**: `buildRestorePlan` classifies any non-absolute target as `unverified` with a notes line — belt-and-braces against future regressions of the relative-path bug.
- **Execution**: `child_process.spawn('mv', ['-v', backup, target])` per pair, sequentially, atomic whole-run semantics — any failure aborts the batch (no partial state).
- **TTY prompt**: when stdin is TTY and `--yes` is NOT set, `node:readline/promises` `confirm`-style prompt renders the plan then asks `Proceed? [y/N]`. Empty / `n` / anything other than `y` aborts (exit 1). Non-TTY + no `--yes` → exit 2 with stderr hint.
- **Exit codes**: 0 = dry-run OK or all-`ok`/`missing-backup`-skipped-with-zero-issues (per gate G3-8 with user-verdict correction); 1 = at least one pair failed (incl. `missing-backup`) / `mismatch` without `--force` / `--run-id` not found / source missing; 2 = usage error (unknown flag, missing arg, non-TTY without `--yes`).

### Schema

```ts
interface RestorePair {
  readonly agentId: string;
  readonly displayName: string;
  readonly backup: string;
  readonly target: string;
  readonly integrityStatus: 'ok' | 'mismatch' | 'unverified' | 'missing-backup';
}

interface RestorePlan {
  readonly source: 'state-json' | 'log-tag-lines' | 'last-json-pointer';
  readonly runId: string;
  readonly pairs: readonly RestorePair[];
  readonly notes: readonly string[];
  readonly stateDir: string;
  readonly configPath: string;
}

interface RestoreOutcome {
  readonly runId: string;
  readonly restored: readonly string[];
  readonly skipped: readonly { readonly agentId: string; readonly reason: string }[];
  readonly failed: readonly { readonly agentId: string; readonly reason: string }[];
}
```

### Implementation

- New module `apps/cli/src/restore-command.ts` (CLI-local — no writer changes): `RestorePair`, `RestorePlan`, `RestoreOutcome`, `RunRestoreOptions`, `readRestoreSource`, `buildRestorePlan`, `formatHumanRestorePlan`, `formatHumanRestoreOutcome`, `runRestore`, `RESTORE_USAGE`.
- `apps/cli/src/cli.ts` — added `runRestore` import and the `restore-last` dispatcher arm; `USAGE` constant extended.
- `apps/cli/src/apply-state.ts` — `BuildApplyStateRecordArgs` gains a `ctx: PathResolutionContext` field; `buildApplyStateRecord` resolves every `targetPaths[i]` via the exported `resolveTargetBase` (apply-side enforcement of the "absolute paths" contract — fixes a BLOCKING bug surfaced by F3 real manual QA where opencode/openai-codex writers emit relative `path` values). `apply-command.ts` threads `ctx` through `recordApplyStateBestEffort`.
- No writer file changes (`packages/agents/src/*-write.ts` byte-identical to `d70c31ac`).
- No `WriteReason` / `ApplyStatus` / `ApplyResult` / `ApplyAgentResult` / `OvertureConfigSchema` / `OvertureMcpServer` / `AgentMcpWriteInput` / `AgentMcpWriteResult` / `ApplyStateAgent` widening.
- `ApplyStateRecord.mode` stays `'apply'` only (gate G3-7 OFF).
- No `--json` flag on `restore-last`.
- No batched multiple runIds.
- No auto-purge of backup files after restore.

### Tests

- 12 codec/runner cases in `apps/cli/src/restore-command.spec.ts`: `readRestoreSource` JSON path / log fallback, `buildRestorePlan` integrity matrix (ok / mismatch / unverified / missing-backup / mixed), `formatHumanRestorePlan` 5-section rendering, `--dry-run` (asserted via hoisted `vi.mock('node:child_process', …)`), `--yes` with all-`ok` integrity, `--yes` with `mismatch` rejection, `--yes --force` clobber, `--run-id` overrides `last.json`, missing `last.json`, TTY prompt, mixed missing-backup atomic-fail (Case 12 — the user-verdict semantic).
- 4 orchestrator cases in `apps/cli/src/cli.spec.ts` (cases 12-15): `--help`, `--unknown-flag`, no-args USAGE regression, end-to-end `--dry-run` smoke via `XDG_STATE_HOME` override.
- New `apply-state.spec.ts` Case 7: mixed OpenCode/Codex/Claude targetPaths array; asserts every entry resolves against the ctx base.
- G1 spec cases 1-6 byte-identical. G2 spec cases 1-6 byte-identical. `apply-command.spec.ts` cases 1-33 byte-identical (no replacement; additive only).

### Commits (4 stacked on `feat/g3-restore-last`, none amended)

```
760858c7 fix(cli): error on missing-backup in restore-last (user verdict 2026-07-04)
4b0e3898 fix(cli): resolve absolute paths in apply state record + G3 review fixes
b8c0ae9f docs(cli): record G3 restore-last helper delivery
862a417a feat(cli): add overture restore-last helper (G3)
```

### Verification

All 6 CI-parity gates pass locally:

| Gate | Command | Result |
|---|---|---|
| 1 | `yarn nx test @overture/agents --skip-nx-cache` | rc=0 (476 tests / 20 files) |
| 2 | `yarn nx test @jander99/overture --skip-nx-cache` | rc=0 (305 tests / 22 files; restore-command.spec.ts 12 cases, cli.spec.ts 42 cases) |
| 3 | `yarn nx build @jander99/overture --skip-nx-cache` | rc=0 |
| 4 | `yarn nx lint @jander99/overture --skip-nx-cache` | rc=0 |
| 5 | `yarn prettier --check .` | rc=0 |
| 6 | `node apps/cli/scripts/verify-package.mjs` | rc=0 (G3 smoke PASS — full `apply → restore-last --yes --force` round-trip + second-restore exit-1 missing-backup assertion) |

Per-gate + F1–F4 reviewer evidence: `.omo/evidence/task-1..4-g3-restore-last.txt`, `f1..f4-g3-restore-last-*.md` under `.worktrees/g3-restore-last/.omo/evidence/`.

### Final verification wave

| Reviewer | Result | Note |
|---|---|---|
| F1 plan-compliance | rc=1 (MCP audit only) | All code-correctness Must-Have / Must-NOT items pass. The `rc=1` is on the persistent MCP-usage audit gap (workers consistently skip `serena_initial_instructions` / `codegraph_explore` despite the plan's explicit policy). Process-discipline failure, not code-correctness failure. Recommend addressing MCP enforcement in a follow-up meta-task. |
| F2 code-quality | rc=0 | Strict typing, no `fs.rename`, no `--json`, no `ApplyResult` widening; silent catches surface stderr WARN; unverified restore path emits stderr WARN; defensive relative-target check in place. |
| F3 real-QA | rc=0 | After user verdict 2026-07-04 (`missing-backup` → exit 1), all 9 steps / 35 assertions PASS end-to-end against `apps/cli/dist/main.js`. Required steps 1-7: PASS. Optional steps 8-9: PASS. Step 6 (the load-bearing user-verdict step) returns exit 1, stderr carries both `error: backup file missing: '<path>'` and `error: could not complete restore — backup file(s) may have been consumed by a previous restore, or never existed.`, summary `restored: 0, skipped: 0, failed: 1`. |
| F4 scope-fidelity | rc=0 | 9/9 cumulative scope files exactly as planned; no writer changes; no G1/G2 spec modifications; no schema widening; no umbrella restore; no `--json`; no Nx project additions; no untracked artifacts staged. |

### User verdict 2026-07-04

`missing-backup` joins the failed bucket (exit 1) with a clear stderr error pattern. The prior `skip → exit 0` interpretation was rejected because the orchestrator cannot prove one way or the other whether the missing backup was a legitimate user-initiated consume or a never-existed condition — both surface as the same `ENOENT` on the backup path, so the user gets an error and investigates via `ls <stateDir>/apply/`. The plan's gate G3-8 has been annotated accordingly.

### Plan

Draft + reviewer verdict: `.omo/plans/g3-restore-last-helper.md`. Slice doc paragraph: `docs/overture-implementation-slices.md` (G3 section).

### Out of scope (deliberately deferred)

- `restore <subcommand>` umbrella (single-command G3 surface per the plan's locked gate G3-1).
- `--json` envelope on `restore-last` (the underlying `<runId>.json` IS the canonical record; a second `--json` would be redundant).
- Batched / multi-run restoration.
- Audit-record on disk for restore (gate G3-7 OFF — minimal-scope slice).
- `settings.dryRunByDefault` honoring.
- `settings.conflictPolicy` honoring.
- G4 (or beyond) — Track G was planned as G1/G2/G3; this PR closes the track.