### PR TITLE
chore(npm): add publishConfig.registry; fix stale .omo/plans/ refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ npx @jander99/overture@latest --help
 Requires **Node.js >= 24** (the CLI's first published version targets the
 Node 24 LTS baseline; local Node 25 also works).
 
-> **Status**: the npm package shape is ready and the first publish is gated
-> behind a manual approval step. See `.omo/plans/npm-npx-readiness-phase-set.md`
-> for the publish-readiness phase-set.
+> **Status**: the npm package shape is ready. The first publish is gated
+> behind a manual approval step; see [`docs/publishing.md`](docs/publishing.md)
+> for the publish runbook.
 
 ## What it does
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -30,7 +30,8 @@
     "LICENSE"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   },
   "scripts": {
     "link": "yarn nx build @jander99/overture --skip-nx-cache && npm link",

--- a/apps/cli/src/apply-state.ts
+++ b/apps/cli/src/apply-state.ts
@@ -354,8 +354,8 @@ export async function pruneApplyState(
 
 /**
  * Inline atomic write — open temp → write → fsync → close → rename. Mirrors
- * the G1 plan's "write-to-temp + fsync before rename" contract (see
- * `.omo/plans/g1-apply-state-file.md`); fsync is what guarantees the bytes
+ * the G1 plan's "write-to-temp + fsync before rename" contract; fsync
+ * is what guarantees the bytes
  * survive a crash between the temp write and the rename. Kept local to G1
  * (no shared helper per the plan's "Must NOT introduce a shared atomic-write
  * helper" guardrail). On failure the temp file is unlinked best-effort so

--- a/apps/cli/src/restore-command.ts
+++ b/apps/cli/src/restore-command.ts
@@ -101,8 +101,8 @@ export interface RestorePlan {
  * Per-pair result of an `mv` execution. `ok` = exit 0; `failed` =
  * `mv` exited non-zero, a `mismatch` was blocked (no `--force`), or
  * `integrityStatus: 'missing-backup'`. Per the **user verdict
- * 2026-07-04** recorded in `.omo/plans/g3-restore-last-helper.md`
- * gate G3-8, a missing backup is a FAILURE, not a silent skip — we
+ * 2026-07-04**, gate G3-8, a missing backup is a FAILURE, not a silent
+ * skip — we
  * cannot prove whether the file was consumed by a prior restore or
  * never existed, so the restore request cannot be fulfilled and the
  * user must investigate. The `'skipped'` status is reserved for

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,7 +1,7 @@
 # Publishing `@jander99/overture` to npm — manual runbook
 
-This runbook is the executable counterpart to the npm/npx readiness
-phase-set plan at `.omo/plans/npm-npx-readiness-phase-set.md`. It is
+This runbook is the canonical publish procedure for `@jander99/overture`
+on npmjs.com. It is
 written for a maintainer (you) who has **not yet registered on
 npmjs.com** — so it starts with the one-time setup and ends with the
 publish trigger.


### PR DESCRIPTION
## Summary

Small npm-publish-readiness fixes ahead of the upcoming release-train work:

- **`apps/cli/package.json`**: add `publishConfig.registry: "https://registry.npmjs.org"` so Yarn 4 routes `yarn npm publish` through the public registry. With only `access: "public"` set, Yarn 4 may otherwise pick up a workspace-level registry hint.
- **`README.md` + `docs/publishing.md`**: fix dead references to `.omo/plans/npm-npx-readiness-phase-set.md`. The `.omo/` directory was deleted in #139, leaving these callouts pointing at non-existent paths. The README status callout now points at `docs/publishing.md`, which is the canonical publish runbook.
- **`apps/cli/src/apply-state.ts` + `apps/cli/src/restore-command.ts`**: drop dead references in source comments to `.omo/plans/g1-apply-state-file.md` and `.omo/plans/g3-restore-last-helper.md`. The surrounding text already names the contract.

## Context

Researched npx distribution for `@jander99/overture`. The CLI is already npx-ready — `bin`, `files`, `engines`, `dependencies` (including the externally-loaded `smol-toml`) are all in place. The only remaining gap was `publishConfig.registry`.

The `.omo/plans/` reference fixes are an opportunistic follow-up from the same audit. They have the same one-line edit shape and the same root cause (#139 cleanup missed these callouts).

## Verification

Pre-PR gate stack per `AGENTS.md`, all green:

- `yarn nx lint @jander99/overture --skip-nx-cache` — clean
- `npx tsc -b apps/cli/tsconfig.json` — no errors
- `yarn prettier --check .` — clean
- `yarn nx test @jander99/overture` — 22 files, 306 tests, all pass
- `yarn nx build @jander99/overture --skip-nx-cache` — clean (5 targets)
- `node apps/cli/scripts/verify-package.mjs` — all smoke checks pass, including F2 (no-change apply), F3 (refused apply), G1 (apply state file), G2 (apply log file), G3 (restore-last end-to-end + second-restore missing-backup)
- `node apps/cli/dist/main.js detect --json` — 4 platforms, 0 parseErrors

## Out of scope

- Versioning / release-train work (deferred; will be its own PR).
- Dropping `jsonc-parser` / `yaml` from `dependencies` — `smol-toml` is the only `dependency` that genuinely must be on disk (dual-package hazard). The other two are esbuild-inlined via `thirdParty: true` but listing them in `dependencies` is wasteful, not broken.

## Files changed

```
 README.md                       | 6 +++---
 apps/cli/package.json           | 3 ++-
 apps/cli/src/apply-state.ts     | 4 ++--
 apps/cli/src/restore-command.ts | 4 ++--
 docs/publishing.md              | 4 ++--
 5 files changed, 11 insertions(+), 10 deletions(-)
```